### PR TITLE
Fix duplicate headers and replace ASCII diagrams with Mermaid

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,9 +1,13 @@
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import { rehypeMermaid } from './src/plugins/rehype-mermaid.mjs';
 
 export default defineConfig({
   site: 'https://jmassardo.github.io',
   base: '/octowatch',
+  markdown: {
+    rehypePlugins: [rehypeMermaid],
+  },
   integrations: [
     starlight({
       title: 'OctoWatch',
@@ -12,6 +16,27 @@ export default defineConfig({
         { icon: 'github', label: 'GitHub', href: 'https://github.com/jmassardo/octowatch' },
       ],
       customCss: ['./src/styles/custom.css'],
+      head: [
+        {
+          tag: 'script',
+          attrs: { type: 'module' },
+          content: `
+            import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+            mermaid.initialize({
+              startOnLoad: true,
+              theme: 'dark',
+              themeVariables: {
+                primaryColor: '#1e293b',
+                primaryTextColor: '#e2e8f0',
+                primaryBorderColor: '#3b82f6',
+                lineColor: '#94a3b8',
+                secondaryColor: '#1a2744',
+                tertiaryColor: '#0f172a',
+              },
+            });
+          `,
+        },
+      ],
       sidebar: [
         {
           label: 'Getting Started',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@astrojs/starlight": "^0.34.0",
         "astro": "^5.7.0",
-        "sharp": "^0.33.0"
+        "sharp": "^0.33.0",
+        "unist-util-visit": "^5.1.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -5920,6 +5921,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },

--- a/website/package.json
+++ b/website/package.json
@@ -10,8 +10,9 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^5.7.0",
     "@astrojs/starlight": "^0.34.0",
-    "sharp": "^0.33.0"
+    "astro": "^5.7.0",
+    "sharp": "^0.33.0",
+    "unist-util-visit": "^5.1.0"
   }
 }

--- a/website/src/content/docs/getting-started/first-login.md
+++ b/website/src/content/docs/getting-started/first-login.md
@@ -3,8 +3,6 @@ title: First Login
 description: Complete your initial OctoWatch setup
 ---
 
-# First Login
-
 After deploying OctoWatch, follow these steps to complete the initial setup.
 
 ## Accessing OctoWatch

--- a/website/src/content/docs/getting-started/installation.md
+++ b/website/src/content/docs/getting-started/installation.md
@@ -3,8 +3,6 @@ title: Installation
 description: Deploy OctoWatch on Kubernetes or Docker Compose
 ---
 
-# Installation
-
 OctoWatch can be deployed using Helm on Kubernetes (recommended for production) or Docker Compose (for development and small-scale deployments).
 
 ## Option 1: Helm on Kubernetes (Recommended)

--- a/website/src/content/docs/getting-started/introduction.md
+++ b/website/src/content/docs/getting-started/introduction.md
@@ -3,8 +3,6 @@ title: Introduction
 description: What is OctoWatch and why you need it
 ---
 
-# What is OctoWatch?
-
 OctoWatch is a **security monitoring and intelligence platform** purpose-built for GitHub Enterprise environments. It ingests GitHub audit logs in real-time, applies automated detection rules, and provides comprehensive dashboards for security teams to monitor, investigate, and report on activity across their GitHub organizations.
 
 ## The Problem
@@ -53,28 +51,30 @@ OctoWatch solves this by providing:
 
 ## Architecture Overview
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    GitHub Enterprise Cloud                        │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐                      │
-│  │  Org A   │  │  Org B   │  │  Org C   │  ...                 │
-│  └────┬─────┘  └────┬─────┘  └────┬─────┘                      │
-│       │              │              │                             │
-│       └──────────────┼──────────────┘                            │
-│                      │ Audit Log Streaming                        │
-└──────────────────────┼───────────────────────────────────────────┘
-                       ▼
-┌──────────────────────────────────────────────────────────────────┐
-│                        OctoWatch                                  │
-│  ┌─────────────┐  ┌──────────────┐  ┌────────────────────────┐  │
-│  │ HEC Ingest  │→ │  Detection   │→ │  Dashboards & Reports  │  │
-│  │  Endpoint   │  │   Engine     │  │   (React Frontend)     │  │
-│  └─────────────┘  └──────────────┘  └────────────────────────┘  │
-│  ┌─────────────┐  ┌──────────────┐  ┌────────────────────────┐  │
-│  │  PostgreSQL │  │    Valkey    │  │   FastAPI Backend      │  │
-│  │  (Storage)  │  │   (Cache)    │  │   (REST API)           │  │
-│  └─────────────┘  └──────────────┘  └────────────────────────┘  │
-└──────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph GH["GitHub Enterprise Cloud"]
+        OrgA[Org A]
+        OrgB[Org B]
+        OrgC[Org C]
+    end
+
+    subgraph OW["OctoWatch"]
+        HEC[HEC Ingest\nEndpoint]
+        Detection[Detection\nEngine]
+        Dashboards[Dashboards & Reports\nReact Frontend]
+        PG[PostgreSQL\nStorage]
+        VK[Valkey\nCache]
+        API[FastAPI Backend\nREST API]
+    end
+
+    OrgA -->|Audit Log Streaming| HEC
+    OrgB -->|Audit Log Streaming| HEC
+    OrgC -->|Audit Log Streaming| HEC
+    HEC --> Detection
+    Detection --> Dashboards
+    API --> PG
+    API --> VK
 ```
 
 ## Next Steps

--- a/website/src/content/docs/getting-started/prerequisites.md
+++ b/website/src/content/docs/getting-started/prerequisites.md
@@ -3,8 +3,6 @@ title: Prerequisites
 description: What you need before deploying OctoWatch
 ---
 
-# Prerequisites
-
 Before deploying OctoWatch, ensure you have the following requirements in place.
 
 ## GitHub Requirements

--- a/website/src/content/docs/guides/github-app-setup.md
+++ b/website/src/content/docs/guides/github-app-setup.md
@@ -3,8 +3,6 @@ title: GitHub App Setup
 description: Configure the OctoWatch GitHub App for enhanced integration
 ---
 
-# GitHub App Setup
-
 While OctoWatch can operate with just HEC audit log streaming, installing a GitHub App enables enhanced features like real-time webhook events, organization metadata sync, and repository-level details.
 
 ## What the GitHub App Enables

--- a/website/src/content/docs/guides/hec-configuration.md
+++ b/website/src/content/docs/guides/hec-configuration.md
@@ -3,8 +3,6 @@ title: HEC Configuration
 description: Configure the HTTP Event Collector endpoint for audit log ingestion
 ---
 
-# HEC Configuration
-
 OctoWatch's HEC (HTTP Event Collector) endpoint receives GitHub audit log streams in Splunk HEC format. This guide covers advanced configuration options.
 
 ## Endpoint Details

--- a/website/src/content/docs/guides/org-sync.md
+++ b/website/src/content/docs/guides/org-sync.md
@@ -3,8 +3,6 @@ title: Organization Sync
 description: Configure and manage organization synchronization
 ---
 
-# Organization Sync
-
 OctoWatch synchronizes metadata from your GitHub organizations to provide rich context for audit events. This guide covers how org sync works and how to configure it.
 
 ## How Sync Works

--- a/website/src/content/docs/guides/rbac.md
+++ b/website/src/content/docs/guides/rbac.md
@@ -3,8 +3,6 @@ title: RBAC & Permissions
 description: Configure role-based access control in OctoWatch
 ---
 
-# RBAC & Permissions
-
 OctoWatch implements fine-grained role-based access control (RBAC) with organization-scoped permissions. This ensures teams only see data relevant to their organizations.
 
 ## Role Hierarchy

--- a/website/src/content/docs/index.mdx
+++ b/website/src/content/docs/index.mdx
@@ -44,10 +44,11 @@ OctoWatch transforms raw GitHub audit logs into actionable security intelligence
 
 ## How It Works
 
-```
-GitHub Enterprise  ──→  HEC Endpoint  ──→  OctoWatch Engine  ──→  Dashboards
-   (Audit Logs)         (Streaming)        (Detection &          (Alerts &
-                                            Enrichment)           Reports)
+```mermaid
+flowchart LR
+    A[GitHub Enterprise\nAudit Logs] --> B[HEC Endpoint\nStreaming]
+    B --> C[OctoWatch Engine\nDetection & Enrichment]
+    C --> D[Dashboards\nAlerts & Reports]
 ```
 
 1. **Stream** — Configure GitHub audit log streaming to OctoWatch's HEC endpoint

--- a/website/src/content/docs/reference/api.md
+++ b/website/src/content/docs/reference/api.md
@@ -3,8 +3,6 @@ title: API Reference
 description: OctoWatch REST API documentation
 ---
 
-# API Reference
-
 OctoWatch exposes a REST API built with FastAPI. The API serves both the web frontend and programmatic integrations.
 
 ## Interactive Documentation

--- a/website/src/content/docs/reference/architecture.md
+++ b/website/src/content/docs/reference/architecture.md
@@ -3,68 +3,51 @@ title: Architecture
 description: OctoWatch system architecture and data flow
 ---
 
-# Architecture
-
 OctoWatch is a multi-tier application designed for reliability, scalability, and security. This page describes the system architecture, component interactions, and deployment topology.
 
 ## System Overview
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│                         External Sources                                  │
-│                                                                          │
-│   GitHub Enterprise ──── Audit Log Streaming (HEC) ──────┐              │
-│   GitHub Apps ────────── Webhooks ────────────────────────┤              │
-│                                                           ▼              │
-└───────────────────────────────────────────────────────────┼──────────────┘
-                                                            │
-┌───────────────────────────────────────────────────────────┼──────────────┐
-│                        Ingress Layer                       │              │
-│                                                           │              │
-│   ┌─────────────────┐   ┌──────────────────┐            │              │
-│   │  nginx-ingress  │   │  Rate Limiting   │◀───────────┘              │
-│   │  (TLS term.)    │   │  (per-path)      │                           │
-│   └────────┬────────┘   └────────┬─────────┘                           │
-│            └──────────────────────┘                                      │
-└───────────────────────────┬──────────────────────────────────────────────┘
-                            │
-┌───────────────────────────┼──────────────────────────────────────────────┐
-│                    Application Layer                                      │
-│                                                                          │
-│   ┌────────────────────────────────────────────────────────────────┐    │
-│   │                    FastAPI Backend                               │    │
-│   │                                                                  │    │
-│   │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐  │    │
-│   │  │  HEC     │  │ Webhook  │  │  REST    │  │  Detection   │  │    │
-│   │  │ Ingest   │  │ Ingest   │  │   API    │  │   Engine     │  │    │
-│   │  └──────────┘  └──────────┘  └──────────┘  └──────────────┘  │    │
-│   │  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────────┐  │    │
-│   │  │  Auth    │  │  RBAC    │  │  Report  │  │  Org Sync    │  │    │
-│   │  │ Service  │  │ Service  │  │ Service  │  │  Service     │  │    │
-│   │  └──────────┘  └──────────┘  └──────────┘  └──────────────┘  │    │
-│   └────────────────────────────────────────────────────────────────┘    │
-│                                                                          │
-│   ┌─────────────────────────────────────────────────────────────────┐   │
-│   │                   React Frontend (SPA)                           │   │
-│   │   Dashboards │ Activity │ Reports │ Settings │ Detection Rules  │   │
-│   └─────────────────────────────────────────────────────────────────┘   │
-│                                                                          │
-└───────────────────────────┬──────────────────────────────────────────────┘
-                            │
-┌───────────────────────────┼──────────────────────────────────────────────┐
-│                      Data Layer                                           │
-│                                                                          │
-│   ┌──────────────────┐        ┌──────────────────┐                      │
-│   │   PostgreSQL     │        │     Valkey        │                      │
-│   │                  │        │   (Redis-compat)  │                      │
-│   │  • Audit events  │        │  • Session store  │                      │
-│   │  • Organizations │        │  • Rate limiting  │                      │
-│   │  • Users/RBAC    │        │  • Cache layer    │                      │
-│   │  • Detection     │        │                   │                      │
-│   │    rules/alerts  │        │                   │                      │
-│   └──────────────────┘        └──────────────────┘                      │
-│                                                                          │
-└──────────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TD
+    subgraph External["External Sources"]
+        GHE[GitHub Enterprise]
+        GHA[GitHub Apps]
+    end
+
+    subgraph Ingress["Ingress Layer"]
+        NGINX[nginx-ingress\nTLS termination]
+        RL[Rate Limiting\nper-path]
+    end
+
+    subgraph App["Application Layer"]
+        subgraph Backend["FastAPI Backend"]
+            HEC[HEC Ingest]
+            WH[Webhook Ingest]
+            REST[REST API]
+            DET[Detection Engine]
+            AUTH[Auth Service]
+            RBAC[RBAC Service]
+            RPT[Report Service]
+            SYNC[Org Sync Service]
+        end
+        FE["React Frontend (SPA)\nDashboards | Activity | Reports | Settings | Detection Rules"]
+    end
+
+    subgraph Data["Data Layer"]
+        PG["PostgreSQL\n• Audit events\n• Organizations\n• Users/RBAC\n• Detection rules/alerts"]
+        VK["Valkey (Redis-compat)\n• Session store\n• Rate limiting\n• Cache layer"]
+    end
+
+    GHE -->|Audit Log Streaming| NGINX
+    GHA -->|Webhooks| NGINX
+    NGINX --> RL
+    RL --> HEC
+    RL --> WH
+    RL --> REST
+    HEC --> DET
+    Backend --> PG
+    Backend --> VK
+    FE --> REST
 ```
 
 ## Component Details
@@ -108,21 +91,33 @@ Single-page application providing:
 
 ## Deployment Topology (Kubernetes)
 
-```
-Namespace: octowatch
-├── Deployment: octowatch-backend (2+ replicas)
-├── Deployment: octowatch-frontend (2+ replicas)
-├── StatefulSet: postgresql (1 replica, persistent volume)
-├── StatefulSet: valkey (1 replica)
-├── Ingress: octowatch-hec (rate limited)
-├── Ingress: octowatch-webhook (rate limited)
-├── Ingress: octowatch-app (standard)
-├── Service: backend (ClusterIP)
-├── Service: frontend (ClusterIP)
-├── Service: postgresql (ClusterIP)
-├── Service: valkey (ClusterIP)
-├── Secret: octowatch-secrets
-└── ConfigMap: octowatch-config
+```mermaid
+graph TD
+    subgraph NS["Namespace: octowatch"]
+        D1["Deployment: octowatch-backend\n(2+ replicas)"]
+        D2["Deployment: octowatch-frontend\n(2+ replicas)"]
+        SS1["StatefulSet: postgresql\n(1 replica, persistent volume)"]
+        SS2["StatefulSet: valkey\n(1 replica)"]
+        I1["Ingress: octowatch-hec\n(rate limited)"]
+        I2["Ingress: octowatch-webhook\n(rate limited)"]
+        I3["Ingress: octowatch-app\n(standard)"]
+        S1[Service: backend - ClusterIP]
+        S2[Service: frontend - ClusterIP]
+        S3[Service: postgresql - ClusterIP]
+        S4[Service: valkey - ClusterIP]
+        SEC[Secret: octowatch-secrets]
+        CM[ConfigMap: octowatch-config]
+    end
+
+    I1 --> S1
+    I2 --> S1
+    I3 --> S2
+    S1 --> D1
+    S2 --> D2
+    S3 --> SS1
+    S4 --> SS2
+    D1 --> S3
+    D1 --> S4
 ```
 
 ## Data Flow

--- a/website/src/content/docs/reference/changelog.md
+++ b/website/src/content/docs/reference/changelog.md
@@ -3,8 +3,6 @@ title: Changelog
 description: OctoWatch version history and release notes
 ---
 
-# Changelog
-
 All notable changes to OctoWatch are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).

--- a/website/src/content/docs/reference/detection-rules.md
+++ b/website/src/content/docs/reference/detection-rules.md
@@ -3,14 +3,17 @@ title: Detection Rules
 description: Built-in and custom detection rules reference
 ---
 
-# Detection Rules
-
 OctoWatch's detection engine evaluates incoming audit events against configurable rules. When a rule matches, an alert is created and notifications are sent.
 
 ## How Detection Works
 
-```
-Incoming Event → Rule Evaluation → Match? → Create Alert → Notify
+```mermaid
+flowchart LR
+    A[Incoming Event] --> B[Rule Evaluation]
+    B --> C{Match?}
+    C -->|Yes| D[Create Alert]
+    D --> E[Notify]
+    C -->|No| F[Discard]
 ```
 
 Rules are evaluated in real-time as events are ingested. Each rule defines:

--- a/website/src/content/docs/reference/faq.md
+++ b/website/src/content/docs/reference/faq.md
@@ -3,8 +3,6 @@ title: FAQ
 description: Frequently asked questions about OctoWatch
 ---
 
-# Frequently Asked Questions
-
 ## General
 
 ### What is OctoWatch?

--- a/website/src/plugins/rehype-mermaid.mjs
+++ b/website/src/plugins/rehype-mermaid.mjs
@@ -1,0 +1,29 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Rehype plugin that transforms ```mermaid code blocks into
+ * <pre class="mermaid"> elements for client-side rendering.
+ */
+export function rehypeMermaid() {
+  return (tree) => {
+    visit(tree, 'element', (node, index, parent) => {
+      if (
+        node.tagName === 'pre' &&
+        node.children?.[0]?.tagName === 'code' &&
+        node.children[0].properties?.className?.includes('language-mermaid')
+      ) {
+        const code = node.children[0];
+        const value = code.children
+          ?.map((child) => (child.type === 'text' ? child.value : ''))
+          .join('');
+
+        parent.children[index] = {
+          type: 'element',
+          tagName: 'pre',
+          properties: { className: ['mermaid'] },
+          children: [{ type: 'text', value }],
+        };
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Changes

- **Remove duplicate H1 headers** — Starlight renders the frontmatter `title` as the page H1, so the manual `# Heading` in each file was duplicating it
- **Replace ASCII art with Mermaid diagrams** — All 4 architecture/flow diagrams now use proper Mermaid syntax rendered client-side
- **Add rehype plugin** for transforming ```mermaid code blocks into `<pre class="mermaid">` elements
- **Add Mermaid CDN script** with dark theme matching OctoWatch brand colors

Follows up on #169.