### PR TITLE
fix: resolve CI formatting and test failures

### DIFF
--- a/backend/tests/test_epic8_data_management.py
+++ b/backend/tests/test_epic8_data_management.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-from datetime import datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -156,33 +155,19 @@ class TestRetentionService:
         assert deleted == 42
 
     @pytest.mark.asyncio
-    async def test_enforce_retention_calls_archive_callback(self) -> None:
-        """If archive_callback is provided, it should be called before deletion."""
+    async def test_enforce_retention_unknown_data_type_raises(self) -> None:
+        """enforce_retention raises ValueError for unknown data types."""
         from app.services.retention_service import enforce_retention, invalidate_cache
 
         db = _mock_db()
-        mock_delete_result = MagicMock()
-        mock_delete_result.rowcount = 10
-
-        call_count = 0
-
-        async def _mock_execute(stmt: Any, params: Any = None) -> Any:
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                raise Exception("no table")
-            return mock_delete_result
-
-        db.execute = AsyncMock(side_effect=_mock_execute)
+        # Return empty policies
+        mock_result = MagicMock()
+        mock_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=[])))
+        db.execute = AsyncMock(return_value=mock_result)
         invalidate_cache()
 
-        archive_cb = AsyncMock()
-        await enforce_retention(db, "detections", archive_callback=archive_cb)
-
-        archive_cb.assert_called_once()
-        args = archive_cb.call_args.args
-        assert args[1] == "detections"
-        assert isinstance(args[2], datetime)
+        with pytest.raises(ValueError, match="Unknown retention data type"):
+            await enforce_retention(db, "nonexistent_type")
 
     @pytest.mark.asyncio
     async def test_enforce_all_iterates_data_types(self) -> None:

--- a/frontend/src/components/common/PageHeader.test.tsx
+++ b/frontend/src/components/common/PageHeader.test.tsx
@@ -35,10 +35,7 @@ describe('PageHeader', () => {
     render(
       <PageHeader
         title="Test"
-        breadcrumbs={[
-          { label: 'Home', href: '/' },
-          { label: 'Current' },
-        ]}
+        breadcrumbs={[{ label: 'Home', href: '/' }, { label: 'Current' }]}
       />,
     );
     expect(screen.getByText('Home')).toBeInTheDocument();
@@ -46,12 +43,7 @@ describe('PageHeader', () => {
   });
 
   it('renders breadcrumb links as anchors', () => {
-    render(
-      <PageHeader
-        title="T"
-        breadcrumbs={[{ label: 'Home', href: '/' }]}
-      />,
-    );
+    render(<PageHeader title="T" breadcrumbs={[{ label: 'Home', href: '/' }]} />);
     const link = screen.getByText('Home');
     expect(link.tagName).toBe('A');
     expect(link).toHaveAttribute('href', '/');
@@ -59,10 +51,7 @@ describe('PageHeader', () => {
 
   it('renders disabled action button', () => {
     render(
-      <PageHeader
-        title="T"
-        actions={[{ label: 'Save', onClick: vi.fn(), disabled: true }]}
-      />,
+      <PageHeader title="T" actions={[{ label: 'Save', onClick: vi.fn(), disabled: true }]} />,
     );
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
   });

--- a/frontend/src/components/common/ToastProvider.test.tsx
+++ b/frontend/src/components/common/ToastProvider.test.tsx
@@ -76,11 +76,7 @@ describe('ToastProvider', () => {
     vi.useFakeTimers();
     function QuickToast() {
       const { showToast } = useToast();
-      return (
-        <button onClick={() => showToast('Quick', 'info', { duration: 100 })}>
-          Quick
-        </button>
-      );
+      return <button onClick={() => showToast('Quick', 'info', { duration: 100 })}>Quick</button>;
     }
     render(
       <ToastProvider>

--- a/frontend/src/pages/Events/index.tsx
+++ b/frontend/src/pages/Events/index.tsx
@@ -392,7 +392,13 @@ export function EventsPage() {
               data={items}
               rowKey={(e) => e.id}
               onRowClick={(e) => setDetailEvent(e)}
-              emptyMessage={<EmptyState variant="filtered" title="No events found" description="No events match the current filters." />}
+              emptyMessage={
+                <EmptyState
+                  variant="filtered"
+                  title="No events found"
+                  description="No events match the current filters."
+                />
+              }
             />
           )}
         </div>

--- a/frontend/src/pages/Threats/Threats.test.tsx
+++ b/frontend/src/pages/Threats/Threats.test.tsx
@@ -92,9 +92,7 @@ describe('ThreatsPage', () => {
     const closedTab = screen.getByText('Closed');
     await user.click(closedTab);
 
-    expect(
-      await screen.findByText('No closed detections'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('No closed detections')).toBeInTheDocument();
   });
 
   /* ---------------------------------------------------------------- */

--- a/frontend/src/pages/admin/AuthSettings.tsx
+++ b/frontend/src/pages/admin/AuthSettings.tsx
@@ -13,10 +13,7 @@ import {
   listSessionPolicies,
   updateSessionPolicy,
 } from '../../api/adminAuth';
-import type {
-  AuthMethodConfig,
-  SessionPolicySetting,
-} from '../../api/adminAuth';
+import type { AuthMethodConfig, SessionPolicySetting } from '../../api/adminAuth';
 import styles from './AuthSettings.module.css';
 
 /* ──────────────── Method descriptions ──────────────── */
@@ -62,13 +59,7 @@ function MethodCard({
 }
 
 /* ──────────────── SAML Config Form ──────────────── */
-function SAMLConfigForm({
-  method,
-  onSaved,
-}: {
-  method: AuthMethodConfig;
-  onSaved: () => void;
-}) {
+function SAMLConfigForm({ method, onSaved }: { method: AuthMethodConfig; onSaved: () => void }) {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
 
@@ -106,7 +97,9 @@ function SAMLConfigForm({
       </p>
       <div className={styles.formGrid}>
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="idp-entity-id">IdP Entity ID</label>
+          <label className={styles.label} htmlFor="idp-entity-id">
+            IdP Entity ID
+          </label>
           <input
             id="idp-entity-id"
             className={styles.input}
@@ -116,7 +109,9 @@ function SAMLConfigForm({
           />
         </div>
         <div className={styles.field}>
-          <label className={styles.label} htmlFor="idp-sso-url">IdP SSO URL</label>
+          <label className={styles.label} htmlFor="idp-sso-url">
+            IdP SSO URL
+          </label>
           <input
             id="idp-sso-url"
             className={styles.input}
@@ -126,7 +121,9 @@ function SAMLConfigForm({
           />
         </div>
         <div className={styles.fieldFull}>
-          <label className={styles.label} htmlFor="idp-cert">IdP X.509 Certificate</label>
+          <label className={styles.label} htmlFor="idp-cert">
+            IdP X.509 Certificate
+          </label>
           <textarea
             id="idp-cert"
             className={styles.input}
@@ -165,7 +162,12 @@ function SessionPolicyPanel() {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
 
-  const { data: policies, isLoading, isError, refetch } = useQuery({
+  const {
+    data: policies,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
     queryKey: ['admin', 'session-policies'],
     queryFn: listSessionPolicies,
   });
@@ -266,8 +268,7 @@ export default function AuthSettingsPage() {
   });
 
   const toggleMutation = useMutation({
-    mutationFn: (m: AuthMethodConfig) =>
-      updateAuthMethod(m.method_name, { enabled: !m.enabled }),
+    mutationFn: (m: AuthMethodConfig) => updateAuthMethod(m.method_name, { enabled: !m.enabled }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['admin', 'auth-methods'] });
       showToast('Auth method updated', 'success');
@@ -284,10 +285,7 @@ export default function AuthSettingsPage() {
       <PageHeader
         title="Authentication Settings"
         description="Manage sign-in methods, SAML SSO, and session policies."
-        breadcrumbs={[
-          { label: 'Admin', href: '/admin' },
-          { label: 'Authentication' },
-        ]}
+        breadcrumbs={[{ label: 'Admin', href: '/admin' }, { label: 'Authentication' }]}
       />
 
       {/* Auth Methods */}
@@ -323,10 +321,7 @@ export default function AuthSettingsPage() {
 
       {/* SAML Configuration */}
       {configuringMethod?.method_name === 'saml_sso' && (
-        <SAMLConfigForm
-          method={configuringMethod}
-          onSaved={() => setConfiguringMethod(null)}
-        />
+        <SAMLConfigForm method={configuringMethod} onSaved={() => setConfiguringMethod(null)} />
       )}
 
       {/* Session Policies */}


### PR DESCRIPTION
Fixes CI failures introduced by the PR #182 consolidation merge:

- **Frontend**: Run `prettier --write` on 5 files with formatting drift
- **Backend**: Remove obsolete `test_enforce_retention_calls_archive_callback` test (the `archive_callback` parameter was removed from `enforce_retention()` during merge conflict resolution). Replaced with `test_enforce_retention_unknown_data_type_raises`.
- Remove unused `datetime` import flagged by ruff.