### PR TITLE
fix: enable local_password auth for E2E tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,9 @@ jobs:
           docker compose up -d db valkey
           sleep 15
           docker compose run --rm migrate || true
+          # Enable local_password auth method for E2E dev-login
+          docker compose exec -T db psql -U test -d auditlogs -c \
+            "UPDATE auth_method_configs SET enabled = true WHERE method_name = 'local_password';" || true
           docker compose up -d api frontend nginx
           sleep 10
       - name: Health check


### PR DESCRIPTION
The E2E test suite uses `/api/v1/auth/dev-login` which requires the `local_password` auth method to be enabled. Migration 0040 seeds it as `enabled=false` by default, causing E2E auth setup to fail with 403.

Adds a psql UPDATE after migrations in the E2E CI step to enable it.