### PR TITLE
fix: HEC token startup retry + Events Explorer performance

### DIFF
--- a/backend/alembic/versions/0044_add_events_performance_indexes.py
+++ b/backend/alembic/versions/0044_add_events_performance_indexes.py
@@ -1,0 +1,47 @@
+"""Add performance indexes for events queries.
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-05-06 00:00:00.000000+00:00
+
+Adds indexes to speed up the Events Explorer page:
+- Composite index on (org, created_at DESC) for the main listing query
+- Partial indexes on org+actor, org+action, org+repo, org+namespace for
+  the suggestion/typeahead DISTINCT queries
+"""
+
+from alembic import op
+
+revision = "0044"
+down_revision = "0043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Main events listing: WHERE org = ANY(...) ORDER BY created_at DESC
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_events_org_created_at"
+        " ON events (org, created_at DESC)"
+    )
+    # Suggestions: SELECT DISTINCT action WHERE org = ANY(...)
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_events_org_action ON events (org, action)"
+    )
+    # Suggestions: SELECT DISTINCT actor WHERE org = ANY(...) AND actor IS NOT NULL
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_events_org_actor"
+        " ON events (org, actor) WHERE actor IS NOT NULL AND actor != ''"
+    )
+    # Suggestions: SELECT DISTINCT repo WHERE org = ANY(...) AND repo IS NOT NULL
+    op.execute(
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_events_org_repo"
+        " ON events (org, repo) WHERE repo IS NOT NULL AND repo != ''"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_events_org_repo")
+    op.execute("DROP INDEX IF EXISTS ix_events_org_actor")
+    op.execute("DROP INDEX IF EXISTS ix_events_org_action")
+    op.execute("DROP INDEX IF EXISTS ix_events_org_created_at")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -198,6 +198,54 @@ class RequestIdMiddleware(BaseHTTPMiddleware):
 # ─── Lifespan ───────────────────────────────────────────────────────────────────
 
 
+async def _retry_hec_token_load() -> None:
+    """Background task: retry loading HEC token from DB with exponential backoff.
+
+    This handles the case where PostgreSQL starts after the API pod. Retries up
+    to 10 times (total ~8.5 minutes of waiting) before giving up.
+    """
+    import asyncio
+
+    max_retries = 10
+    base_delay = 5.0  # seconds
+
+    for attempt in range(1, max_retries + 1):
+        delay = base_delay * (2 ** (attempt - 1))  # 5, 10, 20, 40, ...
+        delay = min(delay, 60.0)  # cap at 60s
+        await asyncio.sleep(delay)
+
+        try:
+            from app.database import AsyncSessionLocal
+            from app.routers.ingest_hec import set_hec_token_cache
+            from app.services.settings_service import get_setting
+
+            async with AsyncSessionLocal() as db_session:
+                db_hec_token = await get_setting(db_session, "hec_token")
+                if db_hec_token:
+                    set_hec_token_cache(db_hec_token)
+                    logger.info(
+                        "hec.token_loaded_from_db_retry",
+                        attempt=attempt,
+                    )
+                    return
+                else:
+                    logger.debug(
+                        "hec.token_retry_no_token",
+                        attempt=attempt,
+                    )
+        except Exception as exc:
+            logger.debug(
+                "hec.token_retry_failed",
+                attempt=attempt,
+                error=str(exc),
+            )
+
+    logger.error(
+        "hec.token_retry_exhausted",
+        message="Failed to load HEC token after all retries. Manual pod restart required.",
+    )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """Startup and shutdown events."""
@@ -293,6 +341,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
                     set_hec_token_cache(db_hec_token)
                     logger.info("hec.token_loaded_from_db")
+                else:
+                    logger.warning("hec.token_not_found_at_startup")
 
                 # Generate setup token on first boot if setup is not complete
                 if not await is_setup_complete(db_session):
@@ -319,6 +369,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     logger.info("setup.already_complete")
         except Exception as exc:
             logger.warning("settings_overlay.load_failed", error=str(exc))
+            # Schedule background retry for HEC token loading
+            import asyncio
+
+            asyncio.create_task(_retry_hec_token_load())
+    else:
+        # DB not ready at startup — schedule background retry
+        import asyncio
+
+        asyncio.create_task(_retry_hec_token_load())
 
     yield
 

--- a/backend/app/routers/suggestions.py
+++ b/backend/app/routers/suggestions.py
@@ -35,7 +35,11 @@ async def suggest_actions(
         return {"actions": []}
 
     result = await db.execute(
-        text("SELECT DISTINCT action FROM events WHERE org = ANY(:scoped_orgs) ORDER BY action"),
+        text(
+            "SELECT DISTINCT action FROM events"
+            " WHERE org = ANY(:scoped_orgs)"
+            " ORDER BY action LIMIT 500"
+        ),
         {"scoped_orgs": scoped_orgs},
     )
     actions = [row[0] for row in result.fetchall()]
@@ -83,7 +87,7 @@ async def suggest_actors(
             "SELECT DISTINCT actor FROM events"
             " WHERE org = ANY(:scoped_orgs)"
             " AND actor IS NOT NULL AND actor != ''"
-            " ORDER BY actor"
+            " ORDER BY actor LIMIT 500"
         ),
         {"scoped_orgs": scoped_orgs},
     )
@@ -106,7 +110,7 @@ async def suggest_repos(
             "SELECT DISTINCT repo FROM events"
             " WHERE org = ANY(:scoped_orgs)"
             " AND repo IS NOT NULL AND repo != ''"
-            " ORDER BY repo"
+            " ORDER BY repo LIMIT 500"
         ),
         {"scoped_orgs": scoped_orgs},
     )
@@ -129,7 +133,7 @@ async def suggest_orgs(
             "SELECT DISTINCT org FROM events"
             " WHERE org = ANY(:scoped_orgs)"
             " AND org IS NOT NULL AND org != ''"
-            " ORDER BY org"
+            " ORDER BY org LIMIT 500"
         ),
         {"scoped_orgs": scoped_orgs},
     )
@@ -152,7 +156,7 @@ async def suggest_namespaces(
             "SELECT DISTINCT namespace FROM events"
             " WHERE org = ANY(:scoped_orgs)"
             " AND namespace IS NOT NULL AND namespace != ''"
-            " ORDER BY namespace"
+            " ORDER BY namespace LIMIT 500"
         ),
         {"scoped_orgs": scoped_orgs},
     )

--- a/backend/app/services/event_service.py
+++ b/backend/app/services/event_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 import structlog
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.audit_event import AuditEvent, EventRawPayload
@@ -41,33 +41,52 @@ async def list_events(
         AuditEvent.repo,  # type: ignore[arg-type]
     )
 
+    # Track whether user-supplied narrowing filters are active
+    has_narrowing_filters = False
+
     # Additional filters
     if params.actor:
         base_stmt = base_stmt.where(AuditEvent.actor == params.actor)
+        has_narrowing_filters = True
     if params.action:
         if params.action.endswith(".*"):
             ns = params.action[:-2]
             base_stmt = base_stmt.where(AuditEvent.namespace == ns)
         else:
             base_stmt = base_stmt.where(AuditEvent.action == params.action)
+        has_narrowing_filters = True
     if params.namespace:
         base_stmt = base_stmt.where(AuditEvent.namespace == params.namespace)
+        has_narrowing_filters = True
     if params.source_ip:
         base_stmt = base_stmt.where(
             func.host(AuditEvent.source_ip) == params.source_ip  # type: ignore[arg-type]
         )
+        has_narrowing_filters = True
     if params.since:
         base_stmt = base_stmt.where(AuditEvent.created_at >= params.since)
+        has_narrowing_filters = True
     if params.until:
         base_stmt = base_stmt.where(AuditEvent.created_at < params.until)
+        has_narrowing_filters = True
     if params.actor_is_bot is not None:
         base_stmt = base_stmt.where(AuditEvent.actor_is_bot == params.actor_is_bot)
+        has_narrowing_filters = True
     if params.geo_country_code:
         base_stmt = base_stmt.where(AuditEvent.geo_country_code == params.geo_country_code)
+        has_narrowing_filters = True
 
-    # Count total results
-    count_stmt = select(func.count()).select_from(base_stmt.subquery())
-    total: int = (await session.execute(count_stmt)).scalar_one()
+    # Count total results — use fast estimated count when no narrowing filters
+    if has_narrowing_filters:
+        count_stmt = select(func.count()).select_from(base_stmt.subquery())
+        total: int = (await session.execute(count_stmt)).scalar_one()
+    else:
+        # Use pg_class reltuples for a fast approximate count on unfiltered queries
+        est_result = await session.execute(
+            text("SELECT reltuples::bigint FROM pg_class WHERE relname = 'events'")
+        )
+        row = est_result.scalar_one_or_none()
+        total = max(int(row), 0) if row else 0
 
     # Ordering
     sort_columns = {


### PR DESCRIPTION
Fixes #181 and #183.

## HEC Token Retry (Issue #181)

When the API pod starts before PostgreSQL is ready, the HEC token fails to load and all ingestion requests return 503 until manually restarted. This adds:

- A background retry task (`_retry_hec_token_load`) with exponential backoff (5s→60s cap, 10 attempts)
- Automatically triggered if DB is unavailable at startup or if token load fails
- Eliminates the manual `kubectl rollout restart` required after every outage

## Events Explorer Performance (Issue #183)

The Events Explorer page was slow due to:
1. Unbounded `SELECT DISTINCT` queries for suggestions (full table scans on 500k rows)
2. Expensive `COUNT(*)` on the initial unfiltered page load

Fixes:
- Add `LIMIT 500` to all 5 suggestion queries
- Use `pg_class.reltuples` for fast approximate total count when no filters are active
- Add migration 0044 with covering indexes on `events(org, ...)` for listing and suggestions