### PR TITLE
fix: Reconcile TimescaleDB retention with centralized policy table (#139)

### DIFF
--- a/backend/alembic/versions/0046_reconcile_timescaledb_retention.py
+++ b/backend/alembic/versions/0046_reconcile_timescaledb_retention.py
@@ -1,0 +1,75 @@
+"""Reconcile TimescaleDB retention policies with centralized retention_policies table.
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-05-06
+
+The old migration 0023 created TimescaleDB retention policies with values
+(events=730d, audit_trail=1095d, health=180d) that conflict with the
+centralized retention_policies table (migration 0041). This migration
+updates the TimescaleDB policies to match the source of truth.
+"""
+
+from alembic import op
+
+revision = "0046"
+down_revision = "0045"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Update TimescaleDB retention policies to match retention_policies table.
+
+    Uses the centralized table as source of truth for all retention values.
+    Safe to run whether or not TimescaleDB is installed — errors are silently ignored.
+    """
+    # Remove old hardcoded TimescaleDB policies and re-create from source of truth.
+    # If TimescaleDB is not installed, these are no-ops.
+    op.execute("""
+        DO $$
+        BEGIN
+            -- Only proceed if TimescaleDB is installed
+            IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+                -- Remove old hardcoded policies
+                PERFORM remove_retention_policy('events', if_exists => true);
+                PERFORM remove_retention_policy('audit_trail', if_exists => true);
+                PERFORM remove_retention_policy('system_health_events', if_exists => true);
+
+                -- Re-create from retention_policies table values
+                PERFORM add_retention_policy(
+                    'events',
+                    (SELECT (retention_days || ' days')::INTERVAL FROM retention_policies WHERE data_type = 'events'),
+                    if_not_exists => true
+                );
+                PERFORM add_retention_policy(
+                    'audit_trail',
+                    (SELECT (retention_days || ' days')::INTERVAL FROM retention_policies WHERE data_type = 'audit_trail'),
+                    if_not_exists => true
+                );
+                PERFORM add_retention_policy(
+                    'system_health_events',
+                    (SELECT (retention_days || ' days')::INTERVAL FROM retention_policies WHERE data_type = 'system_health_events'),
+                    if_not_exists => true
+                );
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade() -> None:
+    """Revert to original hardcoded TimescaleDB retention policies."""
+    op.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb') THEN
+                PERFORM remove_retention_policy('events', if_exists => true);
+                PERFORM remove_retention_policy('audit_trail', if_exists => true);
+                PERFORM remove_retention_policy('system_health_events', if_exists => true);
+
+                PERFORM add_retention_policy('events', INTERVAL '730 days', if_not_exists => true);
+                PERFORM add_retention_policy('audit_trail', INTERVAL '1095 days', if_not_exists => true);
+                PERFORM add_retention_policy('system_health_events', INTERVAL '180 days', if_not_exists => true);
+            END IF;
+        END $$;
+    """)

--- a/backend/app/services/retention_service.py
+++ b/backend/app/services/retention_service.py
@@ -49,8 +49,10 @@ _TABLE_MAP: dict[str, dict[str, str]] = {
     "notification_history": {"table": "notification_configs", "time_col": "updated_at"},
 }
 
-# Hardcoded fallback defaults — used only when the DB table doesn't exist yet
-# or a data_type is missing from the DB.
+# Hardcoded fallback defaults — used ONLY when the retention_policies table
+# doesn't exist yet (pre-migration-0041). The DB table is the source of truth.
+# These values must match what migration 0041 seeds.
+# TimescaleDB hypertable policies are synced from the DB table by migration 0046.
 _FALLBACK_DEFAULTS: dict[str, dict[str, Any]] = {
     "events": {"retention_days": 365, "minimum_days": 90, "time_col": "created_at"},
     "raw_payloads": {"retention_days": 90, "minimum_days": 7, "time_col": "ingested_at"},


### PR DESCRIPTION
## Summary

Closes #139 — The centralized data retention system was already complete (migration 0041, admin API, Settings UI, enforcement worker). This PR fixes the last remaining issue: TimescaleDB hypertable policies that were out of sync.

## Problem

Migration 0023 created TimescaleDB retention policies with hardcoded values:
- events: 730 days
- audit_trail: 1095 days  
- system_health_events: 180 days

These conflicted with the centralized `retention_policies` table (source of truth):
- events: 365 days
- audit_trail: 730 days
- system_health_events: 90 days

## Fix

Migration 0046 reconciles TimescaleDB policies by reading values from the `retention_policies` table instead of hardcoding them. Safely handles non-TimescaleDB databases.

## Already Complete (prior work)
- ✅ `retention_policies` table with 11 data types (migration 0041)
- ✅ Admin API with minimum enforcement (`/admin/retention`)
- ✅ Settings → Retention UI (editable days, row counts, storage sizes)
- ✅ Celery worker for periodic enforcement
- ✅ In-memory cache with 5-min TTL
- ✅ Schema deprecation notice on legacy `RetentionConfig`