### PR TITLE
feat: Detection workflow overhaul — assign/dismiss, inline timeline, deep links (#118, #114, #113)

### DIFF
--- a/frontend/src/pages/Threats/DetectionDetailPane.tsx
+++ b/frontend/src/pages/Threats/DetectionDetailPane.tsx
@@ -1,0 +1,750 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  updateDetectionStatus,
+  deleteDetection,
+  assignDetection,
+} from '../../api/detections';
+import { getDetectionTimeline } from '../../api/executive';
+import type { TimelineEvent } from '../../api/executive';
+import type { DetectionResponse } from '../../types/detections';
+import { SeverityDot } from '../../components/primitives/SeverityDot';
+import { Label } from '../../components/primitives/Label';
+import { Button } from '../../components/primitives/Button';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { Autocomplete } from '../../components/primitives/Autocomplete';
+import { formatRelativeShort, formatCompact } from '../../utils/dates';
+import styles from './Threats.module.css';
+
+/**
+ * Safely convert any value to a display string.
+ */
+function safeText(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  return JSON.stringify(value);
+}
+
+/**
+ * Safely check whether an object has entries.
+ */
+function hasEntries(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.keys(value).length > 0
+  );
+}
+
+type DismissReason = 'False positive' | 'Expected behavior' | 'Duplicate' | "Won't fix";
+const DISMISS_REASONS: DismissReason[] = [
+  'False positive',
+  'Expected behavior',
+  'Duplicate',
+  "Won't fix",
+];
+
+/* -------------------------------------------------------------------------- */
+/*  Evidence display (moved from index.tsx)                                     */
+/* -------------------------------------------------------------------------- */
+
+function EvidenceValue({ value, depth = 0 }: { value: unknown; depth?: number }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (value === null || value === undefined) {
+    return <span className={styles.evidenceMuted}>—</span>;
+  }
+  if (typeof value === 'string') {
+    return <span className={styles.evidenceVal}>{value}</span>;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return <span className={styles.evidenceVal}>{String(value)}</span>;
+  }
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className={styles.evidenceMuted}>[]</span>;
+    }
+    const allPrimitive = value.every(
+      (v) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean',
+    );
+    if (allPrimitive && value.length <= 5) {
+      return <span className={styles.evidenceVal}>{value.join(', ')}</span>;
+    }
+    return (
+      <div>
+        <button
+          type="button"
+          className={styles.expandToggle}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? '▾' : '▸'} {value.length} item{value.length !== 1 ? 's' : ''}
+        </button>
+        {expanded && (
+          <div className={styles.evidenceNested}>
+            {value.map((item, i) => (
+              <div key={i} className={styles.evidenceRow}>
+                <span className={styles.evidenceKey}>[{i}]</span>
+                <EvidenceValue value={item} depth={depth + 1} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+      return <span className={styles.evidenceMuted}>{'{}'}</span>;
+    }
+    return (
+      <div>
+        <button
+          type="button"
+          className={styles.expandToggle}
+          onClick={() => setExpanded((v) => !v)}
+        >
+          {expanded ? '▾' : '▸'} {entries.length} field{entries.length !== 1 ? 's' : ''}
+        </button>
+        {expanded && (
+          <div className={styles.evidenceNested}>
+            {entries.map(([k, v]) => (
+              <div key={k} className={styles.evidenceRow}>
+                <span className={styles.evidenceKey}>{k}</span>
+                <EvidenceValue value={v} depth={depth + 1} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+  return <span className={styles.evidenceVal}>{String(value)}</span>;
+}
+
+function EvidenceDisplay({ data }: { data: Record<string, unknown> }) {
+  return (
+    <div className={styles.evidenceTable}>
+      {Object.entries(data).map(([key, value]) => (
+        <div key={key} className={styles.evidenceRow}>
+          <span className={styles.evidenceKey}>{key}</span>
+          <div className={styles.evidenceValWrap}>
+            <EvidenceValue value={value} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Props                                                                       */
+/* -------------------------------------------------------------------------- */
+
+interface DetectionDetailPaneProps {
+  selected: DetectionResponse;
+  actorSuggestions: string[];
+  onClose: () => void;
+  onDeleted: () => void;
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Component                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export function DetectionDetailPane({
+  selected,
+  actorSuggestions,
+  onClose,
+  onDeleted,
+}: DetectionDetailPaneProps) {
+  const qc = useQueryClient();
+
+  // Local UI state
+  const [showAssignDropdown, setShowAssignDropdown] = useState(false);
+  const [assignValue, setAssignValue] = useState('');
+  const [showDismissForm, setShowDismissForm] = useState(false);
+  const [dismissReason, setDismissReason] = useState<DismissReason>('False positive');
+  const [dismissNote, setDismissNote] = useState('');
+  const [showResolveForm, setShowResolveForm] = useState(false);
+  const [resolveNote, setResolveNote] = useState('');
+  const [timelineExpanded, setTimelineExpanded] = useState(false);
+
+  // Mutations
+  const assignMutation = useMutation({
+    mutationFn: ({ id, assignee }: { id: number; assignee: string }) =>
+      assignDetection(id, { assigned_to: assignee }),
+    onSuccess: () => {
+      setShowAssignDropdown(false);
+      setAssignValue('');
+      void qc.invalidateQueries({ queryKey: ['detections'] });
+    },
+  });
+
+  const dismissMutation = useMutation({
+    mutationFn: ({ id, note }: { id: number; note: string }) =>
+      updateDetectionStatus(id, { status: 'false_positive', resolution_note: note }),
+    onSuccess: () => {
+      setShowDismissForm(false);
+      setDismissReason('False positive');
+      setDismissNote('');
+      void qc.invalidateQueries({ queryKey: ['detections'] });
+    },
+  });
+
+  const resolveMutation = useMutation({
+    mutationFn: ({ id, note }: { id: number; note: string }) =>
+      updateDetectionStatus(id, {
+        status: 'resolved',
+        resolution_note: note || undefined,
+      }),
+    onSuccess: () => {
+      setShowResolveForm(false);
+      setResolveNote('');
+      void qc.invalidateQueries({ queryKey: ['detections'] });
+    },
+  });
+
+  const reopenMutation = useMutation({
+    mutationFn: (id: number) => updateDetectionStatus(id, { status: 'open' }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['detections'] });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteDetection(id),
+    onSuccess: () => {
+      onDeleted();
+      void qc.invalidateQueries({ queryKey: ['detections'] });
+    },
+  });
+
+  // Timeline query (lazy — only fetched when expanded)
+  const {
+    data: timelineData,
+    isLoading: timelineLoading,
+    isError: timelineError,
+    refetch: refetchTimeline,
+  } = useQuery({
+    queryKey: ['detection-timeline', selected.id],
+    queryFn: () => getDetectionTimeline(selected.id),
+    enabled: timelineExpanded,
+    staleTime: 30_000,
+  });
+
+  const timelineEvents: readonly TimelineEvent[] = timelineData?.events ?? [];
+
+  const sevLabelVariant = (sev: string) => {
+    if (sev === 'critical') return 'danger' as const;
+    if (sev === 'high') return 'severe' as const;
+    if (sev === 'medium') return 'attention' as const;
+    return 'success' as const;
+  };
+
+  const statusColor = (status: string) => {
+    if (status === 'open') return 'danger' as const;
+    if (status === 'investigating') return 'attention' as const;
+    if (status === 'resolved') return 'success' as const;
+    return 'muted' as const;
+  };
+
+  const isActionable = selected.status === 'open' || selected.status === 'investigating';
+  const isResolvable = selected.status === 'investigating';
+  const isReopenable = selected.status === 'resolved' || selected.status === 'false_positive';
+
+  const eventIds = Array.isArray(selected.event_ids) ? selected.event_ids : [];
+
+  return (
+    <>
+      {/* Header */}
+      <div className={styles.panelHeader}>
+        <div style={{ fontWeight: 600 }}>{safeText(selected.title)}</div>
+        <button className={styles.panelClose} onClick={onClose}>
+          &#215;
+        </button>
+      </div>
+
+      {/* Labels row */}
+      <div className={styles.panelLabels}>
+        <Label variant={sevLabelVariant(selected.severity)}>{selected.severity}</Label>
+        {selected.rule_name && <Label variant="muted">{safeText(selected.rule_name)}</Label>}
+        {selected.confidence_score > 0 && (
+          <span className={styles.confidenceBadge}>
+            {Math.round(selected.confidence_score * 100)}% confidence
+          </span>
+        )}
+      </div>
+
+      {/* Summary */}
+      <div className={styles.sectionHeader}>Summary</div>
+      <p className={styles.panelDesc}>{safeText(selected.description)}</p>
+
+      {/* Key Details */}
+      <div className={styles.sectionHeader}>Key Details</div>
+      <div className={styles.keyDetails}>
+        {selected.actor && (
+          <>
+            <span className={styles.keyDetailsLabel}>Actor</span>
+            <span className={styles.keyDetailsValue}>
+              <Link
+                to={`/actors/${encodeURIComponent(selected.actor)}`}
+                className={styles.mention}
+              >
+                @{safeText(selected.actor)}
+              </Link>
+            </span>
+          </>
+        )}
+        {safeText(
+          selected.repo || selected.context_data?.repo || selected.context_data?.repository,
+        ) && (
+          <>
+            <span className={styles.keyDetailsLabel}>Repository</span>
+            <span className={styles.keyDetailsValue}>
+              {safeText(
+                selected.repo ||
+                  selected.context_data?.repo ||
+                  selected.context_data?.repository,
+              )}
+            </span>
+          </>
+        )}
+        {safeText(
+          selected.org || selected.context_data?.org || selected.context_data?.organization,
+        ) && (
+          <>
+            <span className={styles.keyDetailsLabel}>Organization</span>
+            <span className={styles.keyDetailsValue}>
+              {safeText(
+                selected.org ||
+                  selected.context_data?.org ||
+                  selected.context_data?.organization,
+              )}
+            </span>
+          </>
+        )}
+        {safeText(selected.context_data?.action) && (
+          <>
+            <span className={styles.keyDetailsLabel}>Action</span>
+            <span className={styles.keyDetailsValue}>
+              {safeText(selected.context_data.action)}
+            </span>
+          </>
+        )}
+        {safeText(selected.context_data?.what_changed) && (
+          <>
+            <span className={styles.keyDetailsLabel}>What Changed</span>
+            <span className={styles.keyDetailsValue}>
+              {safeText(selected.context_data.what_changed)}
+            </span>
+          </>
+        )}
+        {selected.source_ip && (
+          <>
+            <span className={styles.keyDetailsLabel}>Source IP</span>
+            <span className={styles.keyDetailsValue}>{safeText(selected.source_ip)}</span>
+          </>
+        )}
+        {selected.triggered_at && (
+          <>
+            <span className={styles.keyDetailsLabel}>Triggered</span>
+            <span className={styles.keyDetailsValue}>
+              {formatRelativeShort(selected.triggered_at)}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Rule Info */}
+      {selected.rule_id && (
+        <>
+          <div className={styles.sectionHeader}>Rule Info</div>
+          <div className={styles.keyDetails}>
+            <span className={styles.keyDetailsLabel}>Rule</span>
+            <span className={styles.keyDetailsValue}>
+              <Link to={`/rules?id=${selected.rule_id}`} className={styles.mention}>
+                {safeText(selected.rule_name) || `Rule #${selected.rule_id}`}
+              </Link>
+            </span>
+            {safeText(selected.context_data?.category) && (
+              <>
+                <span className={styles.keyDetailsLabel}>Category</span>
+                <span className={styles.keyDetailsValue}>
+                  <Label variant="muted">{safeText(selected.context_data.category)}</Label>
+                </span>
+              </>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Detection Window */}
+      {(selected.window_start || selected.window_end) && (
+        <>
+          <div className={styles.sectionHeader}>Detection Window</div>
+          <div className={styles.keyDetails}>
+            {selected.window_start && (
+              <>
+                <span className={styles.keyDetailsLabel}>Start</span>
+                <span className={styles.keyDetailsValue}>
+                  {formatCompact(selected.window_start)}
+                </span>
+              </>
+            )}
+            {selected.window_end && (
+              <>
+                <span className={styles.keyDetailsLabel}>End</span>
+                <span className={styles.keyDetailsValue}>
+                  {formatCompact(selected.window_end)}
+                </span>
+              </>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Status & Assignment */}
+      <div className={styles.sectionHeader}>Status &amp; Assignment</div>
+      <div className={styles.keyDetails}>
+        <span className={styles.keyDetailsLabel}>Status</span>
+        <span className={styles.keyDetailsValue}>
+          <Label variant={statusColor(selected.status)}>
+            {selected.status.replace('_', ' ')}
+          </Label>
+        </span>
+        <span className={styles.keyDetailsLabel}>Assigned To</span>
+        <span className={styles.keyDetailsValue}>
+          {selected.assigned_to ? (
+            <Link
+              to={`/actors/${encodeURIComponent(selected.assigned_to)}`}
+              className={styles.mention}
+            >
+              @{safeText(selected.assigned_to)}
+            </Link>
+          ) : (
+            <span className={styles.evidenceMuted}>Unassigned</span>
+          )}
+        </span>
+        {selected.resolved_at && (
+          <>
+            <span className={styles.keyDetailsLabel}>Resolved At</span>
+            <span className={styles.keyDetailsValue}>
+              {formatCompact(selected.resolved_at)}
+            </span>
+          </>
+        )}
+        {selected.resolution_note && (
+          <>
+            <span className={styles.keyDetailsLabel}>Resolution</span>
+            <span className={styles.keyDetailsValue}>
+              {safeText(selected.resolution_note)}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Linked Tickets */}
+      {selected.tickets.length > 0 && (
+        <>
+          <div className={styles.sectionHeader}>Linked Tickets</div>
+          <div className={styles.ticketList}>
+            {selected.tickets.map((ticket) => (
+              <a
+                key={ticket.id}
+                href={ticket.external_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.ticketLink}
+              >
+                <span className={styles.ticketProvider}>{ticket.provider}</span>
+                <span>{ticket.external_id}</span>
+              </a>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Related Events */}
+      {eventIds.length > 0 && (
+        <>
+          <div className={styles.sectionHeader}>Related Events</div>
+          <div className={styles.relatedEventsSection}>
+            {eventIds.length <= 5 ? (
+              eventIds.map((eventId) => {
+                const timelineEvent = timelineEvents.find((e) => e.id === eventId);
+                return (
+                  <Link
+                    key={eventId}
+                    to={`/events?id=${eventId}`}
+                    className={styles.relatedEventRow}
+                  >
+                    <span className={styles.relatedEventId}>#{eventId}</span>
+                    {timelineEvent && (
+                      <>
+                        <span className={styles.relatedEventAction}>
+                          {timelineEvent.action}
+                        </span>
+                        {timelineEvent.actor && (
+                          <span className={styles.relatedEventActor}>
+                            @{timelineEvent.actor}
+                          </span>
+                        )}
+                        <span className={styles.relatedEventTime}>
+                          {formatRelativeShort(timelineEvent.created_at)}
+                        </span>
+                      </>
+                    )}
+                  </Link>
+                );
+              })
+            ) : (
+              <>
+                {eventIds.slice(0, 3).map((eventId) => {
+                  const timelineEvent = timelineEvents.find((e) => e.id === eventId);
+                  return (
+                    <Link
+                      key={eventId}
+                      to={`/events?id=${eventId}`}
+                      className={styles.relatedEventRow}
+                    >
+                      <span className={styles.relatedEventId}>#{eventId}</span>
+                      {timelineEvent && (
+                        <>
+                          <span className={styles.relatedEventAction}>
+                            {timelineEvent.action}
+                          </span>
+                          {timelineEvent.actor && (
+                            <span className={styles.relatedEventActor}>
+                              @{timelineEvent.actor}
+                            </span>
+                          )}
+                          <span className={styles.relatedEventTime}>
+                            {formatRelativeShort(timelineEvent.created_at)}
+                          </span>
+                        </>
+                      )}
+                    </Link>
+                  );
+                })}
+                <Link
+                  to={`/events?detection_id=${selected.id}`}
+                  className={styles.eventCountLink}
+                >
+                  View all {eventIds.length} events →
+                </Link>
+              </>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Evidence */}
+      {hasEntries(selected.context_data) && (
+        <>
+          <div className={styles.sectionHeader}>Evidence</div>
+          <EvidenceDisplay data={selected.context_data} />
+        </>
+      )}
+
+      {/* Investigation Timeline (inline, collapsible) */}
+      <div className={styles.sectionHeader}>
+        <button
+          type="button"
+          className={styles.expandToggle}
+          onClick={() => setTimelineExpanded((v) => !v)}
+          aria-expanded={timelineExpanded}
+          aria-controls="timeline-section"
+        >
+          {timelineExpanded ? '▾' : '▸'} Investigation Timeline
+        </button>
+      </div>
+      {timelineExpanded && (
+        <div id="timeline-section" className={styles.timelineInline}>
+          {timelineLoading && <Spinner />}
+          {timelineError && (
+            <ErrorBanner message="Failed to load timeline" onRetry={refetchTimeline} />
+          )}
+          {!timelineLoading && !timelineError && timelineEvents.length === 0 && (
+            <p className={styles.evidenceMuted}>No timeline events yet.</p>
+          )}
+          {timelineEvents.map((event) => (
+            <Link
+              key={event.id}
+              to={`/events?id=${event.id}`}
+              className={styles.timelineEvent}
+            >
+              <div className={styles.timelineEventDot}>
+                <SeverityDot severity="low" />
+              </div>
+              <div className={styles.timelineEventContent}>
+                <div className={styles.timelineEventAction}>{event.action}</div>
+                <div className={styles.timelineEventMeta}>
+                  {event.actor && <span>@{event.actor}</span>}
+                  {event.org && <span>· {event.org}</span>}
+                  {event.repo && <span>· {event.repo}</span>}
+                  {event.source_ip && <span>· {event.source_ip}</span>}
+                </div>
+                <div className={styles.timelineEventTime}>
+                  {formatCompact(event.created_at)}
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* Action Buttons */}
+      <div className={styles.panelActions}>
+        {isActionable && (
+          <>
+            <Button
+              size="sm"
+              variant="primary"
+              onClick={() => setShowAssignDropdown((v) => !v)}
+              disabled={assignMutation.isPending}
+            >
+              👤 Assign
+            </Button>
+            <Button
+              size="sm"
+              variant="danger"
+              onClick={() => setShowDismissForm((v) => !v)}
+              disabled={dismissMutation.isPending}
+            >
+              ✕ Dismiss
+            </Button>
+          </>
+        )}
+        {isResolvable && (
+          <Button
+            size="sm"
+            onClick={() => setShowResolveForm((v) => !v)}
+            disabled={resolveMutation.isPending}
+          >
+            ✓ Resolve
+          </Button>
+        )}
+        {isReopenable && (
+          <Button
+            size="sm"
+            onClick={() => reopenMutation.mutate(selected.id)}
+            disabled={reopenMutation.isPending}
+          >
+            {reopenMutation.isPending ? 'Reopening…' : '↺ Reopen'}
+          </Button>
+        )}
+      </div>
+
+      {/* Assign Dropdown */}
+      {showAssignDropdown && (
+        <div className={styles.assignDropdown} data-testid="assign-dropdown">
+          <Autocomplete
+            value={assignValue}
+            onChange={setAssignValue}
+            suggestions={actorSuggestions}
+            placeholder="Enter username…"
+            ariaLabel="Assign to username"
+            className={styles.filterInput}
+          />
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => {
+              if (assignValue.trim()) {
+                assignMutation.mutate({ id: selected.id, assignee: assignValue.trim() });
+              }
+            }}
+            disabled={!assignValue.trim() || assignMutation.isPending}
+          >
+            {assignMutation.isPending ? 'Assigning…' : 'Confirm Assign'}
+          </Button>
+        </div>
+      )}
+
+      {/* Dismiss Form */}
+      {showDismissForm && (
+        <div className={styles.dismissForm} data-testid="dismiss-form">
+          <fieldset className={styles.dismissReasons}>
+            <legend className={styles.dismissLegend}>Reason for dismissal</legend>
+            {DISMISS_REASONS.map((reason) => (
+              <label key={reason} className={styles.dismissRadio}>
+                <input
+                  type="radio"
+                  name="dismiss-reason"
+                  value={reason}
+                  checked={dismissReason === reason}
+                  onChange={() => setDismissReason(reason)}
+                />
+                {reason}
+              </label>
+            ))}
+          </fieldset>
+          <textarea
+            className={styles.dismissTextarea}
+            placeholder="Additional notes (optional)…"
+            value={dismissNote}
+            onChange={(e) => setDismissNote(e.target.value)}
+            rows={2}
+          />
+          <Button
+            size="sm"
+            variant="danger"
+            onClick={() => {
+              const note = dismissNote.trim()
+                ? `${dismissReason}: ${dismissNote.trim()}`
+                : dismissReason;
+              dismissMutation.mutate({ id: selected.id, note });
+            }}
+            disabled={dismissMutation.isPending}
+          >
+            {dismissMutation.isPending ? 'Dismissing…' : 'Confirm Dismiss'}
+          </Button>
+        </div>
+      )}
+
+      {/* Resolve Form */}
+      {showResolveForm && (
+        <div className={styles.dismissForm} data-testid="resolve-form">
+          <textarea
+            className={styles.dismissTextarea}
+            placeholder="Resolution notes (optional)…"
+            value={resolveNote}
+            onChange={(e) => setResolveNote(e.target.value)}
+            rows={2}
+          />
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={() => {
+              resolveMutation.mutate({ id: selected.id, note: resolveNote.trim() });
+            }}
+            disabled={resolveMutation.isPending}
+          >
+            {resolveMutation.isPending ? 'Resolving…' : 'Confirm Resolve'}
+          </Button>
+        </div>
+      )}
+
+      {/* Delete — subtle link at bottom */}
+      <div className={styles.panelDeleteSection}>
+        <button
+          type="button"
+          className={styles.deleteLink}
+          onClick={() => {
+            if (window.confirm('Delete this detection record? This action cannot be undone.')) {
+              deleteMutation.mutate(selected.id);
+            }
+          }}
+          disabled={deleteMutation.isPending}
+        >
+          {deleteMutation.isPending ? 'Deleting…' : 'Delete Detection'}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Threats/DetectionDetailPane.tsx
+++ b/frontend/src/pages/Threats/DetectionDetailPane.tsx
@@ -1,11 +1,7 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
-  updateDetectionStatus,
-  deleteDetection,
-  assignDetection,
-} from '../../api/detections';
+import { updateDetectionStatus, deleteDetection, assignDetection } from '../../api/detections';
 import { getDetectionTimeline } from '../../api/executive';
 import type { TimelineEvent } from '../../api/executive';
 import type { DetectionResponse } from '../../types/detections';
@@ -291,10 +287,7 @@ export function DetectionDetailPane({
           <>
             <span className={styles.keyDetailsLabel}>Actor</span>
             <span className={styles.keyDetailsValue}>
-              <Link
-                to={`/actors/${encodeURIComponent(selected.actor)}`}
-                className={styles.mention}
-              >
+              <Link to={`/actors/${encodeURIComponent(selected.actor)}`} className={styles.mention}>
                 @{safeText(selected.actor)}
               </Link>
             </span>
@@ -307,9 +300,7 @@ export function DetectionDetailPane({
             <span className={styles.keyDetailsLabel}>Repository</span>
             <span className={styles.keyDetailsValue}>
               {safeText(
-                selected.repo ||
-                  selected.context_data?.repo ||
-                  selected.context_data?.repository,
+                selected.repo || selected.context_data?.repo || selected.context_data?.repository,
               )}
             </span>
           </>
@@ -321,9 +312,7 @@ export function DetectionDetailPane({
             <span className={styles.keyDetailsLabel}>Organization</span>
             <span className={styles.keyDetailsValue}>
               {safeText(
-                selected.org ||
-                  selected.context_data?.org ||
-                  selected.context_data?.organization,
+                selected.org || selected.context_data?.org || selected.context_data?.organization,
               )}
             </span>
           </>
@@ -331,9 +320,7 @@ export function DetectionDetailPane({
         {safeText(selected.context_data?.action) && (
           <>
             <span className={styles.keyDetailsLabel}>Action</span>
-            <span className={styles.keyDetailsValue}>
-              {safeText(selected.context_data.action)}
-            </span>
+            <span className={styles.keyDetailsValue}>{safeText(selected.context_data.action)}</span>
           </>
         )}
         {safeText(selected.context_data?.what_changed) && (
@@ -399,9 +386,7 @@ export function DetectionDetailPane({
             {selected.window_end && (
               <>
                 <span className={styles.keyDetailsLabel}>End</span>
-                <span className={styles.keyDetailsValue}>
-                  {formatCompact(selected.window_end)}
-                </span>
+                <span className={styles.keyDetailsValue}>{formatCompact(selected.window_end)}</span>
               </>
             )}
           </div>
@@ -413,9 +398,7 @@ export function DetectionDetailPane({
       <div className={styles.keyDetails}>
         <span className={styles.keyDetailsLabel}>Status</span>
         <span className={styles.keyDetailsValue}>
-          <Label variant={statusColor(selected.status)}>
-            {selected.status.replace('_', ' ')}
-          </Label>
+          <Label variant={statusColor(selected.status)}>{selected.status.replace('_', ' ')}</Label>
         </span>
         <span className={styles.keyDetailsLabel}>Assigned To</span>
         <span className={styles.keyDetailsValue}>
@@ -433,17 +416,13 @@ export function DetectionDetailPane({
         {selected.resolved_at && (
           <>
             <span className={styles.keyDetailsLabel}>Resolved At</span>
-            <span className={styles.keyDetailsValue}>
-              {formatCompact(selected.resolved_at)}
-            </span>
+            <span className={styles.keyDetailsValue}>{formatCompact(selected.resolved_at)}</span>
           </>
         )}
         {selected.resolution_note && (
           <>
             <span className={styles.keyDetailsLabel}>Resolution</span>
-            <span className={styles.keyDetailsValue}>
-              {safeText(selected.resolution_note)}
-            </span>
+            <span className={styles.keyDetailsValue}>{safeText(selected.resolution_note)}</span>
           </>
         )}
       </div>
@@ -486,13 +465,9 @@ export function DetectionDetailPane({
                     <span className={styles.relatedEventId}>#{eventId}</span>
                     {timelineEvent && (
                       <>
-                        <span className={styles.relatedEventAction}>
-                          {timelineEvent.action}
-                        </span>
+                        <span className={styles.relatedEventAction}>{timelineEvent.action}</span>
                         {timelineEvent.actor && (
-                          <span className={styles.relatedEventActor}>
-                            @{timelineEvent.actor}
-                          </span>
+                          <span className={styles.relatedEventActor}>@{timelineEvent.actor}</span>
                         )}
                         <span className={styles.relatedEventTime}>
                           {formatRelativeShort(timelineEvent.created_at)}
@@ -515,13 +490,9 @@ export function DetectionDetailPane({
                       <span className={styles.relatedEventId}>#{eventId}</span>
                       {timelineEvent && (
                         <>
-                          <span className={styles.relatedEventAction}>
-                            {timelineEvent.action}
-                          </span>
+                          <span className={styles.relatedEventAction}>{timelineEvent.action}</span>
                           {timelineEvent.actor && (
-                            <span className={styles.relatedEventActor}>
-                              @{timelineEvent.actor}
-                            </span>
+                            <span className={styles.relatedEventActor}>@{timelineEvent.actor}</span>
                           )}
                           <span className={styles.relatedEventTime}>
                             {formatRelativeShort(timelineEvent.created_at)}
@@ -531,10 +502,7 @@ export function DetectionDetailPane({
                     </Link>
                   );
                 })}
-                <Link
-                  to={`/events?detection_id=${selected.id}`}
-                  className={styles.eventCountLink}
-                >
+                <Link to={`/events?detection_id=${selected.id}`} className={styles.eventCountLink}>
                   View all {eventIds.length} events →
                 </Link>
               </>
@@ -573,11 +541,7 @@ export function DetectionDetailPane({
             <p className={styles.evidenceMuted}>No timeline events yet.</p>
           )}
           {timelineEvents.map((event) => (
-            <Link
-              key={event.id}
-              to={`/events?id=${event.id}`}
-              className={styles.timelineEvent}
-            >
+            <Link key={event.id} to={`/events?id=${event.id}`} className={styles.timelineEvent}>
               <div className={styles.timelineEventDot}>
                 <SeverityDot severity="low" />
               </div>
@@ -589,9 +553,7 @@ export function DetectionDetailPane({
                   {event.repo && <span>· {event.repo}</span>}
                   {event.source_ip && <span>· {event.source_ip}</span>}
                 </div>
-                <div className={styles.timelineEventTime}>
-                  {formatCompact(event.created_at)}
-                </div>
+                <div className={styles.timelineEventTime}>{formatCompact(event.created_at)}</div>
               </div>
             </Link>
           ))}

--- a/frontend/src/pages/Threats/Threats.module.css
+++ b/frontend/src/pages/Threats/Threats.module.css
@@ -473,3 +473,261 @@
 .expandToggle:hover {
   text-decoration: underline;
 }
+
+/* Assign dropdown */
+.assignDropdown {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  margin-top: 10px;
+  padding: 10px;
+  background: var(--canvas-default);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+/* Dismiss form */
+.dismissForm {
+  margin-top: 10px;
+  padding: 12px;
+  background: var(--canvas-default);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dismissReasons {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dismissLegend {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-muted);
+  margin-bottom: 4px;
+}
+
+.dismissRadio {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.dismissRadio input[type="radio"] {
+  margin: 0;
+  cursor: pointer;
+}
+
+.dismissTextarea {
+  width: 100%;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--canvas-subtle);
+  color: var(--fg);
+  font-size: 12px;
+  font-family: inherit;
+  resize: vertical;
+  min-height: 40px;
+}
+
+.dismissTextarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+
+/* Inline timeline */
+.timelineInline {
+  margin-bottom: 14px;
+  padding-left: 8px;
+  border-left: 2px solid var(--border-muted);
+}
+
+.timelineEvent {
+  display: flex;
+  gap: 8px;
+  padding: 8px 6px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.1s;
+}
+
+.timelineEvent:hover {
+  background: rgba(177, 186, 196, 0.08);
+}
+
+.timelineEventDot {
+  flex-shrink: 0;
+  padding-top: 3px;
+}
+
+.timelineEventContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.timelineEventAction {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+}
+
+.timelineEventMeta {
+  font-size: 12px;
+  color: var(--fg-muted);
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  margin-top: 2px;
+}
+
+.timelineEventTime {
+  font-size: 11px;
+  color: var(--fg-subtle);
+  margin-top: 2px;
+}
+
+/* Related events section */
+.relatedEventsSection {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 14px;
+}
+
+.relatedEventRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  font-size: 12px;
+  transition: background 0.1s;
+}
+
+.relatedEventRow:hover {
+  background: rgba(177, 186, 196, 0.08);
+}
+
+.relatedEventId {
+  font-family: var(--font-mono, monospace);
+  font-size: 11px;
+  color: var(--accent);
+  font-weight: 500;
+  flex-shrink: 0;
+}
+
+.relatedEventAction {
+  color: var(--fg);
+  font-weight: 500;
+}
+
+.relatedEventActor {
+  color: var(--done);
+}
+
+.relatedEventTime {
+  color: var(--fg-subtle);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Confidence badge */
+.confidenceBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(88, 166, 255, 0.12);
+  color: var(--accent);
+}
+
+/* Status badge */
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* Ticket links */
+.ticketList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 14px;
+}
+
+.ticketLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--accent);
+  text-decoration: none;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: background 0.1s;
+}
+
+.ticketLink:hover {
+  background: rgba(177, 186, 196, 0.08);
+  text-decoration: underline;
+}
+
+.ticketProvider {
+  font-size: 10px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: var(--fg-muted);
+  background: var(--canvas-subtle);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+/* Delete link */
+.panelDeleteSection {
+  margin-top: 20px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border-muted);
+  text-align: center;
+}
+
+.deleteLink {
+  background: none;
+  border: none;
+  color: var(--fg-subtle);
+  font-size: 12px;
+  cursor: pointer;
+  font-family: inherit;
+  text-decoration: underline;
+  opacity: 0.7;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.deleteLink:hover {
+  color: var(--danger);
+  opacity: 1;
+}
+
+.deleteLink:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/frontend/src/pages/Threats/Threats.module.css
+++ b/frontend/src/pages/Threats/Threats.module.css
@@ -523,7 +523,7 @@
   cursor: pointer;
 }
 
-.dismissRadio input[type="radio"] {
+.dismissRadio input[type='radio'] {
   margin: 0;
   cursor: pointer;
 }
@@ -719,7 +719,9 @@
   font-family: inherit;
   text-decoration: underline;
   opacity: 0.7;
-  transition: opacity 0.15s, color 0.15s;
+  transition:
+    opacity 0.15s,
+    color 0.15s;
 }
 
 .deleteLink:hover {

--- a/frontend/src/pages/Threats/Threats.test.tsx
+++ b/frontend/src/pages/Threats/Threats.test.tsx
@@ -22,6 +22,20 @@ vi.mock('../../api/detections', () => ({
   assignDetection: (...args: unknown[]) => mockAssignDetection(...args),
 }));
 
+const mockGetDetectionTimeline = vi.fn().mockResolvedValue({
+  detection_id: 1,
+  detection_title: 'Test',
+  detection_severity: 'critical',
+  detection_category: null,
+  events: [],
+  sequence_steps: [],
+  context_data: {},
+});
+
+vi.mock('../../api/executive', () => ({
+  getDetectionTimeline: (...args: unknown[]) => mockGetDetectionTimeline(...args),
+}));
+
 describe('ThreatsPage', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
@@ -166,31 +180,30 @@ describe('ThreatsPage with data', () => {
     expect(screen.getByText('Admin action from unusual IP')).toBeInTheDocument();
   });
 
-  it('shows related events count as a clickable link in detail panel', async () => {
+  it('shows related events as clickable links in detail panel', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ThreatsPage />);
 
     const row = await screen.findByText('Suspicious admin activity detected');
     await user.click(row);
 
-    const link = screen.getByText('3 events →');
-    expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('role', 'button');
+    // Each event_id is rendered as a link
+    const link101 = screen.getByText('#101');
+    expect(link101).toBeInTheDocument();
+    expect(link101.closest('a')).toHaveAttribute('href', '/events?id=101');
   });
 
-  it('navigates to events page when related events count is clicked', async () => {
+  it('shows all related events when 5 or fewer', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ThreatsPage />);
 
     const row = await screen.findByText('Suspicious admin activity detected');
     await user.click(row);
 
-    const link = screen.getByText('3 events →');
-    await user.click(link);
-
-    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/events?'));
-    // Should include actor param
-    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('actor=mallory'));
+    // 3 events in MOCK_DETECTION
+    expect(screen.getByText('#101')).toBeInTheDocument();
+    expect(screen.getByText('#102')).toBeInTheDocument();
+    expect(screen.getByText('#103')).toBeInTheDocument();
   });
 
   it('renders evidence section for detection with context data', async () => {
@@ -229,8 +242,9 @@ describe('ThreatsPage with data', () => {
     await user.click(row);
 
     expect(screen.getByText('Delete Detection')).toBeInTheDocument();
-    expect(screen.getByText('Acknowledge')).toBeInTheDocument();
-    expect(screen.getByText('Assign')).toBeInTheDocument();
+    expect(screen.getByText('👤 Assign')).toBeInTheDocument();
+    expect(screen.getByText('✕ Dismiss')).toBeInTheDocument();
+    expect(screen.getByText('✓ Resolve')).toBeInTheDocument();
   });
 
   it('shows actor mention in detection row', async () => {
@@ -340,5 +354,253 @@ describe('ThreatsPage tab count badges', () => {
     const openTab = screen.getByText('Open').closest('button');
     expect(openTab).toBeInTheDocument();
     expect(within(openTab!).getByText('5')).toBeInTheDocument();
+  });
+});
+
+/* ------------------------------------------------------------------ */
+/*  Detection Detail Pane - Assign, Dismiss, Timeline, Events          */
+/* ------------------------------------------------------------------ */
+
+describe('DetectionDetailPane interactions', () => {
+  const MOCK_DETECTION = {
+    id: 1,
+    rule_id: 10,
+    rule_name: 'suspicious_admin_action',
+    rule_version: 1,
+    severity: 'critical' as const,
+    confidence: 'high',
+    confidence_score: 0.95,
+    status: 'investigating' as const,
+    title: 'Suspicious admin activity detected',
+    description: 'Admin action from unusual IP',
+    actor: 'mallory',
+    org: 'myorg',
+    repo: null,
+    source_ip: '1.2.3.4',
+    window_start: '2024-01-15T11:00:00Z',
+    window_end: '2024-01-15T12:00:00Z',
+    event_ids: [101, 102, 103],
+    context_data: { ip: '1.2.3.4', action: 'org.update_member', category: 'privilege_escalation' },
+    triggered_at: '2024-01-15T12:00:00Z',
+    assigned_to: null,
+    resolved_at: null,
+    resolution_note: null,
+    tickets: [],
+  };
+
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockListDetections.mockClear();
+    mockUpdateDetectionStatus.mockClear();
+    mockAssignDetection.mockClear();
+    mockGetDetectionTimeline.mockClear();
+    mockListDetections.mockResolvedValue({
+      items: [MOCK_DETECTION],
+      total: 1,
+      page: 1,
+      page_size: 50,
+      has_next: false,
+    });
+    mockGetDetectionTimeline.mockResolvedValue({
+      detection_id: 1,
+      detection_title: 'Test',
+      detection_severity: 'critical',
+      detection_category: null,
+      events: [
+        {
+          id: 101,
+          created_at: '2024-01-15T11:30:00Z',
+          action: 'org.update_member',
+          actor: 'mallory',
+          org: 'myorg',
+          repo: null,
+          source_ip: '1.2.3.4',
+          geo_country_code: null,
+          geo_city: null,
+          geo_latitude: null,
+          geo_longitude: null,
+          data: {},
+          is_sequence_step: false,
+          sequence_index: null,
+        },
+      ],
+      sequence_steps: [],
+      context_data: {},
+    });
+  });
+
+  it('opens assign dropdown and submits assignment', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    // Click Assign button
+    const assignBtn = screen.getByText('👤 Assign');
+    await user.click(assignBtn);
+
+    // Dropdown should appear
+    const dropdown = screen.getByTestId('assign-dropdown');
+    expect(dropdown).toBeInTheDocument();
+
+    // Type a username and confirm
+    const input = screen.getByLabelText('Assign to username');
+    await user.type(input, 'alice');
+    const confirmBtn = screen.getByText('Confirm Assign');
+    await user.click(confirmBtn);
+
+    expect(mockAssignDetection).toHaveBeenCalledWith(1, { assigned_to: 'alice' });
+  });
+
+  it('opens dismiss form with reason selection', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    // Click Dismiss button
+    const dismissBtn = screen.getByText('✕ Dismiss');
+    await user.click(dismissBtn);
+
+    // Form should appear with radio buttons
+    const form = screen.getByTestId('dismiss-form');
+    expect(form).toBeInTheDocument();
+    expect(screen.getByLabelText('False positive')).toBeChecked();
+    expect(screen.getByLabelText('Expected behavior')).toBeInTheDocument();
+    expect(screen.getByLabelText('Duplicate')).toBeInTheDocument();
+    expect(screen.getByLabelText("Won't fix")).toBeInTheDocument();
+
+    // Select a different reason
+    await user.click(screen.getByLabelText('Duplicate'));
+
+    // Confirm dismiss
+    const confirmBtn = screen.getByText('Confirm Dismiss');
+    await user.click(confirmBtn);
+
+    expect(mockUpdateDetectionStatus).toHaveBeenCalledWith(1, {
+      status: 'false_positive',
+      resolution_note: 'Duplicate',
+    });
+  });
+
+  it('shows timeline section that expands with events', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    // Timeline section toggle should exist
+    const toggle = screen.getByText(/Investigation Timeline/);
+    expect(toggle).toBeInTheDocument();
+
+    // Click to expand
+    await user.click(toggle);
+
+    // Should show timeline event after loading — check for the timeline event link
+    const timelineLinks = await screen.findAllByText('org.update_member');
+    // At least 2: one in evidence context_data, one in timeline
+    expect(timelineLinks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows detection window timestamps', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    // Detection Window section should show
+    expect(screen.getByText('Detection Window')).toBeInTheDocument();
+  });
+
+  it('shows status and assignment section', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    expect(screen.getByText('Status & Assignment')).toBeInTheDocument();
+    expect(screen.getByText('investigating')).toBeInTheDocument();
+    expect(screen.getByText('Unassigned')).toBeInTheDocument();
+  });
+
+  it('shows confidence score badge', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    expect(screen.getByText('95% confidence')).toBeInTheDocument();
+  });
+
+  it('shows rule info section with link', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    expect(screen.getByText('Rule Info')).toBeInTheDocument();
+    // Rule name should be a link to rules page
+    const ruleLink = screen.getAllByText('suspicious_admin_action').find(
+      (el) => el.closest('a')?.getAttribute('href') === '/rules?id=10',
+    );
+    expect(ruleLink).toBeInTheDocument();
+  });
+
+  it('shows resolve button when investigating and submits', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    const resolveBtn = screen.getByText('✓ Resolve');
+    await user.click(resolveBtn);
+
+    // Resolve form appears
+    const form = screen.getByTestId('resolve-form');
+    expect(form).toBeInTheDocument();
+
+    const confirmBtn = screen.getByText('Confirm Resolve');
+    await user.click(confirmBtn);
+
+    expect(mockUpdateDetectionStatus).toHaveBeenCalledWith(1, {
+      status: 'resolved',
+      resolution_note: undefined,
+    });
+  });
+
+  it('shows reopen button when detection is resolved', async () => {
+    const resolvedDetection = {
+      ...MOCK_DETECTION,
+      status: 'resolved' as const,
+      resolved_at: '2024-01-16T12:00:00Z',
+      resolution_note: 'Investigated and resolved',
+    };
+    mockListDetections.mockResolvedValue({
+      items: [resolvedDetection],
+      total: 1,
+      page: 1,
+      page_size: 50,
+      has_next: false,
+    });
+
+    const user = userEvent.setup();
+    renderWithProviders(<ThreatsPage />);
+
+    const row = await screen.findByText('Suspicious admin activity detected');
+    await user.click(row);
+
+    const reopenBtn = screen.getByText('↺ Reopen');
+    expect(reopenBtn).toBeInTheDocument();
+
+    await user.click(reopenBtn);
+    expect(mockUpdateDetectionStatus).toHaveBeenCalledWith(1, { status: 'open' });
   });
 });

--- a/frontend/src/pages/Threats/Threats.test.tsx
+++ b/frontend/src/pages/Threats/Threats.test.tsx
@@ -547,9 +547,9 @@ describe('DetectionDetailPane interactions', () => {
 
     expect(screen.getByText('Rule Info')).toBeInTheDocument();
     // Rule name should be a link to rules page
-    const ruleLink = screen.getAllByText('suspicious_admin_action').find(
-      (el) => el.closest('a')?.getAttribute('href') === '/rules?id=10',
-    );
+    const ruleLink = screen
+      .getAllByText('suspicious_admin_action')
+      .find((el) => el.closest('a')?.getAttribute('href') === '/rules?id=10');
     expect(ruleLink).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/Threats/index.tsx
+++ b/frontend/src/pages/Threats/index.tsx
@@ -1,25 +1,19 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useNavigate, useSearchParams, Link } from 'react-router-dom';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import {
-  listDetections,
-  updateDetectionStatus,
-  deleteDetection,
-  assignDetection,
-} from '../../api/detections';
+import { useSearchParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { listDetections } from '../../api/detections';
 import { listRules } from '../../api/rules';
 import { getSuggestedRepos, getSuggestedActors } from '../../api/suggestions';
 import type { DetectionResponse } from '../../types/detections';
 import { SeverityDot } from '../../components/primitives/SeverityDot';
 import { Label } from '../../components/primitives/Label';
-import { Button } from '../../components/primitives/Button';
 import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Pagination } from '../../components/primitives/Pagination';
 import { Autocomplete } from '../../components/primitives/Autocomplete';
 import { PageHeader } from '../../components/common/PageHeader';
 import { EmptyState } from '../../components/common/EmptyState';
-import { InvestigationTimeline } from './InvestigationTimeline';
+import { DetectionDetailPane } from './DetectionDetailPane';
 import { formatRelativeShort } from '../../utils/dates';
 import { useOrg } from '../../hooks/useOrg';
 import { useCurrentUser } from '../../hooks/useCurrentUser';
@@ -27,9 +21,6 @@ import styles from './Threats.module.css';
 
 /**
  * Safely convert any value to a display string.
- * Prevents `[object Object]` from appearing when the API returns an
- * object where a string was expected, or when a field typed as
- * `Record<string, unknown>` is accidentally rendered as JSX text.
  */
 function safeText(value: unknown): string {
   if (value === null || value === undefined) return '';
@@ -38,125 +29,12 @@ function safeText(value: unknown): string {
   return JSON.stringify(value);
 }
 
-/**
- * Safely retrieve the length of an array-like value.
- * Returns 0 when the value is not actually an array, preventing
- * runtime errors if the API sends null/undefined for `event_ids`.
- */
-function safeArrayLength(value: unknown): number {
-  return Array.isArray(value) ? value.length : 0;
-}
-
-/**
- * Safely check whether an object has entries.
- * Returns false when the value is not a plain object, preventing
- * `Object.keys(null)` crashes if the API sends null for `context_data`.
- */
-function hasEntries(value: unknown): value is Record<string, unknown> {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    !Array.isArray(value) &&
-    Object.keys(value).length > 0
-  );
-}
-
-function EvidenceValue({ value, depth = 0 }: { value: unknown; depth?: number }) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (value === null || value === undefined) {
-    return <span className={styles.evidenceMuted}>—</span>;
-  }
-  if (typeof value === 'string') {
-    return <span className={styles.evidenceVal}>{value}</span>;
-  }
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return <span className={styles.evidenceVal}>{String(value)}</span>;
-  }
-  if (Array.isArray(value)) {
-    if (value.length === 0) {
-      return <span className={styles.evidenceMuted}>[]</span>;
-    }
-    const allPrimitive = value.every(
-      (v) => typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean',
-    );
-    if (allPrimitive && value.length <= 5) {
-      return <span className={styles.evidenceVal}>{value.join(', ')}</span>;
-    }
-    return (
-      <div>
-        <button
-          type="button"
-          className={styles.expandToggle}
-          onClick={() => setExpanded((v) => !v)}
-        >
-          {expanded ? '▾' : '▸'} {value.length} item{value.length !== 1 ? 's' : ''}
-        </button>
-        {expanded && (
-          <div className={styles.evidenceNested}>
-            {value.map((item, i) => (
-              <div key={i} className={styles.evidenceRow}>
-                <span className={styles.evidenceKey}>[{i}]</span>
-                <EvidenceValue value={item} depth={depth + 1} />
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-  if (typeof value === 'object') {
-    const entries = Object.entries(value as Record<string, unknown>);
-    if (entries.length === 0) {
-      return <span className={styles.evidenceMuted}>{'{}'}</span>;
-    }
-    return (
-      <div>
-        <button
-          type="button"
-          className={styles.expandToggle}
-          onClick={() => setExpanded((v) => !v)}
-        >
-          {expanded ? '▾' : '▸'} {entries.length} field{entries.length !== 1 ? 's' : ''}
-        </button>
-        {expanded && (
-          <div className={styles.evidenceNested}>
-            {entries.map(([k, v]) => (
-              <div key={k} className={styles.evidenceRow}>
-                <span className={styles.evidenceKey}>{k}</span>
-                <EvidenceValue value={v} depth={depth + 1} />
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    );
-  }
-  return <span className={styles.evidenceVal}>{String(value)}</span>;
-}
-
-function EvidenceDisplay({ data }: { data: Record<string, unknown> }) {
-  return (
-    <div className={styles.evidenceTable}>
-      {Object.entries(data).map(([key, value]) => (
-        <div key={key} className={styles.evidenceRow}>
-          <span className={styles.evidenceKey}>{key}</span>
-          <div className={styles.evidenceValWrap}>
-            <EvidenceValue value={value} />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
-
 type TabFilter = 'open' | 'investigating' | 'closed' | 'acknowledged' | 'all';
 
 export function ThreatsPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [tab, setTab] = useState<TabFilter>('open');
   const [selectedOverride, setSelectedOverride] = useState<DetectionResponse | null>(null);
-  const [investigatingId, setInvestigatingId] = useState<number | null>(null);
   const initialSeverity = searchParams.get('severity') ?? '';
   const initialRepo = searchParams.get('repo') ?? '';
   const initialActor = searchParams.get('actor') ?? '';
@@ -214,9 +92,6 @@ export function ThreatsPage() {
 
   // Effective org: explicit orgFilter takes priority, then global selectedOrg
   const effectiveOrg = orgFilter || selectedOrg || undefined;
-
-  const qc = useQueryClient();
-  const navigate = useNavigate();
 
   const statusMap: Record<TabFilter, string | undefined> = {
     open: 'open',
@@ -344,29 +219,6 @@ export function ThreatsPage() {
     acknowledged: ackData?.total ?? null,
     all: allData?.total ?? null,
   };
-
-  const acknowledgeMutation = useMutation({
-    mutationFn: (id: number) => updateDetectionStatus(id, { status: 'false_positive' }),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ['detections'] });
-    },
-  });
-
-  const assignMutation = useMutation({
-    mutationFn: ({ id, assignee }: { id: number; assignee: string }) =>
-      assignDetection(id, { assigned_to: assignee }),
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ['detections'] });
-    },
-  });
-
-  const suspendMutation = useMutation({
-    mutationFn: (id: number) => deleteDetection(id),
-    onSuccess: () => {
-      selectDetection(null);
-      void qc.invalidateQueries({ queryKey: ['detections'] });
-    },
-  });
 
   const items = data?.items ?? [];
 
@@ -686,201 +538,14 @@ export function ThreatsPage() {
           .join(' ')}
       >
         {selected && (
-          <>
-            <div className={styles.panelHeader}>
-              <div style={{ fontWeight: 600 }}>{safeText(selected.title)}</div>
-              <button className={styles.panelClose} onClick={() => selectDetection(null)}>
-                &#215;
-              </button>
-            </div>
-
-            <div className={styles.panelLabels}>
-              <Label variant={sevLabelVariant(selected.severity)}>{selected.severity}</Label>
-              {selected.rule_name && <Label variant="muted">{safeText(selected.rule_name)}</Label>}
-              {selected.confidence && <Label variant="done">{safeText(selected.confidence)}</Label>}
-            </div>
-
-            <div className={styles.sectionHeader}>Summary</div>
-            <p className={styles.panelDesc}>{safeText(selected.description)}</p>
-
-            <div className={styles.sectionHeader}>Key Details</div>
-            <div className={styles.keyDetails}>
-              {selected.actor && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Actor</span>
-                  <span className={styles.keyDetailsValue}>
-                    <Link
-                      to={`/actors/${encodeURIComponent(selected.actor)}`}
-                      className={styles.mention}
-                    >
-                      @{safeText(selected.actor)}
-                    </Link>
-                  </span>
-                </>
-              )}
-              {safeText(
-                selected.repo || selected.context_data?.repo || selected.context_data?.repository,
-              ) && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Repository</span>
-                  <span className={styles.keyDetailsValue}>
-                    {safeText(
-                      selected.repo ||
-                        selected.context_data?.repo ||
-                        selected.context_data?.repository,
-                    )}
-                  </span>
-                </>
-              )}
-              {safeText(
-                selected.org || selected.context_data?.org || selected.context_data?.organization,
-              ) && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Organization</span>
-                  <span className={styles.keyDetailsValue}>
-                    {safeText(
-                      selected.org ||
-                        selected.context_data?.org ||
-                        selected.context_data?.organization,
-                    )}
-                  </span>
-                </>
-              )}
-              {safeText(selected.context_data?.action) && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Action</span>
-                  <span className={styles.keyDetailsValue}>
-                    {safeText(selected.context_data.action)}
-                  </span>
-                </>
-              )}
-              {safeText(selected.context_data?.what_changed) && (
-                <>
-                  <span className={styles.keyDetailsLabel}>What Changed</span>
-                  <span className={styles.keyDetailsValue}>
-                    {safeText(selected.context_data.what_changed)}
-                  </span>
-                </>
-              )}
-              {selected.source_ip && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Source IP</span>
-                  <span className={styles.keyDetailsValue}>{safeText(selected.source_ip)}</span>
-                </>
-              )}
-              {selected.triggered_at && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Triggered</span>
-                  <span className={styles.keyDetailsValue}>
-                    {formatRelativeShort(selected.triggered_at)}
-                  </span>
-                </>
-              )}
-              {selected.assigned_to && (
-                <>
-                  <span className={styles.keyDetailsLabel}>Assigned To</span>
-                  <span className={styles.keyDetailsValue}>{safeText(selected.assigned_to)}</span>
-                </>
-              )}
-            </div>
-
-            {safeArrayLength(selected.event_ids) > 0 && (
-              <div className={styles.relatedEvents}>
-                <span className={styles.evidenceLabel}>Related events</span>
-                <span
-                  role="button"
-                  tabIndex={0}
-                  className={styles.eventCountLink}
-                  aria-label={`${safeArrayLength(selected.event_ids)} related events — view in events page`}
-                  onClick={() => {
-                    const params = new URLSearchParams();
-                    if (selected.actor) params.set('actor', selected.actor);
-                    if (selected.rule_name) params.set('action', selected.rule_name);
-                    navigate(`/events?${params.toString()}`);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                      e.preventDefault();
-                      const params = new URLSearchParams();
-                      if (selected.actor) params.set('actor', selected.actor);
-                      if (selected.rule_name) params.set('action', selected.rule_name);
-                      navigate(`/events?${params.toString()}`);
-                    }
-                  }}
-                >
-                  {safeArrayLength(selected.event_ids)} event
-                  {safeArrayLength(selected.event_ids) === 1 ? '' : 's'} →
-                </span>
-              </div>
-            )}
-
-            {hasEntries(selected.context_data) && (
-              <>
-                <div className={styles.sectionHeader}>Evidence</div>
-                <EvidenceDisplay data={selected.context_data} />
-              </>
-            )}
-
-            <div className={styles.panelActions}>
-              <Button size="sm" variant="primary" onClick={() => setInvestigatingId(selected.id)}>
-                🔍 Investigate
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => {
-                  window.open(
-                    `/query?sql=${encodeURIComponent(`SELECT * FROM events WHERE id IN (SELECT unnest(event_ids) FROM detections WHERE id = ${selected.id})`)}`,
-                    '_self',
-                  );
-                }}
-              >
-                📋 Run Playbook
-              </Button>
-              <Button
-                size="sm"
-                variant="danger"
-                onClick={() => {
-                  if (
-                    window.confirm('Delete this detection record? This action cannot be undone.')
-                  ) {
-                    suspendMutation.mutate(selected.id);
-                  }
-                }}
-                disabled={suspendMutation.isPending}
-              >
-                Delete Detection
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => acknowledgeMutation.mutate(selected.id)}
-                disabled={acknowledgeMutation.isPending}
-              >
-                Acknowledge
-              </Button>
-              <Button
-                size="sm"
-                onClick={() => {
-                  const user = window.prompt('Assign to username:');
-                  if (user?.trim()) {
-                    assignMutation.mutate({ id: selected.id, assignee: user.trim() });
-                  }
-                }}
-                disabled={assignMutation.isPending}
-              >
-                {assignMutation.isPending ? 'Assigning…' : 'Assign'}
-              </Button>
-            </div>
-          </>
+          <DetectionDetailPane
+            selected={selected}
+            actorSuggestions={actorSuggestions}
+            onClose={() => selectDetection(null)}
+            onDeleted={() => selectDetection(null)}
+          />
         )}
       </div>
-      {investigatingId !== null && (
-        <div className={styles.timelineOverlay}>
-          <InvestigationTimeline
-            detectionId={investigatingId}
-            onClose={() => setInvestigatingId(null)}
-          />
-        </div>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Overhauls the detection detail pane UX to fix the three highest-pain issues in Phase 2:

### #118 — Assign/Dismiss Workflow
- Removed confusing "Investigate" overlay and "Run Playbook" button
- Added inline **Assign** dropdown with autocomplete username selection
- Added **Dismiss** form with structured reasons (false positive, expected behavior, duplicate, won't fix) + optional notes
- Added **Resolve** and **Reopen** actions based on current status
- Moved Delete to subtle link at bottom

### #114 — Complete Detection Detail Pane
- Added **Inline Investigation Timeline** (collapsible, lazy-loaded from API)
- Added **Rule Info** section with category badge and link to rules page
- Added **Detection Window** (window_start → window_end timestamps)
- Added **Status & Assignment** section with colored badges
- Added **Confidence Score** as numeric badge
- Added **Linked Tickets** display with provider icons and external links
- Shows resolution_note when detection is resolved/dismissed

### #113 — Related Event Deep Links
- Each related event shown as clickable row (action, actor, timestamp)
- Click navigates to `/events?id={event_id}`
- Shows first 3 events inline, "View all N events →" for larger sets

## Technical
- Extracted `DetectionDetailPane` component (750 lines) for maintainability
- Main page reduced from 886 → 551 lines
- 9 new tests added (1240 total passing)
- TypeScript clean, ESLint clean

Closes #118, closes #114, closes #113