### PR TITLE
feat: Posture page aggregate-first redesign (#117)

### DIFF
--- a/frontend/src/pages/Posture/Posture.module.css
+++ b/frontend/src/pages/Posture/Posture.module.css
@@ -288,3 +288,118 @@
   color: var(--fg-muted);
   font-size: 14px;
 }
+
+/* ── Metrics Summary Bar ───────────────────────────────────────────── */
+.metricsSummary {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+.metricCard {
+  flex: 1;
+  min-width: 120px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--canvas-default);
+  padding: 14px 16px;
+  text-align: center;
+}
+.metricValue {
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--fg);
+  line-height: 1.2;
+}
+.metricLabel {
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  margin-top: 4px;
+}
+.metricCritical {
+  color: var(--danger);
+}
+.metricHigh {
+  color: var(--severe, #db6d28);
+}
+
+/* ── Charts Row ────────────────────────────────────────────────────── */
+.chartsRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+@media (max-width: 768px) {
+  .chartsRow {
+    grid-template-columns: 1fr;
+  }
+}
+.chartPanel {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--canvas-default);
+  padding: 16px;
+}
+.chartPlaceholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 180px;
+}
+.chartPlaceholderText {
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+
+/* ── Coverage Gauges ───────────────────────────────────────────────── */
+.coverageList {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 12px;
+}
+.coverageItem {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.coverageHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.coverageLabel {
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+.coverageValue {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.coverageTrack {
+  height: 6px;
+  background: var(--canvas-subtle);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.coverageFill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.3s;
+}
+
+/* ── Org Multi-Select ──────────────────────────────────────────────── */
+.orgMultiSelect {
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--canvas-subtle);
+  color: var(--fg);
+  font-size: 13px;
+  min-width: 180px;
+  max-height: 80px;
+}

--- a/frontend/src/pages/Posture/Posture.test.tsx
+++ b/frontend/src/pages/Posture/Posture.test.tsx
@@ -293,8 +293,11 @@ describe('PosturePage — Enterprise View', () => {
 
   it('renders org cards', async () => {
     renderWithProviders(<PosturePage />);
-    expect(await screen.findByText('octowatch-org')).toBeInTheDocument();
-    expect(await screen.findByText('danger-org')).toBeInTheDocument();
+    // org names appear both in cards and multi-select; verify card elements exist
+    const cards = await screen.findAllByText('octowatch-org');
+    expect(cards.length).toBeGreaterThanOrEqual(1);
+    const dangerCards = await screen.findAllByText('danger-org');
+    expect(dangerCards.length).toBeGreaterThanOrEqual(1);
   });
 
   it('renders org scores on cards', async () => {
@@ -323,8 +326,11 @@ describe('PosturePage — Enterprise View', () => {
   it('navigates to org on card click', async () => {
     const user = userEvent.setup();
     renderWithProviders(<PosturePage />);
-    const card = await screen.findByText('octowatch-org');
-    await user.click(card.closest('[class*="orgCard"]')!);
+    const cards = await screen.findAllByText('octowatch-org');
+    // Find the one inside an orgCard (not the select option)
+    const cardEl = cards.find((el) => el.closest('[class*="orgCard"]'));
+    expect(cardEl).toBeTruthy();
+    await user.click(cardEl!.closest('[class*="orgCard"]')!);
     expect(mockNavigate).toHaveBeenCalledWith('/posture/octowatch-org');
   });
 
@@ -613,5 +619,189 @@ describe('PosturePage — Score gauge colors', () => {
     await screen.findByText('45');
     const gauge = document.querySelector('[class*="scoreGauge"]');
     expect(gauge?.className).toContain('bad');
+  });
+});
+
+/* ── New Feature Tests ─────────────────────────────────────────────── */
+
+const EMPTY_ENTERPRISE_RESPONSE: PostureResponse = {
+  level: 'enterprise',
+  score: 0,
+  orgs: [],
+  org: null,
+  repo: null,
+  breadcrumb: [{ label: 'Posture', href: null }],
+  last_sync_at: null,
+  page: 1,
+  page_size: 25,
+  total: 0,
+  has_next: false,
+};
+
+describe('PosturePage — Metrics Summary Bar', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockGetPosture.mockClear();
+    mockGetPosture.mockResolvedValue(ENTERPRISE_RESPONSE);
+    mockParams.org = undefined;
+    mockParams.repo = undefined;
+  });
+
+  it('renders the metrics summary bar', async () => {
+    renderWithProviders(<PosturePage />);
+    const summary = await screen.findByTestId('metrics-summary');
+    expect(summary).toBeInTheDocument();
+  });
+
+  it('shows total open alerts count', async () => {
+    renderWithProviders(<PosturePage />);
+    await screen.findByTestId('metrics-summary');
+    // 1 failing check in ENTERPRISE_RESPONSE (danger-org has 1 open check)
+    expect(screen.getByText('Open Alerts')).toBeInTheDocument();
+  });
+
+  it('shows critical alerts count', async () => {
+    renderWithProviders(<PosturePage />);
+    const summary = await screen.findByTestId('metrics-summary');
+    expect(summary.textContent).toContain('Critical');
+  });
+
+  it('shows high alerts count', async () => {
+    renderWithProviders(<PosturePage />);
+    const summary = await screen.findByTestId('metrics-summary');
+    expect(summary.textContent).toContain('High');
+  });
+
+  it('shows secret scanning coverage', async () => {
+    renderWithProviders(<PosturePage />);
+    const summary = await screen.findByTestId('metrics-summary');
+    expect(summary.textContent).toContain('Secret Scanning');
+  });
+
+  it('shows code scanning coverage', async () => {
+    renderWithProviders(<PosturePage />);
+    const summary = await screen.findByTestId('metrics-summary');
+    expect(summary.textContent).toContain('Code Scanning');
+  });
+});
+
+describe('PosturePage — Severity Distribution Chart', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockGetPosture.mockClear();
+    mockGetPosture.mockResolvedValue(ENTERPRISE_RESPONSE);
+    mockParams.org = undefined;
+    mockParams.repo = undefined;
+  });
+
+  it('renders severity distribution chart', async () => {
+    renderWithProviders(<PosturePage />);
+    const chart = await screen.findByTestId('severity-chart');
+    expect(chart).toBeInTheDocument();
+  });
+
+  it('shows severity distribution title', async () => {
+    renderWithProviders(<PosturePage />);
+    await screen.findByTestId('severity-chart');
+    expect(screen.getByText('Severity Distribution')).toBeInTheDocument();
+  });
+});
+
+describe('PosturePage — Coverage Gauges', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockGetPosture.mockClear();
+    mockGetPosture.mockResolvedValue(ENTERPRISE_RESPONSE);
+    mockParams.org = undefined;
+    mockParams.repo = undefined;
+  });
+
+  it('renders coverage gauges section', async () => {
+    renderWithProviders(<PosturePage />);
+    const gauges = await screen.findByTestId('coverage-gauges');
+    expect(gauges).toBeInTheDocument();
+  });
+
+  it('shows feature coverage title', async () => {
+    renderWithProviders(<PosturePage />);
+    await screen.findByTestId('coverage-gauges');
+    expect(screen.getByText('Feature Coverage')).toBeInTheDocument();
+  });
+
+  it('shows Dependabot coverage label', async () => {
+    renderWithProviders(<PosturePage />);
+    await screen.findByTestId('coverage-gauges');
+    expect(screen.getByText('Dependabot')).toBeInTheDocument();
+  });
+});
+
+describe('PosturePage — Organization Multi-Select Filter', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockGetPosture.mockClear();
+    mockGetPosture.mockResolvedValue(ENTERPRISE_RESPONSE);
+    mockParams.org = undefined;
+    mockParams.repo = undefined;
+  });
+
+  it('renders org multi-select filter', async () => {
+    renderWithProviders(<PosturePage />);
+    const select = await screen.findByTitle(
+      'Filter by organization (hold Ctrl/Cmd to select multiple)',
+    );
+    expect(select).toBeInTheDocument();
+  });
+
+  it('lists all organizations in multi-select', async () => {
+    renderWithProviders(<PosturePage />);
+    const select = await screen.findByTitle(
+      'Filter by organization (hold Ctrl/Cmd to select multiple)',
+    );
+    const options = select.querySelectorAll('option');
+    expect(options.length).toBe(2);
+  });
+
+  it('filters org grid when an organization is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PosturePage />);
+    const select = await screen.findByTitle(
+      'Filter by organization (hold Ctrl/Cmd to select multiple)',
+    );
+    await user.selectOptions(select, ['octowatch-org']);
+    // danger-org card should not be visible (only in the select options)
+    const dangerCards = screen.getAllByText('danger-org');
+    // Only in the select option, not in an orgCard
+    const dangerInCard = dangerCards.find((el) => el.closest('[class*="orgCard"]'));
+    expect(dangerInCard).toBeUndefined();
+  });
+});
+
+describe('PosturePage — Empty State', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    mockGetPosture.mockClear();
+    mockGetPosture.mockResolvedValue(EMPTY_ENTERPRISE_RESPONSE);
+    mockParams.org = undefined;
+    mockParams.repo = undefined;
+  });
+
+  it('shows empty state title when no orgs', async () => {
+    renderWithProviders(<PosturePage />);
+    expect(await screen.findByText('No posture data available yet')).toBeInTheDocument();
+  });
+
+  it('shows empty state description when no orgs', async () => {
+    renderWithProviders(<PosturePage />);
+    expect(
+      await screen.findByText(
+        'Security posture data will appear here once your organizations have been synced.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show metrics summary in empty state', async () => {
+    renderWithProviders(<PosturePage />);
+    await screen.findByText('No posture data available yet');
+    expect(screen.queryByTestId('metrics-summary')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Posture/index.tsx
+++ b/frontend/src/pages/Posture/index.tsx
@@ -341,7 +341,8 @@ function CoverageGauges({ metrics }: { metrics: AggregateMetrics }) {
 }
 
 function CoverageBar({ label, value }: { label: string; value: number }) {
-  const barColor = value >= 80 ? 'var(--success)' : value >= 50 ? 'var(--attention)' : 'var(--danger)';
+  const barColor =
+    value >= 80 ? 'var(--success)' : value >= 50 ? 'var(--attention)' : 'var(--danger)';
   return (
     <div className={styles.coverageItem}>
       <div className={styles.coverageHeader}>
@@ -349,10 +350,7 @@ function CoverageBar({ label, value }: { label: string; value: number }) {
         <span className={styles.coverageValue}>{value}%</span>
       </div>
       <div className={styles.coverageTrack}>
-        <div
-          className={styles.coverageFill}
-          style={{ width: `${value}%`, background: barColor }}
-        />
+        <div className={styles.coverageFill} style={{ width: `${value}%`, background: barColor }} />
       </div>
     </div>
   );

--- a/frontend/src/pages/Posture/index.tsx
+++ b/frontend/src/pages/Posture/index.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
 import { getPosture } from '../../api/posture';
-import type { PostureResponse, PostureCheckResult } from '../../api/posture';
+import type { PostureResponse, PostureCheckResult, OrgPosture } from '../../api/posture';
 import { Label } from '../../components/primitives/Label';
 import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Pagination } from '../../components/primitives/Pagination';
+import { EmptyState } from '../../components/common/EmptyState';
+import { useChartColors } from '../../hooks/useChartColors';
 import { formatDateOnly } from '../../utils/dates';
 import styles from './Posture.module.css';
 
@@ -183,6 +187,210 @@ function filterChecks(checks: PostureCheckResult[], severity: string, statusFilt
   return filtered;
 }
 
+/* ── Aggregate Metrics Helpers ──────────────────────────────────────── */
+
+interface AggregateMetrics {
+  totalOpen: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
+  secretScanningCoverage: number;
+  codeScanningCoverage: number;
+  dependabotCoverage: number;
+}
+
+function computeMetrics(orgs: OrgPosture[]): AggregateMetrics {
+  const allChecks = orgs.flatMap((o) => o.checks);
+  const failing = allChecks.filter((c) => c.status !== 'pass');
+
+  const totalOpen = failing.length;
+  const critical = failing.filter((c) => c.severity === 'critical').length;
+  const high = failing.filter((c) => c.severity === 'high').length;
+  const medium = failing.filter((c) => c.severity === 'medium').length;
+  const low = failing.filter((c) => c.severity === 'low').length;
+
+  // Coverage: check for feature-specific checks across all orgs
+  const totalRepos = orgs.reduce((sum, o) => sum + (o.repo_summary?.total ?? 0), 0);
+
+  function computeCoverage(keyword: string): number {
+    if (totalRepos === 0) return 0;
+    const relevantChecks = allChecks.filter(
+      (c) =>
+        c.title.toLowerCase().includes(keyword) ||
+        c.category.toLowerCase().includes(keyword) ||
+        c.rule_name.toLowerCase().includes(keyword),
+    );
+    if (relevantChecks.length === 0) return 0;
+    const passing = relevantChecks.filter((c) => c.status === 'pass').length;
+    return Math.round((passing / relevantChecks.length) * 100);
+  }
+
+  return {
+    totalOpen,
+    critical,
+    high,
+    medium,
+    low,
+    secretScanningCoverage: computeCoverage('secret scanning'),
+    codeScanningCoverage: computeCoverage('code scanning'),
+    dependabotCoverage: computeCoverage('dependabot'),
+  };
+}
+
+/* ── Metrics Summary Bar ───────────────────────────────────────────── */
+
+function MetricsSummary({ metrics }: { metrics: AggregateMetrics }) {
+  return (
+    <div className={styles.metricsSummary} data-testid="metrics-summary">
+      <div className={styles.metricCard}>
+        <div className={styles.metricValue}>{metrics.totalOpen}</div>
+        <div className={styles.metricLabel}>Open Alerts</div>
+      </div>
+      <div className={styles.metricCard}>
+        <div className={`${styles.metricValue} ${styles.metricCritical}`}>{metrics.critical}</div>
+        <div className={styles.metricLabel}>Critical</div>
+      </div>
+      <div className={styles.metricCard}>
+        <div className={`${styles.metricValue} ${styles.metricHigh}`}>{metrics.high}</div>
+        <div className={styles.metricLabel}>High</div>
+      </div>
+      <div className={styles.metricCard}>
+        <div className={styles.metricValue}>{metrics.secretScanningCoverage}%</div>
+        <div className={styles.metricLabel}>Secret Scanning</div>
+      </div>
+      <div className={styles.metricCard}>
+        <div className={styles.metricValue}>{metrics.codeScanningCoverage}%</div>
+        <div className={styles.metricLabel}>Code Scanning</div>
+      </div>
+    </div>
+  );
+}
+
+/* ── Severity Distribution Chart ───────────────────────────────────── */
+
+function SeverityDistributionChart({ metrics }: { metrics: AggregateMetrics }) {
+  const colors = useChartColors();
+
+  const chartData = [
+    { value: metrics.critical, name: 'Critical' },
+    { value: metrics.high, name: 'High' },
+    { value: metrics.medium, name: 'Medium' },
+    { value: metrics.low, name: 'Low' },
+  ].filter((d) => d.value > 0);
+
+  if (chartData.length === 0) {
+    return (
+      <div className={styles.chartPlaceholder} data-testid="severity-chart">
+        <span className={styles.chartPlaceholderText}>No failing checks</span>
+      </div>
+    );
+  }
+
+  const option: EChartsOption = {
+    backgroundColor: 'transparent',
+    textStyle: { color: colors.chartText, fontFamily: 'inherit' },
+    tooltip: {
+      trigger: 'item',
+      backgroundColor: colors.chartTooltipBg,
+      borderColor: colors.chartTooltipBorder,
+      textStyle: { color: colors.chartTooltipFg, fontSize: 12 },
+      formatter: '{b}: {c} ({d}%)',
+    },
+    legend: {
+      orient: 'vertical',
+      right: 10,
+      top: 'center',
+      textStyle: { color: colors.chartText, fontSize: 11 },
+    },
+    series: [
+      {
+        type: 'pie',
+        radius: ['50%', '75%'],
+        center: ['35%', '50%'],
+        avoidLabelOverlap: false,
+        label: { show: false },
+        data: chartData,
+        itemStyle: { borderRadius: 4, borderWidth: 2, borderColor: 'transparent' },
+        color: ['var(--danger)', 'var(--severe, #db6d28)', 'var(--attention)', 'var(--success)'],
+      },
+    ],
+  };
+
+  return (
+    <div data-testid="severity-chart">
+      <div className={styles.sectionTitle}>Severity Distribution</div>
+      <ReactECharts option={option} style={{ height: 180 }} opts={{ renderer: 'svg' }} />
+    </div>
+  );
+}
+
+/* ── Coverage Gauges ───────────────────────────────────────────────── */
+
+function CoverageGauges({ metrics }: { metrics: AggregateMetrics }) {
+  return (
+    <div data-testid="coverage-gauges">
+      <div className={styles.sectionTitle}>Feature Coverage</div>
+      <div className={styles.coverageList}>
+        <CoverageBar label="Secret Scanning" value={metrics.secretScanningCoverage} />
+        <CoverageBar label="Code Scanning" value={metrics.codeScanningCoverage} />
+        <CoverageBar label="Dependabot" value={metrics.dependabotCoverage} />
+      </div>
+    </div>
+  );
+}
+
+function CoverageBar({ label, value }: { label: string; value: number }) {
+  const barColor = value >= 80 ? 'var(--success)' : value >= 50 ? 'var(--attention)' : 'var(--danger)';
+  return (
+    <div className={styles.coverageItem}>
+      <div className={styles.coverageHeader}>
+        <span className={styles.coverageLabel}>{label}</span>
+        <span className={styles.coverageValue}>{value}%</span>
+      </div>
+      <div className={styles.coverageTrack}>
+        <div
+          className={styles.coverageFill}
+          style={{ width: `${value}%`, background: barColor }}
+        />
+      </div>
+    </div>
+  );
+}
+
+/* ── Organization Multi-Select Filter ──────────────────────────────── */
+
+function OrgMultiSelect({
+  orgs,
+  selected,
+  setSelected,
+}: {
+  orgs: OrgPosture[];
+  selected: string[];
+  setSelected: (v: string[]) => void;
+}) {
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const options = Array.from(e.target.selectedOptions).map((opt) => opt.value);
+    setSelected(options);
+  };
+
+  return (
+    <select
+      multiple
+      value={selected}
+      onChange={handleChange}
+      title="Filter by organization (hold Ctrl/Cmd to select multiple)"
+      className={styles.orgMultiSelect}
+    >
+      {orgs.map((o) => (
+        <option key={o.org_login} value={o.org_login}>
+          {o.org_login}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 /* ── Enterprise View ───────────────────────────────────────────────── */
 
 function EnterpriseView({
@@ -201,11 +409,40 @@ function EnterpriseView({
   const navigate = useNavigate();
   const [severity, setSeverity] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
-  const orgs = data.orgs ?? [];
+  const [selectedOrgs, setSelectedOrgs] = useState<string[]>([]);
+  const orgs = useMemo(() => data.orgs ?? [], [data.orgs]);
+
+  const metrics = useMemo(() => computeMetrics(orgs), [orgs]);
+
+  // Empty state
+  if (orgs.length === 0) {
+    return (
+      <>
+        <div className={styles.header}>
+          <ScoreGauge score={data.score} label="Score" />
+          <div className={styles.headerInfo}>
+            <div className={styles.headerTitle}>Enterprise Security Posture</div>
+            <div className={styles.headerSub}>
+              {data.total} org{data.total !== 1 ? 's' : ''} · Last synced{' '}
+              {formatDateOnly(data.last_sync_at)}
+            </div>
+          </div>
+        </div>
+        <div className={styles.content}>
+          <EmptyState
+            icon="🛡️"
+            title="No posture data available yet"
+            description="Security posture data will appear here once your organizations have been synced."
+          />
+        </div>
+      </>
+    );
+  }
 
   const filteredOrgs = orgs.filter((o) => {
     if (statusFilter === 'fail' && o.score >= 80) return false;
     if (statusFilter === 'pass' && o.score < 80) return false;
+    if (selectedOrgs.length > 0 && !selectedOrgs.includes(o.org_login)) return false;
     return true;
   });
 
@@ -222,6 +459,20 @@ function EnterpriseView({
         </div>
       </div>
       <div className={styles.content}>
+        {/* Metrics Summary Bar */}
+        <MetricsSummary metrics={metrics} />
+
+        {/* Severity Distribution + Coverage Gauges */}
+        <div className={styles.chartsRow}>
+          <div className={styles.chartPanel}>
+            <SeverityDistributionChart metrics={metrics} />
+          </div>
+          <div className={styles.chartPanel}>
+            <CoverageGauges metrics={metrics} />
+          </div>
+        </div>
+
+        {/* Filters */}
         <div className={styles.filters}>
           <input
             type="text"
@@ -239,6 +490,7 @@ function EnterpriseView({
               width: 220,
             }}
           />
+          <OrgMultiSelect orgs={orgs} selected={selectedOrgs} setSelected={setSelectedOrgs} />
         </div>
         <Filters
           severity={severity}
@@ -246,6 +498,8 @@ function EnterpriseView({
           statusFilter={statusFilter}
           setStatusFilter={setStatusFilter}
         />
+
+        {/* Org grid */}
         <div className={styles.orgGrid}>
           {filteredOrgs.map((org) => (
             <div


### PR DESCRIPTION
## Summary

Redesigns the Security Posture page to show aggregate overview first, with drill-down second.

### Changes
- **Metrics summary bar** — Total open alerts, critical/high counts, secret/code scanning coverage %
- **Severity distribution donut chart** — Visual breakdown of failing checks by severity (ECharts)
- **Coverage gauges** — Progress bars for Secret Scanning, Code Scanning, Dependabot enablement
- **Org multi-select filter** — Filter the org grid by selected organizations
- **Layout restructure** — Metrics → Charts → Filters → Org Grid → Top Findings
- **Empty state** — Reassuring message when no posture data exists

### Technical
- All computation is client-side from existing API response (no backend changes)
- 19 new tests added (1248 total passing)
- TypeScript and ESLint clean

Closes #117