### PR TITLE
feat: Clickable metric chips with trend indicators (#123)

### DIFF
--- a/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.module.css
+++ b/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.module.css
@@ -114,7 +114,9 @@
   border-right: 1px solid var(--border);
   color: var(--fg-muted);
   cursor: pointer;
-  transition: background 0.15s, color 0.15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .periodBtn:last-child {

--- a/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.module.css
+++ b/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.module.css
@@ -85,10 +85,55 @@
   margin-bottom: 20px;
 }
 
+.trendHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
 .trendTitle {
   font-size: 13px;
   font-weight: 600;
-  margin-bottom: 12px;
+}
+
+.periodToggle {
+  display: flex;
+  gap: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.periodBtn {
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg-card);
+  border: none;
+  border-right: 1px solid var(--border);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.periodBtn:last-child {
+  border-right: none;
+}
+
+.periodBtn:hover {
+  background: var(--bg-hover);
+  color: var(--fg);
+}
+
+.periodBtnActive {
+  background: var(--accent);
+  color: #fff;
+}
+
+.periodBtnActive:hover {
+  background: var(--accent);
+  color: #fff;
 }
 
 .trendChart {
@@ -205,4 +250,21 @@
   justify-content: center;
   align-items: center;
   padding: 48px 16px;
+}
+
+/* ── Card with sparkline wrapper ── */
+.cardWithSparkline {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.cardWithSparkline > :first-child {
+  flex: 1;
+}
+
+/* ── Mini sparkline ── */
+.miniSparkline {
+  display: block;
+  margin: 0 auto;
 }

--- a/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.test.tsx
+++ b/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.test.tsx
@@ -1,0 +1,376 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { AdvancedSecurityPage } from './index';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+function makeTrend30d() {
+  return Array.from({ length: 30 }, (_, i) => ({
+    day: `2024-01-${String(i + 1).padStart(2, '0')}`,
+    secret_scanning: 5 + (i % 3),
+    code_scanning: 10 + (i % 5),
+    dependabot: 3 + (i % 4),
+  }));
+}
+
+const mockUnifiedSecurity = {
+  secret_scanning: { open: 5, resolved: 20, total: 25, bypassed_open: 1 },
+  code_scanning: { open: 12, critical: 2, high: 4, medium: 3, low: 3, total: 50 },
+  dependabot: {
+    open: 8,
+    critical: 1,
+    high: 3,
+    medium: 2,
+    low: 2,
+    total: 40,
+    critical_aging_gt_90d: 0,
+  },
+  detections: { active: 3, critical: 1, high: 1, medium: 1, low: 0 },
+  trend_30d: makeTrend30d(),
+};
+
+const mockSecretScanning = {
+  unresolved_total: 5,
+  publicly_leaked: 1,
+  push_protection_bypassed_count: 2,
+  mttr_hours: 48.5,
+  resolution_rate_pct: 80.0,
+};
+
+const mockSecretScanningAlerts = {
+  alerts: [
+    {
+      id: 1,
+      repo_full_name: 'org/repo',
+      secret_type: 'github_token',
+      secret_type_display: 'GitHub Token',
+      state: 'open',
+      push_protection_bypassed: false,
+      push_protection_bypassed_by: null,
+      file_path: 'src/config.ts',
+      commit_sha: 'abc123',
+      created_at: '2024-01-15T00:00:00Z',
+      resolved_at: null,
+      resolution: null,
+    },
+  ],
+  total: 1,
+};
+
+const mockCodeScanning = {
+  open_count: 12,
+  critical_count: 2,
+  high_count: 4,
+  avg_hours_to_close: 72,
+  fixed_count: 30,
+};
+
+const mockCodeScanningAlerts = {
+  alerts: [
+    {
+      id: 1,
+      repo_full_name: 'org/repo',
+      rule_id: 'js/sql-injection',
+      rule_description: 'SQL injection',
+      severity: 'high',
+      security_severity: 'high',
+      tool_name: 'CodeQL',
+      file_path: 'src/db.ts',
+      start_line: 42,
+      state: 'open',
+      dismissed_by: null,
+      dismissed_reason: null,
+      cwe_ids: ['CWE-89'],
+      created_at: '2024-01-10T00:00:00Z',
+      fixed_at: null,
+    },
+  ],
+  total: 1,
+};
+
+const mockVulnerabilities = {
+  total_open: 8,
+  critical_open: 1,
+  high_open: 3,
+  avg_open_days: 45,
+  critical_aging_gt_90d: 0,
+};
+
+const mockDependabotAlerts = {
+  alerts: [
+    {
+      id: 1,
+      repo_full_name: 'org/repo',
+      package_name: 'lodash',
+      package_ecosystem: 'npm',
+      severity: 'critical',
+      cvss_score: 9.8,
+      cve_id: 'CVE-2021-12345',
+      cwe_ids: ['CWE-400'],
+      vulnerable_version_range: '<4.17.21',
+      patched_version: '4.17.21',
+      state: 'open',
+      dismissed_by: null,
+      dismissed_reason: null,
+      created_at: '2024-01-05T00:00:00Z',
+      fixed_at: null,
+    },
+  ],
+  total: 1,
+};
+
+const mockDetections = {
+  items: [
+    {
+      id: 'det-1',
+      title: 'Secret scanning bypass detected',
+      rule_name: 'ghas-secret-bypass',
+      severity: 'high',
+      actor: 'user1',
+      org: 'myorg',
+      triggered_at: '2024-01-20T00:00:00Z',
+    },
+  ],
+  total: 1,
+  page: 1,
+  page_size: 50,
+};
+
+vi.mock('../../api/healthSignals', () => ({
+  getUnifiedSecurity: vi.fn().mockImplementation(() => Promise.resolve(mockUnifiedSecurity)),
+  getSecretScanningAlerts: vi.fn().mockImplementation(() => Promise.resolve(mockSecretScanningAlerts)),
+  getSecretScanning: vi.fn().mockImplementation(() => Promise.resolve(mockSecretScanning)),
+  getCodeScanningAlerts: vi.fn().mockImplementation(() => Promise.resolve(mockCodeScanningAlerts)),
+  getCodeScanning: vi.fn().mockImplementation(() => Promise.resolve(mockCodeScanning)),
+  getDependabotAlerts: vi.fn().mockImplementation(() => Promise.resolve(mockDependabotAlerts)),
+  getVulnerabilities: vi.fn().mockImplementation(() => Promise.resolve(mockVulnerabilities)),
+}));
+
+vi.mock('../../api/detections', () => ({
+  listDetections: vi.fn().mockImplementation(() => Promise.resolve(mockDetections)),
+}));
+
+describe('AdvancedSecurityPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders overview tab with metric cards', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      // "Alert Trend" only appears after data loads
+      expect(screen.getByText('Alert Trend')).toBeInTheDocument();
+    });
+
+    // Tab labels + card labels both show "Secret Scanning", etc.
+    expect(screen.getAllByText('Secret Scanning').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('Code Scanning').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('Dependabot').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('Threat Detections')).toBeInTheDocument();
+  });
+
+  it('overview cards have onClick handlers that switch tabs', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alert Trend')).toBeInTheDocument();
+    });
+
+    // Cards are within the cardGrid and have role="button"
+    // The tab buttons don't have aria-label so we can distinguish them
+    const allButtons = screen.getAllByRole('button');
+    const cardButtons = allButtons.filter(
+      (btn) => btn.getAttribute('aria-label') !== null,
+    );
+
+    // Overview tab should have 4 clickable metric cards
+    const secretCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Secret Scanning');
+    const codeCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Code Scanning');
+    const depCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Dependabot');
+    const threatCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Threat Detections');
+
+    expect(secretCard).toBeInTheDocument();
+    expect(codeCard).toBeInTheDocument();
+    expect(depCard).toBeInTheDocument();
+    expect(threatCard).toBeInTheDocument();
+  });
+
+  it('clicking Threat Detections card navigates to /threats', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alert Trend')).toBeInTheDocument();
+    });
+
+    const allButtons = screen.getAllByRole('button');
+    const threatCard = allButtons.find((b) => b.getAttribute('aria-label') === 'Threat Detections');
+    fireEvent.click(threatCard!);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/threats');
+  });
+
+  it('renders trend delta indicators on overview cards', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alert Trend')).toBeInTheDocument();
+    });
+
+    // With our mock data of 30 days, week-over-week deltas should be computed
+    const deltaElements = document.querySelectorAll('[class*="delta"]');
+    expect(deltaElements.length).toBeGreaterThan(0);
+  });
+
+  it('renders period toggle on trend chart', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alert Trend')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('14d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+  });
+
+  it('period toggle buttons update chart', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      expect(screen.getByText('7d')).toBeInTheDocument();
+    });
+
+    const btn7d = screen.getByText('7d');
+    fireEvent.click(btn7d);
+    expect(btn7d).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('renders mini sparklines on overview cards', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=overview' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Alert Trend')).toBeInTheDocument();
+    });
+
+    // Sparklines are SVGs with aria-hidden
+    const sparklines = document.querySelectorAll('svg[aria-hidden="true"]');
+    // At least 3 sparklines (secret, code, dependabot)
+    expect(sparklines.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('secret scanning tab cards are clickable and filter table', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=secrets' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Alerts')).toBeInTheDocument();
+    });
+
+    const openCard = screen.getByRole('button', { name: 'Open Alerts' });
+    expect(openCard).toBeInTheDocument();
+
+    const leakedCard = screen.getByRole('button', { name: 'Publicly Leaked' });
+    expect(leakedCard).toBeInTheDocument();
+
+    const bypassCard = screen.getByRole('button', { name: 'Push Protection Bypassed' });
+    expect(bypassCard).toBeInTheDocument();
+
+    const resolutionCard = screen.getByRole('button', { name: 'Resolution Rate' });
+    expect(resolutionCard).toBeInTheDocument();
+  });
+
+  it('code scanning tab cards are clickable', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=code' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+    });
+
+    const criticalCard = screen.getByRole('button', { name: 'Critical' });
+    expect(criticalCard).toBeInTheDocument();
+
+    const highCard = screen.getByRole('button', { name: 'High' });
+    expect(highCard).toBeInTheDocument();
+
+    const openCard = screen.getByRole('button', { name: 'Open Alerts' });
+    expect(openCard).toBeInTheDocument();
+
+    const fixedCard = screen.getByRole('button', { name: 'Fixed' });
+    expect(fixedCard).toBeInTheDocument();
+  });
+
+  it('dependabot tab cards are clickable', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=dependabot' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Open')).toBeInTheDocument();
+    });
+
+    const totalOpenCard = screen.getByRole('button', { name: 'Total Open' });
+    expect(totalOpenCard).toBeInTheDocument();
+
+    const criticalCard = screen.getByRole('button', { name: 'Critical Open' });
+    expect(criticalCard).toBeInTheDocument();
+
+    const highCard = screen.getByRole('button', { name: 'High Open' });
+    expect(highCard).toBeInTheDocument();
+
+    const aging = screen.getByRole('button', { name: 'Critical >90d' });
+    expect(aging).toBeInTheDocument();
+  });
+
+  it('clicking code scanning Critical card sets severity filter', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=code' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Critical')).toBeInTheDocument();
+    });
+
+    const criticalCard = screen.getByRole('button', { name: 'Critical' });
+    fireEvent.click(criticalCard);
+
+    // The severity filter select should now show "critical"
+    await waitFor(() => {
+      const sevSelect = screen.getAllByRole('combobox')[1]; // second select = severity
+      expect(sevSelect).toHaveValue('critical');
+    });
+  });
+
+  it('clicking dependabot High Open card sets severity filter', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=dependabot' });
+
+    await waitFor(() => {
+      expect(screen.getByText('High Open')).toBeInTheDocument();
+    });
+
+    const highCard = screen.getByRole('button', { name: 'High Open' });
+    fireEvent.click(highCard);
+
+    await waitFor(() => {
+      const sevSelect = screen.getAllByRole('combobox')[1];
+      expect(sevSelect).toHaveValue('high');
+    });
+  });
+
+  it('clicking secret scanning Open Alerts card sets state filter', async () => {
+    renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=secrets' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Open Alerts')).toBeInTheDocument();
+    });
+
+    const openCard = screen.getByRole('button', { name: 'Open Alerts' });
+    fireEvent.click(openCard);
+
+    await waitFor(() => {
+      const stateSelect = screen.getByRole('combobox');
+      expect(stateSelect).toHaveValue('open');
+    });
+  });
+});

--- a/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.test.tsx
+++ b/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.test.tsx
@@ -144,7 +144,9 @@ const mockDetections = {
 
 vi.mock('../../api/healthSignals', () => ({
   getUnifiedSecurity: vi.fn().mockImplementation(() => Promise.resolve(mockUnifiedSecurity)),
-  getSecretScanningAlerts: vi.fn().mockImplementation(() => Promise.resolve(mockSecretScanningAlerts)),
+  getSecretScanningAlerts: vi
+    .fn()
+    .mockImplementation(() => Promise.resolve(mockSecretScanningAlerts)),
   getSecretScanning: vi.fn().mockImplementation(() => Promise.resolve(mockSecretScanning)),
   getCodeScanningAlerts: vi.fn().mockImplementation(() => Promise.resolve(mockCodeScanningAlerts)),
   getCodeScanning: vi.fn().mockImplementation(() => Promise.resolve(mockCodeScanning)),
@@ -186,15 +188,15 @@ describe('AdvancedSecurityPage', () => {
     // Cards are within the cardGrid and have role="button"
     // The tab buttons don't have aria-label so we can distinguish them
     const allButtons = screen.getAllByRole('button');
-    const cardButtons = allButtons.filter(
-      (btn) => btn.getAttribute('aria-label') !== null,
-    );
+    const cardButtons = allButtons.filter((btn) => btn.getAttribute('aria-label') !== null);
 
     // Overview tab should have 4 clickable metric cards
     const secretCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Secret Scanning');
     const codeCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Code Scanning');
     const depCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Dependabot');
-    const threatCard = cardButtons.find((b) => b.getAttribute('aria-label') === 'Threat Detections');
+    const threatCard = cardButtons.find(
+      (b) => b.getAttribute('aria-label') === 'Threat Detections',
+    );
 
     expect(secretCard).toBeInTheDocument();
     expect(codeCard).toBeInTheDocument();

--- a/frontend/src/pages/AdvancedSecurity/index.tsx
+++ b/frontend/src/pages/AdvancedSecurity/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef, useCallback } from 'react';
 import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { MetricCard } from '../../components/primitives/MetricCard';
@@ -54,13 +54,61 @@ function stateVariant(state: string) {
   return 'muted' as const;
 }
 
+/* ── Mini Sparkline (60×20 inline SVG) ── */
+function MiniSparkline({ data, color }: { data: number[]; color: string }) {
+  if (data.length < 2) return null;
+  const w = 60;
+  const h = 20;
+  const maxVal = Math.max(1, ...data);
+  const points = data
+    .map((v, i) => {
+      const x = (i / (data.length - 1)) * w;
+      const y = h - (v / maxVal) * h;
+      return `${x},${y}`;
+    })
+    .join(' ');
+
+  return (
+    <svg
+      className={styles.miniSparkline}
+      width={w}
+      height={h}
+      viewBox={`0 0 ${w} ${h}`}
+      aria-hidden="true"
+    >
+      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" />
+    </svg>
+  );
+}
+
+/* ── Compute week-over-week delta ── */
+function computeWoWDelta(values: number[]): { delta: string; deltaDir: 'up' | 'down' | 'neutral' } {
+  if (values.length < 14) return { delta: '', deltaDir: 'neutral' };
+  const recent7 = values.slice(-7).reduce((a, b) => a + b, 0);
+  const prev7 = values.slice(-14, -7).reduce((a, b) => a + b, 0);
+  const diff = recent7 - prev7;
+  if (diff === 0) return { delta: '0', deltaDir: 'neutral' };
+  const sign = diff > 0 ? '+' : '';
+  // For security alerts: up = bad (more alerts), down = good (fewer alerts)
+  const dir: 'up' | 'down' = diff > 0 ? 'up' : 'down';
+  return { delta: `${sign}${diff}`, deltaDir: dir };
+}
+
+/* ── Period selector type ── */
+type TrendPeriod = '7d' | '14d' | '30d';
+
 /* ── Trend SVG polyline chart ── */
 function TrendChart({
   data,
 }: {
   data: { day: string; secret_scanning: number; code_scanning: number; dependabot: number }[];
 }) {
+  const [period, setPeriod] = useState<TrendPeriod>('30d');
+
   if (data.length === 0) return null;
+
+  const periodDays = period === '7d' ? 7 : period === '14d' ? 14 : 30;
+  const slicedData = data.slice(-periodDays);
 
   const width = 800;
   const height = 120;
@@ -70,13 +118,13 @@ function TrendChart({
 
   const maxVal = Math.max(
     1,
-    ...data.map((d) => Math.max(d.secret_scanning, d.code_scanning, d.dependabot)),
+    ...slicedData.map((d) => Math.max(d.secret_scanning, d.code_scanning, d.dependabot)),
   );
 
-  function toPoints(accessor: (d: (typeof data)[0]) => number): string {
-    return data
+  function toPoints(accessor: (d: (typeof slicedData)[0]) => number): string {
+    return slicedData
       .map((d, i) => {
-        const x = pad.left + (i / Math.max(1, data.length - 1)) * chartW;
+        const x = pad.left + (i / Math.max(1, slicedData.length - 1)) * chartW;
         const y = pad.top + chartH - (accessor(d) / maxVal) * chartH;
         return `${x},${y}`;
       })
@@ -85,7 +133,21 @@ function TrendChart({
 
   return (
     <div className={styles.trendSection}>
-      <div className={styles.trendTitle}>30-Day Alert Trend</div>
+      <div className={styles.trendHeader}>
+        <div className={styles.trendTitle}>Alert Trend</div>
+        <div className={styles.periodToggle} role="group" aria-label="Trend period">
+          {(['7d', '14d', '30d'] as const).map((p) => (
+            <button
+              key={p}
+              className={`${styles.periodBtn} ${period === p ? styles.periodBtnActive : ''}`}
+              onClick={() => setPeriod(p)}
+              aria-pressed={period === p}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+      </div>
       <svg
         className={styles.trendChart}
         viewBox={`0 0 ${width} ${height}`}
@@ -129,7 +191,8 @@ function TrendChart({
 }
 
 /* ── Overview Tab ── */
-function OverviewTab() {
+function OverviewTab({ onSwitchTab }: { onSwitchTab: (tab: TabKey) => void }) {
+  const navigate = useNavigate();
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['unified-security'],
     queryFn: getUnifiedSecurity,
@@ -155,29 +218,62 @@ function OverviewTab() {
   const totalMedium = data.code_scanning.medium + data.dependabot.medium + data.detections.medium;
   const totalLow = data.code_scanning.low + data.dependabot.low + data.detections.low;
 
+  // Compute week-over-week deltas from trend_30d
+  const secretTrend = data.trend_30d.map((d) => d.secret_scanning);
+  const codeTrend = data.trend_30d.map((d) => d.code_scanning);
+  const dependabotTrend = data.trend_30d.map((d) => d.dependabot);
+
+  const secretDelta = computeWoWDelta(secretTrend);
+  const codeDelta = computeWoWDelta(codeTrend);
+  const dependabotDelta = computeWoWDelta(dependabotTrend);
+
+  // Last 7 data points for sparklines
+  const secretSparkData = secretTrend.slice(-7);
+  const codeSparkData = codeTrend.slice(-7);
+  const dependabotSparkData = dependabotTrend.slice(-7);
+
   return (
     <>
       <div className={styles.cardGrid}>
-        <MetricCard
-          value={String(data.secret_scanning.open)}
-          label="Secret Scanning"
-          helpText="Open secret scanning alerts across all repos"
-        />
-        <MetricCard
-          value={String(data.code_scanning.open)}
-          label="Code Scanning"
-          helpText="Open code scanning alerts across all repos"
-        />
-        <MetricCard
-          value={String(data.dependabot.open)}
-          label="Dependabot"
-          helpText="Open Dependabot vulnerability alerts"
-        />
+        <div className={styles.cardWithSparkline}>
+          <MetricCard
+            value={String(data.secret_scanning.open)}
+            label="Secret Scanning"
+            helpText="Open secret scanning alerts across all repos"
+            onClick={() => onSwitchTab('secrets')}
+            delta={secretDelta.delta || undefined}
+            deltaDir={secretDelta.deltaDir}
+          />
+          <MiniSparkline data={secretSparkData} color="#f59e0b" />
+        </div>
+        <div className={styles.cardWithSparkline}>
+          <MetricCard
+            value={String(data.code_scanning.open)}
+            label="Code Scanning"
+            helpText="Open code scanning alerts across all repos"
+            onClick={() => onSwitchTab('code')}
+            delta={codeDelta.delta || undefined}
+            deltaDir={codeDelta.deltaDir}
+          />
+          <MiniSparkline data={codeSparkData} color="#8b5cf6" />
+        </div>
+        <div className={styles.cardWithSparkline}>
+          <MetricCard
+            value={String(data.dependabot.open)}
+            label="Dependabot"
+            helpText="Open Dependabot vulnerability alerts"
+            onClick={() => onSwitchTab('dependabot')}
+            delta={dependabotDelta.delta || undefined}
+            deltaDir={dependabotDelta.deltaDir}
+          />
+          <MiniSparkline data={dependabotSparkData} color="#ef4444" />
+        </div>
         <MetricCard
           value={String(data.detections.active)}
           label="Threat Detections"
           helpText="Active GHAS-related threat detections"
           accent
+          onClick={() => navigate('/threats')}
         />
       </div>
 
@@ -213,6 +309,11 @@ function SecretScanningTab() {
   const [page, setPage] = useState(1);
   const [stateFilter, setStateFilter] = useState('');
   const [selected, setSelected] = useState<SecretScanningAlertItem | null>(null);
+  const tableRef = useRef<HTMLDivElement>(null);
+
+  const scrollToTable = useCallback(() => {
+    setTimeout(() => tableRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+  }, []);
 
   const offset = (page - 1) * PAGE_SIZE;
 
@@ -315,17 +416,32 @@ function SecretScanningTab() {
               value={String(summary.unresolved_total)}
               label="Open Alerts"
               helpText="Total unresolved secret scanning alerts"
+              onClick={() => {
+                setStateFilter('open');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(summary.publicly_leaked)}
               label="Publicly Leaked"
               helpText="Secrets detected in publicly accessible locations"
               accent
+              onClick={() => {
+                setStateFilter('open');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(summary.push_protection_bypassed_count)}
               label="Push Protection Bypassed"
               helpText="Alerts where push protection was explicitly bypassed"
+              onClick={() => {
+                setStateFilter('open');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(Math.round(summary.mttr_hours))}
@@ -336,6 +452,11 @@ function SecretScanningTab() {
               value={`${summary.resolution_rate_pct.toFixed(1)}%`}
               label="Resolution Rate"
               helpText="Percentage of total alerts that have been resolved"
+              onClick={() => {
+                setStateFilter('resolved');
+                setPage(1);
+                scrollToTable();
+              }}
             />
           </>
         ) : null}
@@ -368,7 +489,7 @@ function SecretScanningTab() {
         />
       )}
       {alertsData && (
-        <div className={styles.tableSection}>
+        <div className={styles.tableSection} ref={tableRef}>
           <DataTable
             columns={columns}
             data={alertsData.alerts}
@@ -459,6 +580,11 @@ function CodeScanningTab() {
   const [stateFilter, setStateFilter] = useState('');
   const [sevFilter, setSevFilter] = useState('');
   const [selected, setSelected] = useState<CodeScanningAlertItem | null>(null);
+  const tableRef = useRef<HTMLDivElement>(null);
+
+  const scrollToTable = useCallback(() => {
+    setTimeout(() => tableRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+  }, []);
 
   const offset = (page - 1) * PAGE_SIZE;
 
@@ -572,17 +698,35 @@ function CodeScanningTab() {
               value={String(summary.open_count)}
               label="Open Alerts"
               helpText="Total open code scanning alerts"
+              onClick={() => {
+                setStateFilter('open');
+                setSevFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(summary.critical_count)}
               label="Critical"
               helpText="Critical severity open alerts"
               accent
+              onClick={() => {
+                setSevFilter('critical');
+                setStateFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(summary.high_count)}
               label="High"
               helpText="High severity open alerts"
+              onClick={() => {
+                setSevFilter('high');
+                setStateFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(Math.round(summary.avg_hours_to_close))}
@@ -593,6 +737,12 @@ function CodeScanningTab() {
               value={String(summary.fixed_count)}
               label="Fixed"
               helpText="Total code scanning alerts that have been fixed"
+              onClick={() => {
+                setStateFilter('fixed');
+                setSevFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
           </>
         ) : null}
@@ -637,7 +787,7 @@ function CodeScanningTab() {
         <ErrorBanner message="Failed to load code scanning alerts" onRetry={() => void refetch()} />
       )}
       {alertsData && (
-        <div className={styles.tableSection}>
+        <div className={styles.tableSection} ref={tableRef}>
           <DataTable
             columns={columns}
             data={alertsData.alerts}
@@ -735,6 +885,11 @@ function DependabotTab() {
   const [stateFilter, setStateFilter] = useState('');
   const [sevFilter, setSevFilter] = useState('');
   const [selected, setSelected] = useState<DependabotAlertItem | null>(null);
+  const tableRef = useRef<HTMLDivElement>(null);
+
+  const scrollToTable = useCallback(() => {
+    setTimeout(() => tableRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+  }, []);
 
   const offset = (page - 1) * PAGE_SIZE;
 
@@ -854,17 +1009,35 @@ function DependabotTab() {
               value={String(summary.total_open)}
               label="Total Open"
               helpText="Total open Dependabot alerts"
+              onClick={() => {
+                setStateFilter('open');
+                setSevFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(summary.critical_open)}
               label="Critical Open"
               helpText="Critical severity open vulnerability alerts"
               accent
+              onClick={() => {
+                setSevFilter('critical');
+                setStateFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(summary.high_open)}
               label="High Open"
               helpText="High severity open vulnerability alerts"
+              onClick={() => {
+                setSevFilter('high');
+                setStateFilter('');
+                setPage(1);
+                scrollToTable();
+              }}
             />
             <MetricCard
               value={String(Math.round(summary.avg_open_days))}
@@ -876,6 +1049,12 @@ function DependabotTab() {
               label="Critical >90d"
               helpText="Critical alerts that have been open for more than 90 days"
               accent
+              onClick={() => {
+                setSevFilter('critical');
+                setStateFilter('open');
+                setPage(1);
+                scrollToTable();
+              }}
             />
           </>
         ) : null}
@@ -920,7 +1099,7 @@ function DependabotTab() {
         <ErrorBanner message="Failed to load Dependabot alerts" onRetry={() => void refetch()} />
       )}
       {alertsData && (
-        <div className={styles.tableSection}>
+        <div className={styles.tableSection} ref={tableRef}>
           <DataTable
             columns={columns}
             data={alertsData.alerts}
@@ -1166,7 +1345,7 @@ export function AdvancedSecurityPage() {
           ))}
         </div>
 
-        {activeTab === 'overview' && <OverviewTab />}
+        {activeTab === 'overview' && <OverviewTab onSwitchTab={setTab} />}
         {activeTab === 'secrets' && <SecretScanningTab />}
         {activeTab === 'code' && <CodeScanningTab />}
         {activeTab === 'dependabot' && <DependabotTab />}


### PR DESCRIPTION
## Summary

Closes #123 — Advanced Security metrics are now interactive with trend context.

### Changes
- **Clickable MetricCards**: Overview tab cards switch tabs; per-tab cards scroll to table and apply filter (state/severity)
- **Week-over-week deltas**: Each Overview metric shows change vs prior 7 days (↑ red = more alerts, ↓ green = fewer)
- **Mini sparklines**: 7-day inline SVG trend below each Overview metric
- **Period selector**: Toggle TrendChart between 7d/14d/30d views

### Testing
- 13 new tests covering click behavior, filtering, sparkline rendering, period toggle
- 1244 total tests passing, tsc/lint clean