### PR TITLE
feat: Split Workflows into Security + Health pages, dedup from Velocity (#122, #125)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { SettingsPage } from './pages/Settings';
 import { ActorsPage } from './pages/Actors';
 import { CrossOrgPage } from './pages/CrossOrg';
 import { WorkflowsPage } from './pages/Workflows';
+import { WorkflowHealthPage } from './pages/WorkflowHealth';
 import { AdvancedSecurityPage } from './pages/AdvancedSecurity';
 import AuthSettingsPage from './pages/admin/AuthSettings';
 
@@ -51,6 +52,7 @@ export const router = createBrowserRouter([
       { path: '/events', element: <EventsPage /> },
       { path: '/crossorg', element: <CrossOrgPage /> },
       { path: '/workflows', element: <WorkflowsPage /> },
+      { path: '/workflows/health', element: <WorkflowHealthPage /> },
       { path: '/advanced-security', element: <AdvancedSecurityPage /> },
       { path: '/velocity', element: <VelocityPage /> },
       { path: '/devactivity', element: <DevActivityPage /> },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -219,7 +219,14 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
             icon={
               <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
                 <path d="M8 16A8 8 0 108 0a8 8 0 000 16zm0-1.5a6.5 6.5 0 110-13 6.5 6.5 0 010 13z" />
-                <path d="M2.5 8h2.3l1.2-3 2 6 1.2-3h4.3" stroke="currentColor" strokeWidth="1.2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+                <path
+                  d="M2.5 8h2.3l1.2-3 2 6 1.2-3h4.3"
+                  stroke="currentColor"
+                  strokeWidth="1.2"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
               </svg>
             }
           >

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -214,6 +214,20 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
         )}
         {hasPermission('detections', 'view') && (
           <NavItem
+            to="/workflows/health"
+            onClick={handleNavClick}
+            icon={
+              <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M8 16A8 8 0 108 0a8 8 0 000 16zm0-1.5a6.5 6.5 0 110-13 6.5 6.5 0 010 13z" />
+                <path d="M2.5 8h2.3l1.2-3 2 6 1.2-3h4.3" stroke="currentColor" strokeWidth="1.2" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            }
+          >
+            Workflow Health
+          </NavItem>
+        )}
+        {hasPermission('detections', 'view') && (
+          <NavItem
             to="/advanced-security"
             onClick={handleNavClick}
             icon={

--- a/frontend/src/pages/Velocity/Velocity.module.css
+++ b/frontend/src/pages/Velocity/Velocity.module.css
@@ -402,3 +402,50 @@
   border-color: rgba(248, 81, 73, 0.4);
   color: var(--danger);
 }
+
+/* ── Workflow Health Callout ── */
+.workflowCallout {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 14px 18px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-card);
+  margin-bottom: 24px;
+}
+
+.calloutIcon {
+  font-size: 18px;
+  line-height: 1;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.calloutContent {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.calloutTitle {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--fg);
+}
+
+.calloutDesc {
+  font-size: 13px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+}
+
+.calloutDesc a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.calloutDesc a:hover {
+  text-decoration: underline;
+}

--- a/frontend/src/pages/Velocity/Velocity.test.tsx
+++ b/frontend/src/pages/Velocity/Velocity.test.tsx
@@ -180,48 +180,14 @@ describe('VelocityPage', () => {
   });
 
   /* ---------------------------------------------------------------- */
-  /*  Top failing workflows table                                       */
+  /*  Workflow Health callout (replaced workflow tables)                 */
   /* ---------------------------------------------------------------- */
 
-  it('renders the top failing workflows section title', () => {
+  it('renders the workflow health callout with link to /workflows/health', () => {
     renderWithProviders(<VelocityPage />);
 
-    expect(screen.getByText('Top failing workflows')).toBeInTheDocument();
-  });
-
-  it('renders the top failing workflows table with correct column headers', () => {
-    renderWithProviders(<VelocityPage />);
-
-    const sectionTitle = screen.getByText('Top failing workflows');
-    const tableWrap = sectionTitle.nextElementSibling;
-    const table = tableWrap?.querySelector('table');
-    expect(table).toBeTruthy();
-    // Get only the first header row (DataTable may add a filter row)
-    const headerRow = table!.querySelector('thead tr');
-    const headers = headerRow!.querySelectorAll('th');
-    const headerTexts = Array.from(headers).map((h) =>
-      h.textContent?.replace(/[⇅↑↓ⓘ]/g, '').trim(),
-    );
-
-    expect(headerTexts).toEqual([
-      'Workflow',
-      'Repository',
-      'Failure rate',
-      'Last run',
-      'Total runs',
-    ]);
-  });
-
-  it('shows empty state when no workflow health data is available', () => {
-    renderWithProviders(<VelocityPage />);
-
-    expect(screen.getByText('No workflow health data available')).toBeInTheDocument();
-  });
-
-  it('does not show sample data banner for top failing workflows', () => {
-    renderWithProviders(<VelocityPage />);
-
-    expect(screen.queryByText(/Top failing workflows display sample data/)).not.toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /Workflow Health/i });
+    expect(link).toHaveAttribute('href', '/workflows/health');
   });
 
   /* ---------------------------------------------------------------- */
@@ -698,53 +664,6 @@ describe('VelocityPage failure row modal', () => {
 /* ------------------------------------------------------------------ */
 /*  Helper function tests                                              */
 /* ------------------------------------------------------------------ */
-
-describe('Workflow health failure rate variants', () => {
-  const MOCK_WORKFLOWS = [
-    {
-      repo: 'acme/api',
-      workflow_name: 'ci.yml',
-      total_runs: 100,
-      successes: 40,
-      failures: 60,
-      failure_rate_pct: 60.0,
-      last_run: '2024-01-15T00:00:00Z',
-    },
-    {
-      repo: 'acme/web',
-      workflow_name: 'deploy.yml',
-      total_runs: 50,
-      successes: 36,
-      failures: 14,
-      failure_rate_pct: 28.0,
-      last_run: '2024-01-14T00:00:00Z',
-    },
-    {
-      repo: 'acme/lib',
-      workflow_name: 'test.yml',
-      total_runs: 80,
-      successes: 68,
-      failures: 12,
-      failure_rate_pct: 15.0,
-      last_run: '2024-01-13T00:00:00Z',
-    },
-  ];
-
-  it('renders workflow health data with failure rate badges', async () => {
-    const { getWorkflowHealth } = await import('../../api/healthSignals');
-    vi.mocked(getWorkflowHealth).mockResolvedValue({ workflows: MOCK_WORKFLOWS });
-    mockGetActionsVolumeReport.mockResolvedValue({ data: [] });
-    mockListEvents.mockResolvedValue({ items: [], total: 0 });
-
-    renderWithProviders(<VelocityPage />);
-
-    // Wait for workflow health data to load — appears in both "Top failing" and "Workflow health" sections
-    const badges60 = await screen.findAllByText('60.0%');
-    expect(badges60.length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('28.0%').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getAllByText('15.0%').length).toBeGreaterThanOrEqual(1);
-  });
-});
 
 describe('Active repos show real event-derived stats', () => {
   const MOCK_EVENTS = [

--- a/frontend/src/pages/Velocity/index.tsx
+++ b/frontend/src/pages/Velocity/index.tsx
@@ -3,14 +3,14 @@ import { useQuery } from '@tanstack/react-query';
 import { useNavigate, Link } from 'react-router-dom';
 import { getActionsVolumeReport } from '../../api/reports';
 import { listEvents } from '../../api/events';
-import { getWorkflowHealth, getBranchProtection } from '../../api/healthSignals';
+import { getBranchProtection } from '../../api/healthSignals';
 import { ContributionCalendar } from '../../components/charts/ContributionCalendar';
 import { LineAreaChart } from '../../components/charts/LineAreaChart';
 import { BarChart } from '../../components/charts/BarChart';
 import { MetricCard } from '../../components/primitives/MetricCard';
 import { Card, CardHeader } from '../../components/primitives/Card';
 import { Label } from '../../components/primitives/Label';
-import { DataTable, type ColumnDef } from '../../components/primitives/DataTable';
+import { DataTable } from '../../components/primitives/DataTable';
 import { Drawer } from '../../components/primitives/Drawer';
 import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
@@ -18,8 +18,7 @@ import { PageHeader } from '../../components/common/PageHeader';
 import { useFeatures } from '../../hooks/useFeatures';
 import type { ActionsVolumeBucket } from '../../types/reports';
 import type { EventResponse } from '../../types/events';
-import type { WorkflowRow } from '../../api/healthSignals';
-import { formatDateOnly, formatBucketDate } from '../../utils/dates';
+import { formatBucketDate } from '../../utils/dates';
 import styles from './Velocity.module.css';
 
 interface CalendarDay {
@@ -103,12 +102,6 @@ function computeRepoStats(events: readonly EventResponse[]): RepoActivityStats[]
     .slice(0, 10);
 }
 
-function getFailureRateVariant(rate: number): 'danger' | 'attention' | 'success' {
-  if (rate > 20) return 'danger';
-  if (rate > 10) return 'attention';
-  return 'success';
-}
-
 interface DoraTier {
   readonly name: 'Elite' | 'High' | 'Medium' | 'Low';
   readonly icon: string;
@@ -145,96 +138,6 @@ function computeDoraTier(deployFreqPerDay: number, cfr: number | null): DoraTier
   if (avg >= 2.5) return { name: 'High', icon: '▲', cssClass: 'doraTierHigh' };
   if (avg >= 1.5) return { name: 'Medium', icon: '◆', cssClass: 'doraTierMedium' };
   return { name: 'Low', icon: '▼', cssClass: 'doraTierLow' };
-}
-
-function WorkflowHealthSection({ workflows }: { workflows: WorkflowRow[] }) {
-  const topFailing = [...workflows]
-    .filter((wf) => wf.failure_rate_pct > 0)
-    .sort((a, b) => b.failure_rate_pct - a.failure_rate_pct)
-    .slice(0, 10);
-
-  const workflowColumns: ColumnDef<WorkflowRow>[] = [
-    {
-      key: 'repo',
-      header: 'Repository',
-      sortable: true,
-      filterable: true,
-      helpText: 'The repository the workflow belongs to',
-      render: (wf) => <>{wf.repo}</>,
-      sortValue: (wf) => wf.repo,
-      filterValue: (wf) => wf.repo,
-    },
-    {
-      key: 'workflow_name',
-      header: 'Workflow',
-      sortable: true,
-      filterable: true,
-      helpText: 'The name of the CI/CD workflow',
-      render: (wf) => <span className={styles.workflowName}>{wf.workflow_name}</span>,
-      sortValue: (wf) => wf.workflow_name,
-      filterValue: (wf) => wf.workflow_name,
-    },
-    {
-      key: 'total_runs',
-      header: 'Total runs',
-      sortable: true,
-      filterable: true,
-      helpText: 'Total number of workflow runs in the period',
-      render: (wf) => <span style={{ fontVariantNumeric: 'tabular-nums' }}>{wf.total_runs}</span>,
-      sortValue: (wf) => wf.total_runs,
-      filterValue: (wf) => String(wf.total_runs),
-    },
-    {
-      key: 'failures',
-      header: 'Failures',
-      sortable: true,
-      filterable: true,
-      helpText: 'Number of failed runs',
-      render: (wf) => <span style={{ fontVariantNumeric: 'tabular-nums' }}>{wf.failures}</span>,
-      sortValue: (wf) => wf.failures,
-      filterValue: (wf) => String(wf.failures),
-    },
-    {
-      key: 'failure_rate_pct',
-      header: 'Failure rate',
-      sortable: true,
-      filterable: true,
-      helpText: 'Percentage of runs that failed',
-      render: (wf) => (
-        <Label variant={getFailureRateVariant(wf.failure_rate_pct)}>
-          {wf.failure_rate_pct.toFixed(1)}%
-        </Label>
-      ),
-      sortValue: (wf) => wf.failure_rate_pct,
-      filterValue: (wf) => `${wf.failure_rate_pct.toFixed(1)}%`,
-    },
-    {
-      key: 'last_run',
-      header: 'Last run',
-      sortable: true,
-      filterable: true,
-      helpText: 'When the workflow last ran',
-      render: (wf) => (
-        <span style={{ color: 'var(--fg-muted)' }}>{formatDateOnly(wf.last_run)}</span>
-      ),
-      sortValue: (wf) => new Date(wf.last_run),
-      filterValue: (wf) => formatDateOnly(wf.last_run),
-    },
-  ];
-
-  return (
-    <div style={{ marginTop: 8 }}>
-      <div className={styles.sectionTitle}>Workflow health — audit log signals</div>
-      <div style={{ marginBottom: 20 }}>
-        <DataTable<WorkflowRow>
-          columns={workflowColumns}
-          data={topFailing}
-          rowKey={(wf) => `${wf.repo}/${wf.workflow_name}`}
-          emptyMessage="No failing workflows detected"
-        />
-      </div>
-    </div>
-  );
 }
 
 interface BranchProtectionProps {
@@ -314,12 +217,6 @@ export function VelocityPage() {
         page_size: 2000,
         sort: 'created_at_desc',
       }),
-  });
-
-  const { data: workflowHealthData } = useQuery({
-    queryKey: ['health', 'workflows-velocity'],
-    queryFn: getWorkflowHealth,
-    staleTime: 60_000,
   });
 
   const { data: branchProtData } = useQuery({
@@ -933,74 +830,15 @@ export function VelocityPage() {
         </div>
       )}
 
-      <div className={styles.sectionTitle}>Top failing workflows</div>
-      <div className={styles.tableWrap} style={{ marginBottom: 20 }}>
-        {(() => {
-          const topFailingWorkflows = [...(workflowHealthData?.workflows ?? [])]
-            .filter((wf) => wf.failure_rate_pct > 0)
-            .sort((a, b) => b.failure_rate_pct - a.failure_rate_pct)
-            .slice(0, 10);
-          return (
-            <DataTable<WorkflowRow>
-              columns={[
-                {
-                  key: 'workflow_name',
-                  header: 'Workflow',
-                  helpText: 'Name of the GitHub Actions workflow. From workflow_run audit events.',
-                  filterable: true,
-                  render: (wf) => <span className={styles.workflowName}>{wf.workflow_name}</span>,
-                  filterValue: (wf) => wf.workflow_name,
-                },
-                {
-                  key: 'repo',
-                  header: 'Repository',
-                  helpText: 'Repository this workflow belongs to. From workflow_run audit events.',
-                  filterable: true,
-                  render: (wf) => <>{wf.repo}</>,
-                  filterValue: (wf) => wf.repo,
-                },
-                {
-                  key: 'failure_rate_pct',
-                  header: 'Failure rate',
-                  helpText:
-                    'Percentage of runs that failed for this workflow. From workflow_run audit events. Investigate consistently failing workflows.',
-                  sortable: true,
-                  render: (wf) => (
-                    <Label variant={getFailureRateVariant(wf.failure_rate_pct)}>
-                      {wf.failure_rate_pct.toFixed(1)}%
-                    </Label>
-                  ),
-                  sortValue: (wf) => wf.failure_rate_pct,
-                },
-                {
-                  key: 'last_run',
-                  header: 'Last run',
-                  helpText:
-                    'Timestamp of the most recent run of this workflow. From workflow_run audit events.',
-                  sortable: true,
-                  render: (wf) => (
-                    <span style={{ color: 'var(--fg-muted)' }}>{formatDateOnly(wf.last_run)}</span>
-                  ),
-                  sortValue: (wf) => wf.last_run,
-                },
-                {
-                  key: 'total_runs',
-                  header: 'Total runs',
-                  helpText:
-                    'Total number of runs recorded for this workflow. From workflow_run audit events.',
-                  sortable: true,
-                  render: (wf) => (
-                    <span style={{ fontVariantNumeric: 'tabular-nums' }}>{wf.total_runs}</span>
-                  ),
-                  sortValue: (wf) => wf.total_runs,
-                },
-              ]}
-              data={topFailingWorkflows}
-              rowKey={(wf) => `${wf.repo}/${wf.workflow_name}`}
-              emptyMessage="No workflow health data available"
-            />
-          );
-        })()}
+      <div className={styles.workflowCallout}>
+        <div className={styles.calloutIcon}>⚡</div>
+        <div className={styles.calloutContent}>
+          <div className={styles.calloutTitle}>Workflow Health</div>
+          <div className={styles.calloutDesc}>
+            Persistent CI/CD failures and timeouts are tracked on the dedicated{' '}
+            <Link to="/workflows/health">Workflow Health</Link> page.
+          </div>
+        </div>
       </div>
 
       <div ref={reposRef} className={styles.sectionTitle}>
@@ -1083,9 +921,6 @@ export function VelocityPage() {
           No workflow run data for the selected period.
         </div>
       )}
-
-      {/* Workflow Health from audit logs */}
-      <WorkflowHealthSection workflows={workflowHealthData?.workflows ?? []} />
 
       {/* Branch Protection Changes */}
       <BranchProtectionSection branchProt={branchProtData} />

--- a/frontend/src/pages/WorkflowHealth/WorkflowHealth.module.css
+++ b/frontend/src/pages/WorkflowHealth/WorkflowHealth.module.css
@@ -1,0 +1,52 @@
+.page {
+  padding: 24px;
+  max-width: 1200px;
+}
+
+.crossLink {
+  font-size: 13px;
+  color: var(--fg-muted);
+  margin-bottom: 16px;
+}
+
+.crossLinkAnchor {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.crossLinkAnchor:hover {
+  text-decoration: underline;
+}
+
+.guidanceBox {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px 20px;
+  margin-bottom: 24px;
+  background: var(--bg-card);
+}
+
+.guidanceTitle {
+  font-weight: 600;
+  font-size: 14px;
+  margin-bottom: 8px;
+  color: var(--fg);
+}
+
+.guidanceList {
+  list-style: disc;
+  padding-left: 20px;
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  margin: 0;
+}
+
+.guidanceList li {
+  margin-bottom: 4px;
+}
+
+.guidanceList strong {
+  color: var(--fg);
+}

--- a/frontend/src/pages/WorkflowHealth/WorkflowHealth.test.tsx
+++ b/frontend/src/pages/WorkflowHealth/WorkflowHealth.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { WorkflowHealthPage } from './index';
+
+vi.mock('../../api/workflowMetrics', () => ({
+  getAlwaysFailingWorkflows: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  getAlwaysTimingOutWorkflows: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+  getWorkflowRunHistory: vi.fn().mockResolvedValue({ runs: [], workflow_path: '' }),
+}));
+
+describe('WorkflowHealthPage', () => {
+  it('renders the page title', async () => {
+    renderWithProviders(<WorkflowHealthPage />);
+    expect(await screen.findByText('Workflow Health')).toBeInTheDocument();
+  });
+
+  it('renders the page description', async () => {
+    renderWithProviders(<WorkflowHealthPage />);
+    expect(
+      await screen.findByText(
+        'Operational health of CI/CD workflows — persistent failures and timeouts',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders cross-link to Workflow Security page', async () => {
+    renderWithProviders(<WorkflowHealthPage />);
+    const link = await screen.findByRole('link', { name: /Workflow Security →/i });
+    expect(link).toHaveAttribute('href', '/workflows');
+  });
+
+  it('renders the guidance box', async () => {
+    renderWithProviders(<WorkflowHealthPage />);
+    expect(await screen.findByText('What this page shows')).toBeInTheDocument();
+  });
+
+  it('renders guidance about operational failures vs security', async () => {
+    renderWithProviders(<WorkflowHealthPage />);
+    expect(await screen.findByText(/operational failures/i)).toBeInTheDocument();
+  });
+
+  it('renders the WorkflowMetricsTab content', async () => {
+    renderWithProviders(<WorkflowHealthPage />);
+    expect(await screen.findByText('Lookback period')).toBeInTheDocument();
+    expect(
+      await screen.findByText('No persistently failing workflows in this period'),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('No persistently timing-out workflows in this period'),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/WorkflowHealth/index.tsx
+++ b/frontend/src/pages/WorkflowHealth/index.tsx
@@ -1,0 +1,46 @@
+import { Link } from 'react-router-dom';
+import { PageHeader } from '../../components/common/PageHeader';
+import { WorkflowMetricsTab } from '../Workflows/WorkflowMetricsTab';
+import styles from './WorkflowHealth.module.css';
+
+export function WorkflowHealthPage() {
+  return (
+    <div className={styles.page}>
+      <PageHeader
+        title="Workflow Health"
+        description="Operational health of CI/CD workflows — persistent failures and timeouts"
+      />
+
+      <div className={styles.crossLink}>
+        Looking for security findings?{' '}
+        <Link to="/workflows" className={styles.crossLinkAnchor}>
+          Workflow Security →
+        </Link>
+      </div>
+
+      <div className={styles.guidanceBox}>
+        <div className={styles.guidanceTitle}>What this page shows</div>
+        <ul className={styles.guidanceList}>
+          <li>
+            <strong>Always Failing</strong> — Workflows that have failed consecutively beyond the
+            configured threshold. These may indicate broken pipelines requiring attention.
+          </li>
+          <li>
+            <strong>Always Timing Out</strong> — Workflows that have timed out consecutively. These
+            may indicate resource constraints or infinite loops.
+          </li>
+          <li>
+            This page is about <strong>operational failures</strong>, not security. For security
+            findings in workflow YAML files, visit{' '}
+            <Link to="/workflows" className={styles.crossLinkAnchor}>
+              Workflow Security
+            </Link>
+            .
+          </li>
+        </ul>
+      </div>
+
+      <WorkflowMetricsTab />
+    </div>
+  );
+}

--- a/frontend/src/pages/Workflows/Workflows.module.css
+++ b/frontend/src/pages/Workflows/Workflows.module.css
@@ -62,6 +62,23 @@
   color: var(--danger, #e53e3e);
 }
 
+/* ── Cross-link ── */
+.crossLink {
+  font-size: 13px;
+  color: var(--fg-muted);
+  margin-bottom: 16px;
+}
+
+.crossLinkAnchor {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.crossLinkAnchor:hover {
+  text-decoration: underline;
+}
+
 /* ── Guidance ── */
 .guidanceBox {
   background: var(--bg-card);

--- a/frontend/src/pages/Workflows/index.tsx
+++ b/frontend/src/pages/Workflows/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import {
   listWorkflowFindings,
   getRepoSecurityScores,
@@ -12,10 +13,9 @@ import { PageHeader } from '../../components/common/PageHeader';
 import { Button } from '../../components/primitives/Button';
 import { Label } from '../../components/primitives/Label';
 import { formatRelativeShort } from '../../utils/dates';
-import { WorkflowMetricsTab } from './WorkflowMetricsTab';
 import styles from './Workflows.module.css';
 
-type Tab = 'findings' | 'scores' | 'metrics';
+type Tab = 'findings' | 'scores';
 
 function sevVariant(sev: string) {
   if (sev === 'critical') return 'danger' as const;
@@ -120,6 +120,13 @@ export function WorkflowsPage() {
           </div>
         </div>
 
+        <div className={styles.crossLink}>
+          Looking for CI/CD failure metrics?{' '}
+          <Link to="/workflows/health" className={styles.crossLinkAnchor}>
+            Workflow Health →
+          </Link>
+        </div>
+
         <div className={styles.guidanceBox}>
           <div className={styles.guidanceTitle}>What this page shows</div>
           <ul className={styles.guidanceList}>
@@ -151,12 +158,6 @@ export function WorkflowsPage() {
             onClick={() => setTab('scores')}
           >
             Repo Scores
-          </button>
-          <button
-            className={`${styles.tab} ${tab === 'metrics' ? styles.tabActive : ''}`}
-            onClick={() => setTab('metrics')}
-          >
-            Failure Metrics
           </button>
         </div>
 
@@ -269,8 +270,6 @@ export function WorkflowsPage() {
             )}
           </>
         )}
-
-        {tab === 'metrics' && <WorkflowMetricsTab />}
       </div>
 
       {/* Detail slide-out panel */}


### PR DESCRIPTION
## Summary

Closes #122, #125 — Separates security findings from operational health and removes duplicate data from Velocity.

### Changes
- **Workflow Security** (`/workflows`): Now purely security-focused — Findings + Repo Scores tabs only
- **Workflow Health** (`/workflows/health`): New dedicated page for persistent CI/CD failures and timeouts
- **Velocity dedup**: Removed duplicate "Top failing workflows" and WorkflowHealthSection tables, replaced with compact callout linking to Workflow Health
- **Navigation**: Added Workflow Health to sidebar, cross-links between pages

### Testing
- 6 new tests for Workflow Health page
- Updated Velocity tests to reflect removed sections
- 1233 total tests passing, tsc/lint clean