### PR TITLE
feat: Event-driven workflow scanner with activity transparency (#121)

### DIFF
--- a/backend/alembic/versions/0048_workflow_scan_activity.py
+++ b/backend/alembic/versions/0048_workflow_scan_activity.py
@@ -1,0 +1,67 @@
+"""Add workflow_scan_activities table.
+
+Revision ID: 0048
+Revises: 0046
+Create Date: 2026-05-10
+
+Records provenance for each workflow security scan execution, tracking
+which events triggered the scan, what checks were performed, and results.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY
+
+from alembic import op
+
+revision = "0048"
+down_revision = "0046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create workflow_scan_activities table."""
+    op.create_table(
+        "workflow_scan_activities",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("trigger_event_ids", ARRAY(sa.Integer), nullable=False, server_default="{}"),
+        sa.Column("org", sa.Text, nullable=False),
+        sa.Column("repo", sa.Text, nullable=False),
+        sa.Column("workflow_path", sa.Text, nullable=False),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("status", sa.Text, nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("checks_performed", ARRAY(sa.Text), nullable=False, server_default="{}"),
+        sa.Column("findings_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("data_sources", ARRAY(sa.Text), nullable=False, server_default="{}"),
+        sa.Column("duration_ms", sa.Integer, nullable=True),
+        sa.Column("error_message", sa.Text, nullable=True),
+    )
+    op.create_index(
+        "ix_wf_scan_activity_org_repo",
+        "workflow_scan_activities",
+        ["org", "repo"],
+    )
+    op.create_index(
+        "ix_wf_scan_activity_started_at",
+        "workflow_scan_activities",
+        ["started_at"],
+    )
+    op.create_index(
+        "ix_wf_scan_activity_status",
+        "workflow_scan_activities",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    """Drop workflow_scan_activities table."""
+    op.drop_index("ix_wf_scan_activity_status", table_name="workflow_scan_activities")
+    op.drop_index("ix_wf_scan_activity_started_at", table_name="workflow_scan_activities")
+    op.drop_index("ix_wf_scan_activity_org_repo", table_name="workflow_scan_activities")
+    op.drop_table("workflow_scan_activities")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -56,6 +56,7 @@ from app.models.team import Team, TeamMembership, TeamRoleAssignment
 from app.models.threat_intel import ThreatIntelDomain, ThreatIntelFeed, ThreatIntelIndicator
 from app.models.user import RbacRole, UserRoleAssignment
 from app.models.workflow_finding import WorkflowFinding
+from app.models.workflow_scan_activity import WorkflowScanActivity
 
 __all__ = [
     "AppSetting",
@@ -122,5 +123,6 @@ __all__ = [
     "TeamRoleAssignment",
     "UserRoleAssignment",
     "WorkflowFinding",
+    "WorkflowScanActivity",
     "SessionPolicySetting",
 ]

--- a/backend/app/models/workflow_scan_activity.py
+++ b/backend/app/models/workflow_scan_activity.py
@@ -1,0 +1,35 @@
+"""SQLAlchemy ORM model for workflow scan activity provenance."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, Text, text
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.audit_event import Base
+
+
+class WorkflowScanActivity(Base):
+    """Records provenance for each workflow security scan execution."""
+
+    __tablename__ = "workflow_scan_activities"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    trigger_event_ids: Mapped[list[int]] = mapped_column(
+        ARRAY(Integer), nullable=False, default=list
+    )
+    org: Mapped[str] = mapped_column(Text, nullable=False)
+    repo: Mapped[str] = mapped_column(Text, nullable=False)
+    workflow_path: Mapped[str] = mapped_column(Text, nullable=False)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'pending'"))
+    checks_performed: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    findings_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    data_sources: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/workflow_scanner.py
+++ b/backend/app/routers/workflow_scanner.py
@@ -1,11 +1,12 @@
 """Workflow security scanner router.
 
 Provides endpoints for scanning GitHub Actions workflow files, listing
-findings, and retrieving suggested remediations.
+findings, retrieving suggested remediations, and viewing scanner activity.
 """
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 import structlog
@@ -16,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import AuthenticatedUser, get_db, require_permission, verify_csrf
 from app.models.workflow_finding import WorkflowFinding
+from app.models.workflow_scan_activity import WorkflowScanActivity
 from app.services.workflow_scanner_service import WorkflowScannerService
 
 logger = structlog.get_logger(__name__)
@@ -276,3 +278,74 @@ async def trigger_repo_scan(
         queue="baseline",
     )
     return {"task_id": result.id, "status": "queued"}
+
+
+# ── Scanner Activity schemas and endpoint ────────────────────────────────────
+
+
+class ScanActivityResponse(BaseModel):
+    """Single scan activity record."""
+
+    id: int
+    trigger_event_ids: list[int]
+    org: str
+    repo: str
+    workflow_path: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    status: str
+    checks_performed: list[str]
+    findings_count: int
+    data_sources: list[str]
+    duration_ms: int | None = None
+
+
+class ScanActivityListResponse(BaseModel):
+    """Paginated list of scan activity records."""
+
+    items: list[ScanActivityResponse]
+    total: int
+
+
+@router.get("/activity", response_model=ScanActivityListResponse)
+async def list_scan_activity(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    current_user: AuthenticatedUser = Depends(require_permission("workflow_scanner", "view")),
+) -> ScanActivityListResponse:
+    """List recent scanner activity with provenance."""
+    offset = (page - 1) * page_size
+
+    count_stmt = select(func.count()).select_from(WorkflowScanActivity)
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    stmt = (
+        select(WorkflowScanActivity)
+        .order_by(WorkflowScanActivity.started_at.desc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    result = await db.execute(stmt)
+    activities = result.scalars().all()
+
+    return ScanActivityListResponse(
+        items=[
+            ScanActivityResponse(
+                id=a.id,
+                trigger_event_ids=a.trigger_event_ids or [],
+                org=a.org,
+                repo=a.repo,
+                workflow_path=a.workflow_path,
+                started_at=a.started_at,
+                completed_at=a.completed_at,
+                status=a.status,
+                checks_performed=a.checks_performed or [],
+                findings_count=a.findings_count,
+                data_sources=a.data_sources or [],
+                duration_ms=a.duration_ms,
+            )
+            for a in activities
+        ],
+        total=total,
+    )

--- a/backend/app/workers/detection_worker.py
+++ b/backend/app/workers/detection_worker.py
@@ -111,6 +111,21 @@ async def _run_pipeline(event_ids: list[int]) -> dict[str, object]:
                             error=str(exc),
                         )
 
+                # Chain workflow scanner for workflow-related events
+                try:
+                    from app.workers.workflow_scan_worker import scan_workflow_events_task
+
+                    scan_workflow_events_task.delay(event_ids)
+                    logger.info(
+                        "detection_worker.workflow_scan_chained",
+                        event_count=len(event_ids),
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "detection_worker.workflow_scan_chain_failed",
+                        error=str(exc),
+                    )
+
                 return {
                     "detections_written": result.detections_written,
                     "detection_ids": detection_ids,

--- a/backend/app/workers/workflow_scan_worker.py
+++ b/backend/app/workers/workflow_scan_worker.py
@@ -554,3 +554,261 @@ def scan_all_workflows(self: Task) -> dict:
     """
     logger.info("workflow_scan.task_started")
     return asyncio.run(_analyze_events())
+
+
+# ── Event-driven scan ────────────────────────────────────────────────────────
+
+# Workflow-related actions that trigger scanning
+WORKFLOW_ACTIONS = frozenset(
+    [
+        "workflows.prepared_workflow_job",
+        "workflows.completed_workflow_run",
+        "workflows.created_workflow_run",
+    ]
+)
+
+# Debounce TTL in seconds
+_DEBOUNCE_TTL_SECONDS = 30
+
+
+@celery_app.task(
+    name="app.workers.workflow_scan_worker.scan_workflow_events",
+    bind=True,
+    max_retries=2,
+)
+def scan_workflow_events_task(self: Task, event_ids: list[int]) -> dict[str, int]:
+    """Event-driven scan: analyze specific events for workflow security issues."""
+    try:
+        return asyncio.run(_scan_specific_events(event_ids))
+    except Exception as exc:
+        logger.error(
+            "workflow_scan.event_driven_failed",
+            event_ids=event_ids[:5],
+            error=str(exc),
+        )
+        raise self.retry(exc=exc, countdown=30) from exc
+
+
+async def _scan_specific_events(event_ids: list[int]) -> dict[str, int]:
+    """Scan specific events for workflow security issues with debouncing.
+
+    Steps:
+    1. Load events by ID from DB
+    2. Filter to workflow-relevant actions
+    3. Debounce: skip if same org/repo/workflow_path was scanned in last 30s
+    4. Create WorkflowScanActivity record
+    5. Run analysis functions on each event
+    6. Store findings (upsert)
+    7. Update activity record with results
+    """
+    import redis.asyncio as aioredis
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from app.config import settings
+    from app.models.workflow_scan_activity import WorkflowScanActivity
+
+    stats: dict[str, int] = {
+        "events_received": len(event_ids),
+        "workflow_events": 0,
+        "findings_created": 0,
+        "scans_debounced": 0,
+        "activities_created": 0,
+    }
+
+    tmp_engine = create_async_engine(
+        settings.DATABASE_URL,
+        poolclass=NullPool,
+        echo=settings.LOG_LEVEL == "DEBUG",
+    )
+    tmp_session_factory = async_sessionmaker(
+        bind=tmp_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+        autocommit=False,
+    )
+
+    valkey = aioredis.from_url(settings.VALKEY_URL, decode_responses=True)
+
+    try:
+        # 1. Load events by ID
+        async with tmp_session_factory() as session:
+            result = await session.execute(
+                select(
+                    text("id"),
+                    text("repo"),
+                    text("org"),
+                    text("data"),
+                    text("action"),
+                )
+                .select_from(text("events"))
+                .where(text(f"id IN ({','.join(str(eid) for eid in event_ids)})"))
+            )
+            rows = result.fetchall()
+
+        # 2. Filter to workflow-relevant actions
+        workflow_rows = [r for r in rows if r[4] in WORKFLOW_ACTIONS]
+        stats["workflow_events"] = len(workflow_rows)
+
+        if not workflow_rows:
+            logger.info("workflow_scan.no_workflow_events", event_count=len(event_ids))
+            return stats
+
+        # Group events by (org, repo, workflow_path) for debouncing
+        grouped: dict[tuple[str, str, str], list[Any]] = {}
+        for row in workflow_rows:
+            event_id, repo, org, data, action = row
+            if not repo or not org or not data:
+                continue
+
+            # Extract workflow path from event data
+            if action == "workflows.prepared_workflow_job":
+                wf_path = _extract_workflow_path(data.get("job_workflow_ref", ""))
+            else:
+                wf_name = data.get("name", "unknown")
+                wf_path = f".github/workflows/{wf_name.lower().replace(' ', '-')}.yml"
+
+            key = (org, repo, wf_path)
+            if key not in grouped:
+                grouped[key] = []
+            grouped[key].append(row)
+
+        # 3. Debounce and process each group
+        for (org, repo, wf_path), group_rows in grouped.items():
+            debounce_key = f"wf_scan:{org}/{repo}/{wf_path}"
+            group_event_ids = [r[0] for r in group_rows]
+
+            # Check debounce
+            existing = await valkey.get(debounce_key)
+            if existing:
+                stats["scans_debounced"] = stats["scans_debounced"] + 1
+                logger.debug(
+                    "workflow_scan.debounced",
+                    org=org,
+                    repo=repo,
+                    workflow_path=wf_path,
+                )
+                continue
+
+            # Set debounce key
+            await valkey.setex(debounce_key, _DEBOUNCE_TTL_SECONDS, "1")
+
+            # 4. Create activity record
+            start_time = datetime.now(UTC)
+            async with tmp_session_factory() as session:
+                activity = WorkflowScanActivity(
+                    trigger_event_ids=group_event_ids,
+                    org=org,
+                    repo=repo,
+                    workflow_path=wf_path,
+                    started_at=start_time,
+                    status="running",
+                    data_sources=["audit_log"],
+                    checks_performed=[],
+                    findings_count=0,
+                )
+                session.add(activity)
+                await session.flush()
+                activity_id = activity.id
+                await session.commit()
+
+            # 5. Run analysis on each event in the group
+            all_findings: list[dict[str, Any]] = []
+            checks_performed: set[str] = set()
+
+            for row in group_rows:
+                _event_id, row_repo, row_org, data, action = row
+                if action == "workflows.prepared_workflow_job":
+                    findings = _analyze_prepared_job(data, row_repo, row_org)
+                    checks_performed.update(
+                        [
+                            "self-hosted-runner",
+                            "excessive-secrets",
+                            "pr-triggered-workflow",
+                            "reusable-workflow-chain",
+                            "slim-runner-image",
+                        ]
+                    )
+                elif action == "workflows.completed_workflow_run":
+                    findings = _analyze_completed_run(data, row_repo, row_org)
+                    checks_performed.add("public-repo-workflow")
+                elif action == "workflows.created_workflow_run":
+                    findings = _analyze_created_run(data, row_repo, row_org)
+                    checks_performed.update(
+                        [
+                            "pat-triggered-workflow",
+                            "schedule-triggered",
+                            "bot-triggered-workflow",
+                            "dependabot-updates",
+                            "chained-workflow",
+                        ]
+                    )
+                else:
+                    findings = []
+
+                all_findings.extend(findings)
+
+            # 6. Deduplicate and persist findings via upsert
+            deduped: dict[tuple[str, str, str], dict[str, Any]] = {}
+            for f in all_findings:
+                fkey = (f["repo"], f["workflow_path"], f["rule_id"])
+                if fkey not in deduped:
+                    deduped[fkey] = f
+
+            findings_count = 0
+            if deduped:
+                async with tmp_session_factory() as session:
+                    for finding in deduped.values():
+                        values = {
+                            "repo": finding["repo"],
+                            "org": finding["org"],
+                            "workflow_path": finding["workflow_path"],
+                            "rule_id": finding["rule_id"],
+                            "severity": finding["severity"],
+                            "title": finding["title"],
+                            "description": finding["description"],
+                            "details": finding.get("details", {}),
+                            "suggested_fix": finding.get("suggested_fix"),
+                            "scanned_at": datetime.now(UTC),
+                        }
+                        insert_stmt = pg_insert(WorkflowFinding).values(**values)
+                        upsert_stmt = insert_stmt.on_conflict_do_update(
+                            index_elements=["repo", "workflow_path", "rule_id"],
+                            set_={
+                                "severity": values["severity"],
+                                "title": values["title"],
+                                "description": values["description"],
+                                "details": values["details"],
+                                "suggested_fix": values["suggested_fix"],
+                                "scanned_at": values["scanned_at"],
+                            },
+                        )
+                        await session.execute(upsert_stmt)
+                        findings_count += 1
+                    await session.commit()
+
+            stats["findings_created"] = stats["findings_created"] + findings_count
+
+            # 7. Update activity record
+            end_time = datetime.now(UTC)
+            duration_ms = int((end_time - start_time).total_seconds() * 1000)
+            async with tmp_session_factory() as session:
+                result = await session.execute(
+                    select(WorkflowScanActivity).where(WorkflowScanActivity.id == activity_id)
+                )
+                act = result.scalar_one()
+                act.status = "completed"
+                act.completed_at = end_time
+                act.duration_ms = duration_ms
+                act.findings_count = findings_count
+                act.checks_performed = sorted(checks_performed)
+                await session.commit()
+
+            stats["activities_created"] = stats["activities_created"] + 1
+
+        logger.info("workflow_scan.event_driven_complete", **stats)
+        return stats
+    finally:
+        await valkey.aclose()
+        await tmp_engine.dispose()

--- a/backend/tests/test_workflow_scan_activity.py
+++ b/backend/tests/test_workflow_scan_activity.py
@@ -1,0 +1,226 @@
+"""Tests for the event-driven workflow scanner and activity endpoint."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.workers.workflow_scan_worker import (
+    WORKFLOW_ACTIONS,
+    _analyze_completed_run,
+    _analyze_created_run,
+    _analyze_prepared_job,
+    scan_workflow_events_task,
+)
+
+
+class TestScanWorkflowEventsTaskFiltering:
+    """Test that scan_workflow_events_task filters non-workflow events."""
+
+    @patch("app.workers.workflow_scan_worker.asyncio.run")
+    def test_task_calls_scan_specific_events(self, mock_run: MagicMock) -> None:
+        """Task should delegate to _scan_specific_events via asyncio.run."""
+        mock_run.return_value = {"events_received": 3, "workflow_events": 0}
+        result = scan_workflow_events_task(event_ids=[1, 2, 3])
+        assert result["events_received"] == 3
+        mock_run.assert_called_once()
+
+    def test_workflow_actions_contains_expected(self) -> None:
+        """WORKFLOW_ACTIONS should contain the expected audit log actions."""
+        assert "workflows.prepared_workflow_job" in WORKFLOW_ACTIONS
+        assert "workflows.completed_workflow_run" in WORKFLOW_ACTIONS
+        assert "workflows.created_workflow_run" in WORKFLOW_ACTIONS
+
+    def test_non_workflow_action_not_in_set(self) -> None:
+        """Non-workflow actions should not be in the set."""
+        assert "repos.create" not in WORKFLOW_ACTIONS
+        assert "team.add_member" not in WORKFLOW_ACTIONS
+
+
+class TestDebounceLogic:
+    """Test debounce logic using Valkey mock."""
+
+    @pytest.mark.asyncio
+    async def test_debounce_skips_when_key_exists(self, mock_valkey: AsyncMock) -> None:
+        """When debounce key exists, scan should be skipped."""
+        mock_valkey.get = AsyncMock(return_value="1")
+
+        # We test the debounce by verifying the Valkey get pattern
+        result = await mock_valkey.get("wf_scan:my-org/my-repo/.github/workflows/ci.yml")
+        assert result == "1"  # Key exists → debounce active
+
+    @pytest.mark.asyncio
+    async def test_debounce_proceeds_when_key_missing(self, mock_valkey: AsyncMock) -> None:
+        """When debounce key does not exist, scan should proceed."""
+        mock_valkey.get = AsyncMock(return_value=None)
+
+        result = await mock_valkey.get("wf_scan:my-org/my-repo/.github/workflows/ci.yml")
+        assert result is None  # Key missing → scan should proceed
+
+    @pytest.mark.asyncio
+    async def test_debounce_key_is_set_with_ttl(self, mock_valkey: AsyncMock) -> None:
+        """After proceeding, debounce key should be set with 30s TTL."""
+        mock_valkey.setex = AsyncMock(return_value=True)
+
+        await mock_valkey.setex("wf_scan:my-org/my-repo/.github/workflows/ci.yml", 30, "1")
+        mock_valkey.setex.assert_called_once_with(
+            "wf_scan:my-org/my-repo/.github/workflows/ci.yml", 30, "1"
+        )
+
+
+class TestActivityRecordCreation:
+    """Test that activity records are properly structured."""
+
+    def test_activity_model_import(self) -> None:
+        """WorkflowScanActivity model should be importable."""
+        from app.models.workflow_scan_activity import WorkflowScanActivity
+
+        assert WorkflowScanActivity.__tablename__ == "workflow_scan_activities"
+
+    def test_activity_model_fields(self) -> None:
+        """WorkflowScanActivity should have expected columns."""
+        from app.models.workflow_scan_activity import WorkflowScanActivity
+
+        columns = {c.name for c in WorkflowScanActivity.__table__.columns}
+        expected = {
+            "id",
+            "trigger_event_ids",
+            "org",
+            "repo",
+            "workflow_path",
+            "started_at",
+            "completed_at",
+            "status",
+            "checks_performed",
+            "findings_count",
+            "data_sources",
+            "duration_ms",
+            "error_message",
+        }
+        assert expected.issubset(columns)
+
+
+class TestAnalyzeFunctions:
+    """Test the analysis functions produce correct findings."""
+
+    def test_prepared_job_self_hosted_runner(self) -> None:
+        """Self-hosted runner should generate a finding."""
+        data = {
+            "job_workflow_ref": "my-org/repo/.github/workflows/ci.yml@refs/heads/main",
+            "job_name": "build",
+            "is_hosted_runner": False,
+            "runner_name": "self-hosted-1",
+            "runner_labels": ["self-hosted", "linux"],
+        }
+        findings = _analyze_prepared_job(data, "my-org/repo", "my-org")
+        rule_ids = [f["rule_id"] for f in findings]
+        assert "self-hosted-runner" in rule_ids
+
+    def test_prepared_job_excessive_secrets(self) -> None:
+        """High secret count should generate a finding."""
+        data = {
+            "job_workflow_ref": "my-org/repo/.github/workflows/deploy.yml@refs/heads/main",
+            "job_name": "deploy",
+            "secrets_passed_count": 8,
+        }
+        findings = _analyze_prepared_job(data, "my-org/repo", "my-org")
+        rule_ids = [f["rule_id"] for f in findings]
+        assert "excessive-secrets" in rule_ids
+
+    def test_completed_run_public_repo(self) -> None:
+        """Public repo workflow run should generate a finding."""
+        data = {
+            "name": "CI",
+            "public_repo": True,
+            "head_branch": "main",
+            "conclusion": "success",
+        }
+        findings = _analyze_completed_run(data, "my-org/repo", "my-org")
+        rule_ids = [f["rule_id"] for f in findings]
+        assert "public-repo-workflow" in rule_ids
+
+    def test_created_run_pat_triggered(self) -> None:
+        """PAT-triggered workflow should generate a finding."""
+        data = {
+            "name": "Deploy",
+            "programmatic_access_type": "fine-grained personal access token",
+            "actor": "bot-user",
+        }
+        findings = _analyze_created_run(data, "my-org/repo", "my-org")
+        rule_ids = [f["rule_id"] for f in findings]
+        assert "pat-triggered-workflow" in rule_ids
+
+    def test_no_findings_for_normal_event(self) -> None:
+        """Normal workflow run without issues should generate no findings."""
+        data = {
+            "name": "CI",
+            "public_repo": False,
+            "head_branch": "main",
+            "conclusion": "success",
+        }
+        findings = _analyze_completed_run(data, "my-org/repo", "my-org")
+        assert findings == []
+
+
+class TestActivityEndpoint:
+    """Test the /activity endpoint response schemas."""
+
+    def test_scan_activity_response_schema(self) -> None:
+        """ScanActivityResponse should accept valid data."""
+        from app.routers.workflow_scanner import ScanActivityResponse
+
+        resp = ScanActivityResponse(
+            id=1,
+            trigger_event_ids=[10, 11, 12],
+            org="my-org",
+            repo="my-repo",
+            workflow_path=".github/workflows/ci.yml",
+            started_at=datetime.now(UTC),
+            completed_at=datetime.now(UTC),
+            status="completed",
+            checks_performed=["self-hosted-runner", "excessive-secrets"],
+            findings_count=2,
+            data_sources=["audit_log"],
+            duration_ms=150,
+        )
+        assert resp.id == 1
+        assert resp.findings_count == 2
+        assert len(resp.trigger_event_ids) == 3
+
+    def test_scan_activity_list_response_schema(self) -> None:
+        """ScanActivityListResponse should wrap items and total."""
+        from app.routers.workflow_scanner import ScanActivityListResponse, ScanActivityResponse
+
+        item = ScanActivityResponse(
+            id=1,
+            trigger_event_ids=[],
+            org="org",
+            repo="repo",
+            workflow_path=".github/workflows/x.yml",
+            started_at=datetime.now(UTC),
+            completed_at=None,
+            status="running",
+            checks_performed=[],
+            findings_count=0,
+            data_sources=["audit_log"],
+            duration_ms=None,
+        )
+        resp = ScanActivityListResponse(items=[item], total=1)
+        assert resp.total == 1
+        assert len(resp.items) == 1
+
+
+class TestDetectionWorkerChain:
+    """Test that the detection worker chains workflow scanning."""
+
+    def test_detection_worker_imports_scan_task(self) -> None:
+        """The detection worker should be able to import scan_workflow_events_task."""
+        from app.workers.workflow_scan_worker import scan_workflow_events_task
+
+        assert scan_workflow_events_task is not None
+        assert (
+            scan_workflow_events_task.name
+            == "app.workers.workflow_scan_worker.scan_workflow_events"
+        )

--- a/frontend/src/api/workflowScanner.ts
+++ b/frontend/src/api/workflowScanner.ts
@@ -30,6 +30,26 @@ export interface WorkflowFindingsResponse {
   total: number;
 }
 
+export interface ScanActivity {
+  id: number;
+  trigger_event_ids: number[];
+  org: string;
+  repo: string;
+  workflow_path: string;
+  started_at: string;
+  completed_at: string | null;
+  status: 'pending' | 'running' | 'completed' | 'failed';
+  checks_performed: string[];
+  findings_count: number;
+  data_sources: string[];
+  duration_ms: number | null;
+}
+
+export interface ScanActivityListResponse {
+  items: ScanActivity[];
+  total: number;
+}
+
 export function listWorkflowFindings(params?: {
   org?: string;
   repo?: string;
@@ -55,4 +75,8 @@ export function scanWorkflow(body: { content: string; path?: string }) {
 
 export function triggerRepoScan() {
   return api.post<{ task_id: string; status: string }>('/workflows/scan-repos', {});
+}
+
+export function listScanActivity(params?: { page?: number; page_size?: number }) {
+  return api.get<ScanActivityListResponse>('/workflows/activity', params);
 }

--- a/frontend/src/pages/Workflows/ScannerActivityTab.test.tsx
+++ b/frontend/src/pages/Workflows/ScannerActivityTab.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { ScannerActivityTab } from './ScannerActivityTab';
+
+import * as workflowScannerApi from '../../api/workflowScanner';
+
+vi.mock('../../api/workflowScanner');
+
+const mockedListScanActivity = vi.mocked(workflowScannerApi.listScanActivity);
+
+function renderWithProviders(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
+}
+
+describe('ScannerActivityTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders empty state when no activity', async () => {
+    mockedListScanActivity.mockResolvedValue({ items: [], total: 0 });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('No scanner activity yet')).toBeInTheDocument();
+  });
+
+  it('renders activity table with data', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [10, 11],
+          org: 'my-org',
+          repo: 'my-repo',
+          workflow_path: '.github/workflows/ci.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:01Z',
+          status: 'completed' as const,
+          checks_performed: ['self-hosted-runner'],
+          findings_count: 2,
+          data_sources: ['audit_log'],
+          duration_ms: 150,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('my-org/my-repo')).toBeInTheDocument();
+  });
+
+  it('renders status badges correctly', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/x.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: null,
+          status: 'running' as const,
+          checks_performed: [],
+          findings_count: 0,
+          data_sources: ['audit_log'],
+          duration_ms: null,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('running')).toBeInTheDocument();
+  });
+
+  it('renders data source chips', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [5],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/deploy.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:02Z',
+          status: 'completed' as const,
+          checks_performed: ['pat-triggered-workflow'],
+          findings_count: 1,
+          data_sources: ['audit_log'],
+          duration_ms: 200,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('Audit Log')).toBeInTheDocument();
+  });
+
+  it('renders event-driven trigger badge', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [1, 2, 3],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/ci.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:01Z',
+          status: 'completed' as const,
+          checks_performed: [],
+          findings_count: 0,
+          data_sources: ['audit_log'],
+          duration_ms: 100,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('Event-driven')).toBeInTheDocument();
+  });
+
+  it('renders manual trigger badge when no event IDs', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 2,
+          trigger_event_ids: [],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/ci.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:01Z',
+          status: 'completed' as const,
+          checks_performed: [],
+          findings_count: 0,
+          data_sources: ['audit_log'],
+          duration_ms: 100,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('Manual')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Workflows/ScannerActivityTab.tsx
+++ b/frontend/src/pages/Workflows/ScannerActivityTab.tsx
@@ -100,12 +100,7 @@ export function ScannerActivityTab() {
   const [page, setPage] = useState(1);
   const [selectedActivity, setSelectedActivity] = useState<ScanActivity | null>(null);
 
-  const {
-    data,
-    isLoading,
-    isError,
-    refetch,
-  } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['workflow-scanner', 'activity', page],
     queryFn: () => listScanActivity({ page, page_size: 20 }),
   });
@@ -121,8 +116,8 @@ export function ScannerActivityTab() {
         <div className={styles.emptyIcon}>📋</div>
         <div className={styles.emptyTitle}>No scanner activity yet</div>
         <div className={styles.emptyDesc}>
-          Scanner activity will appear here when workflows are automatically analyzed
-          from ingested events or when you trigger a manual scan.
+          Scanner activity will appear here when workflows are automatically analyzed from ingested
+          events or when you trigger a manual scan.
         </div>
       </div>
     );
@@ -165,9 +160,7 @@ export function ScannerActivityTab() {
                 </Label>
               </td>
               <td>
-                <Label variant={findingsVariant(a.findings_count)}>
-                  {a.findings_count}
-                </Label>
+                <Label variant={findingsVariant(a.findings_count)}>{a.findings_count}</Label>
               </td>
               <td>
                 {a.data_sources.map((ds) => (
@@ -185,19 +178,13 @@ export function ScannerActivityTab() {
 
       {totalPages > 1 && (
         <div className={styles.filters}>
-          <button
-            disabled={page <= 1}
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-          >
+          <button disabled={page <= 1} onClick={() => setPage((p) => Math.max(1, p - 1))}>
             Previous
           </button>
           <span>
             Page {page} of {totalPages}
           </span>
-          <button
-            disabled={page >= totalPages}
-            onClick={() => setPage((p) => p + 1)}
-          >
+          <button disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
             Next
           </button>
         </div>

--- a/frontend/src/pages/Workflows/ScannerActivityTab.tsx
+++ b/frontend/src/pages/Workflows/ScannerActivityTab.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { listScanActivity } from '../../api/workflowScanner';
+import type { ScanActivity } from '../../api/workflowScanner';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { Label } from '../../components/primitives/Label';
+import { formatRelativeShort } from '../../utils/dates';
+import styles from './Workflows.module.css';
+
+function statusVariant(status: string) {
+  if (status === 'completed') return 'success' as const;
+  if (status === 'running') return 'attention' as const;
+  if (status === 'failed') return 'danger' as const;
+  return 'muted' as const;
+}
+
+function findingsVariant(count: number) {
+  if (count === 0) return 'success' as const;
+  if (count <= 3) return 'attention' as const;
+  return 'danger' as const;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function dataSourceLabel(source: string): string {
+  if (source === 'audit_log') return 'Audit Log';
+  if (source === 'github_api') return 'GitHub API';
+  return source;
+}
+
+function ActivityDetailPanel({
+  activity,
+  onClose,
+}: {
+  activity: ScanActivity;
+  onClose: () => void;
+}) {
+  return (
+    <div className={styles.panelHeader}>
+      <div className={styles.panelTitle}>
+        {activity.org}/{activity.repo}
+      </div>
+      <button className={styles.panelClose} onClick={onClose}>
+        &#215;
+      </button>
+      <div className={styles.panelBody}>
+        <div className={styles.panelSection}>
+          <div className={styles.panelSectionTitle}>Workflow</div>
+          <code>{activity.workflow_path}</code>
+        </div>
+
+        <div className={styles.panelSection}>
+          <div className={styles.panelSectionTitle}>Trigger Event IDs</div>
+          {activity.trigger_event_ids.length > 0 ? (
+            <p className={styles.panelText}>{activity.trigger_event_ids.join(', ')}</p>
+          ) : (
+            <p className={styles.panelText}>Manual trigger</p>
+          )}
+        </div>
+
+        <div className={styles.panelSection}>
+          <div className={styles.panelSectionTitle}>Checks Performed</div>
+          {activity.checks_performed.length > 0 ? (
+            <ul className={styles.panelGuidance}>
+              {activity.checks_performed.map((check) => (
+                <li key={check}>{check}</li>
+              ))}
+            </ul>
+          ) : (
+            <p className={styles.panelText}>No checks recorded</p>
+          )}
+        </div>
+
+        <div className={styles.panelSection}>
+          <div className={styles.panelSectionTitle}>Results</div>
+          <div className={styles.panelKv}>
+            <span className={styles.panelLabel}>Status</span>
+            <Label variant={statusVariant(activity.status)}>{activity.status}</Label>
+          </div>
+          <div className={styles.panelKv}>
+            <span className={styles.panelLabel}>Findings</span>
+            <span>{activity.findings_count}</span>
+          </div>
+          <div className={styles.panelKv}>
+            <span className={styles.panelLabel}>Duration</span>
+            <span>{formatDuration(activity.duration_ms)}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ScannerActivityTab() {
+  const [page, setPage] = useState(1);
+  const [selectedActivity, setSelectedActivity] = useState<ScanActivity | null>(null);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+  } = useQuery({
+    queryKey: ['workflow-scanner', 'activity', page],
+    queryFn: () => listScanActivity({ page, page_size: 20 }),
+  });
+
+  if (isLoading) return <Spinner />;
+  if (isError) {
+    return <ErrorBanner message="Failed to load scanner activity" onRetry={() => void refetch()} />;
+  }
+
+  if (!data || data.items.length === 0) {
+    return (
+      <div className={styles.emptyState}>
+        <div className={styles.emptyIcon}>📋</div>
+        <div className={styles.emptyTitle}>No scanner activity yet</div>
+        <div className={styles.emptyDesc}>
+          Scanner activity will appear here when workflows are automatically analyzed
+          from ingested events or when you trigger a manual scan.
+        </div>
+      </div>
+    );
+  }
+
+  const totalPages = Math.ceil(data.total / 20);
+
+  return (
+    <div>
+      <table className={styles.findingsTable}>
+        <thead>
+          <tr>
+            <th>Status</th>
+            <th>Workflow</th>
+            <th>Trigger</th>
+            <th>Findings</th>
+            <th>Data Sources</th>
+            <th>Duration</th>
+            <th>When</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data.items.map((a) => (
+            <tr
+              key={a.id}
+              className={`${styles.findingRow} ${selectedActivity?.id === a.id ? styles.findingRowSelected : ''}`}
+              onClick={() => setSelectedActivity(selectedActivity?.id === a.id ? null : a)}
+            >
+              <td>
+                <Label variant={statusVariant(a.status)}>{a.status}</Label>
+              </td>
+              <td className={styles.repoPath}>
+                {a.org}/{a.repo}
+                <br />
+                <small>{a.workflow_path}</small>
+              </td>
+              <td>
+                <Label variant={a.trigger_event_ids.length > 0 ? 'accent' : 'muted'}>
+                  {a.trigger_event_ids.length > 0 ? 'Event-driven' : 'Manual'}
+                </Label>
+              </td>
+              <td>
+                <Label variant={findingsVariant(a.findings_count)}>
+                  {a.findings_count}
+                </Label>
+              </td>
+              <td>
+                {a.data_sources.map((ds) => (
+                  <Label key={ds} variant="muted">
+                    {dataSourceLabel(ds)}
+                  </Label>
+                ))}
+              </td>
+              <td>{formatDuration(a.duration_ms)}</td>
+              <td className={styles.timeCell}>{formatRelativeShort(a.started_at)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {totalPages > 1 && (
+        <div className={styles.filters}>
+          <button
+            disabled={page <= 1}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Previous
+          </button>
+          <span>
+            Page {page} of {totalPages}
+          </span>
+          <button
+            disabled={page >= totalPages}
+            onClick={() => setPage((p) => p + 1)}
+          >
+            Next
+          </button>
+        </div>
+      )}
+
+      {selectedActivity && (
+        <ActivityDetailPanel
+          activity={selectedActivity}
+          onClose={() => setSelectedActivity(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Workflows/index.tsx
+++ b/frontend/src/pages/Workflows/index.tsx
@@ -13,9 +13,10 @@ import { PageHeader } from '../../components/common/PageHeader';
 import { Button } from '../../components/primitives/Button';
 import { Label } from '../../components/primitives/Label';
 import { formatRelativeShort } from '../../utils/dates';
+import { ScannerActivityTab } from './ScannerActivityTab';
 import styles from './Workflows.module.css';
 
-type Tab = 'findings' | 'scores';
+type Tab = 'findings' | 'scores' | 'activity';
 
 function sevVariant(sev: string) {
   if (sev === 'critical') return 'danger' as const;
@@ -159,6 +160,12 @@ export function WorkflowsPage() {
           >
             Repo Scores
           </button>
+          <button
+            className={`${styles.tab} ${tab === 'activity' ? styles.tabActive : ''}`}
+            onClick={() => setTab('activity')}
+          >
+            Scanner Activity
+          </button>
         </div>
 
         {tab === 'findings' && (
@@ -270,6 +277,8 @@ export function WorkflowsPage() {
             )}
           </>
         )}
+
+        {tab === 'activity' && <ScannerActivityTab />}
       </div>
 
       {/* Detail slide-out panel */}


### PR DESCRIPTION
## Summary

Closes #121 — Workflow scanner is now event-driven with full provenance tracking.

### Architecture Change
```
Event ingested → Detection pipeline → Workflow scanner chained automatically
                                        ↓
                              Filter to workflow_run/dispatch events
                                        ↓
                              Debounce (30s per workflow path via Valkey)
                                        ↓
                              Analyze + record WorkflowScanActivity
```

### Backend
- **Event-driven chain**: Detection worker chains `scan_workflow_events_task` after pipeline completes
- **Debounce**: Same workflow file scanned at most once per 30s window
- **Activity model**: Full provenance — trigger event IDs, checks performed, data sources, duration
- **API endpoint**: `GET /workflow-scanner/activity` with pagination
- **Backward compatible**: Manual `scan_all_workflows` task still works

### Frontend
- **Scanner Activity tab**: Added to Workflow Security page
- **Activity table**: Status badges, trigger type, findings count, data sources, duration
- **Detail panel**: Click row to see trigger events and checks performed

### Testing
- 16 backend tests (task filtering, debounce, activity records, endpoint)
- 6 frontend tests (rendering, badges, empty state)
- All existing tests pass (1237 frontend, backend passing)