### PR TITLE
feat: Query explorer — saved queries, sharing, export (#131)

### DIFF
--- a/backend/alembic/versions/0053_saved_queries.py
+++ b/backend/alembic/versions/0053_saved_queries.py
@@ -1,0 +1,74 @@
+"""Add saved_queries table for user-saved queries with sharing and scheduling.
+
+Revision ID: 0051
+Revises: 0050
+Create Date: 2026-06-15
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+
+from alembic import op
+
+revision = "0053"
+down_revision = "0052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create saved_queries table."""
+    op.create_table(
+        "saved_queries",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("sql_text", sa.Text(), nullable=False),
+        sa.Column("owner_login", sa.Text(), nullable=False),
+        sa.Column(
+            "is_shared",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("shared_with", JSONB(), nullable=True),
+        sa.Column("tags", ARRAY(sa.Text()), nullable=True),
+        sa.Column("schedule_cron", sa.Text(), nullable=True),
+        sa.Column(
+            "schedule_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_saved_queries_owner_login",
+        "saved_queries",
+        ["owner_login"],
+    )
+    # GIN index on shared_with JSONB for fast lookup of shared queries
+    op.execute("CREATE INDEX ix_saved_queries_shared_with ON saved_queries USING GIN (shared_with)")
+    # Grant readonly access for the query explorer role
+    op.execute("GRANT SELECT ON saved_queries TO readonly_query_user")
+
+
+def downgrade() -> None:
+    """Drop saved_queries table."""
+    op.execute("REVOKE SELECT ON saved_queries FROM readonly_query_user")
+    op.drop_index("ix_saved_queries_shared_with", table_name="saved_queries")
+    op.drop_index("ix_saved_queries_owner_login", table_name="saved_queries")
+    op.drop_table("saved_queries")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.audit_trail import AuditTrail
 from app.models.auth_method import AuthMethodConfig, SessionPolicySetting
 from app.models.copilot_metrics import CopilotDailyMetric, CopilotSeatSnapshot
 from app.models.copilot_policy import CopilotPolicy, CopilotPolicyViolation
+from app.models.correlation import ChainMembership, CorrelationChain
 from app.models.custom_report import CustomReport
 from app.models.detection import (
     BehavioralBaseline,
@@ -52,6 +53,7 @@ from app.models.playbook import PlaybookExecution, PlaybookTemplate
 from app.models.query_template import QueryTemplate
 from app.models.report_schedule import ReportSchedule
 from app.models.retention_policy import RetentionPolicy
+from app.models.saved_query import SavedQuery
 from app.models.system_health import SystemHealthEvent
 from app.models.team import Team, TeamMembership, TeamRoleAssignment
 from app.models.threat_intel import ThreatIntelDomain, ThreatIntelFeed, ThreatIntelIndicator
@@ -70,11 +72,13 @@ __all__ = [
     "AuthMethodConfig",
     "SessionPolicySetting",
     "BehavioralBaseline",
+    "ChainMembership",
     "CodeScanningAlert",
     "CopilotDailyMetric",
     "CopilotPolicy",
     "CopilotPolicyViolation",
     "CopilotSeatSnapshot",
+    "CorrelationChain",
     "CustomReport",
     "DependabotAlert",
     "Detection",
@@ -102,6 +106,7 @@ __all__ = [
     "PlaybookExecution",
     "PlaybookTemplate",
     "QueryTemplate",
+    "SavedQuery",
     "RepoBranchProtection",
     "Repository",
     "RuleDefinition",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,7 +6,6 @@ from app.models.audit_trail import AuditTrail
 from app.models.auth_method import AuthMethodConfig, SessionPolicySetting
 from app.models.copilot_metrics import CopilotDailyMetric, CopilotSeatSnapshot
 from app.models.copilot_policy import CopilotPolicy, CopilotPolicyViolation
-from app.models.correlation import ChainMembership, CorrelationChain
 from app.models.custom_report import CustomReport
 from app.models.detection import (
     BehavioralBaseline,
@@ -72,13 +71,11 @@ __all__ = [
     "AuthMethodConfig",
     "SessionPolicySetting",
     "BehavioralBaseline",
-    "ChainMembership",
     "CodeScanningAlert",
     "CopilotDailyMetric",
     "CopilotPolicy",
     "CopilotPolicyViolation",
     "CopilotSeatSnapshot",
-    "CorrelationChain",
     "CustomReport",
     "DependabotAlert",
     "Detection",

--- a/backend/app/models/saved_query.py
+++ b/backend/app/models/saved_query.py
@@ -1,0 +1,44 @@
+"""SQLAlchemy ORM model for user-saved queries."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, Text, text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.audit_event import Base
+
+
+class SavedQuery(Base):
+    """A user-saved SQL query with optional sharing and scheduling.
+
+    Supports tagging, sharing with specific users, and lightweight
+    cron-based scheduling metadata.
+    """
+
+    __tablename__ = "saved_queries"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sql_text: Mapped[str] = mapped_column(Text, nullable=False)
+    owner_login: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    is_shared: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    shared_with: Mapped[list[str] | None] = mapped_column(JSONB, nullable=True)
+    tags: Mapped[list[str] | None] = mapped_column(ARRAY(Text), nullable=True)
+    schedule_cron: Mapped[str | None] = mapped_column(Text, nullable=True)
+    schedule_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=text("NOW()"),
+        onupdate=text("NOW()"),
+    )

--- a/backend/app/routers/query.py
+++ b/backend/app/routers/query.py
@@ -6,16 +6,29 @@ import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import AuthenticatedUser, get_db, require_permission, verify_csrf
 from app.models.audit_trail import AuditTrail
 from app.models.query_template import QueryTemplate as QueryTemplateModel
+from app.models.saved_query import SavedQuery as SavedQueryModel
 from app.rate_limit import limiter
-from app.schemas.query import QueryRunRequest, QueryRunResponse, QueryTemplate, QueryTemplateCreate
+from app.schemas.query import (
+    QueryRunRequest,
+    QueryRunResponse,
+    QueryTemplate,
+    QueryTemplateCreate,
+    SavedQueryCreate,
+    SavedQueryResponse,
+    SavedQueryUpdate,
+    ScheduleQueryRequest,
+    SchemaColumn,
+    SchemaTable,
+    ShareQueryRequest,
+)
 from app.services.nl_query_service import NLQueryService
-from app.services.query_service import QueryValidationError, execute_query
+from app.services.query_service import ALLOWED_TABLES, QueryValidationError, execute_query
 from app.services.rbac_service import get_user_scope
 from app.utils.client_ip import get_client_ip
 
@@ -294,6 +307,272 @@ async def run_template(
         return await execute_query(db, sql=template.sql, scope=scope)
     except (QueryValidationError, ValueError) as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+# ── Saved Queries (User's Own) ────────────────────────────────────────────────
+
+
+@router.post(
+    "/saved",
+    response_model=SavedQueryResponse,
+    status_code=status.HTTP_201_CREATED,
+    dependencies=[Depends(verify_csrf)],
+)
+async def create_saved_query(
+    payload: SavedQueryCreate,
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> SavedQueryResponse:
+    """Save a query with name, description, and optional tags."""
+    saved = SavedQueryModel(
+        name=payload.name,
+        description=payload.description,
+        sql_text=payload.sql_text,
+        owner_login=current_user.github_login,
+        tags=payload.tags,
+    )
+    db.add(saved)
+    await db.flush()
+    await db.refresh(saved)
+    return SavedQueryResponse.model_validate(saved)
+
+
+@router.get("/saved", response_model=list[SavedQueryResponse])
+async def list_saved_queries(
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> list[SavedQueryResponse]:
+    """List the current user's saved queries."""
+    result = await db.execute(
+        select(SavedQueryModel)
+        .where(SavedQueryModel.owner_login == current_user.github_login)
+        .order_by(SavedQueryModel.updated_at.desc())
+    )
+    return [SavedQueryResponse.model_validate(row) for row in result.scalars().all()]
+
+
+@router.put(
+    "/saved/{query_id}",
+    response_model=SavedQueryResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def update_saved_query(
+    query_id: int,
+    payload: SavedQueryUpdate,
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> SavedQueryResponse:
+    """Update a saved query owned by the current user."""
+    result = await db.execute(select(SavedQueryModel).where(SavedQueryModel.id == query_id))
+    saved = result.scalar_one_or_none()
+    if not saved:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Saved query not found")
+    if saved.owner_login != current_user.github_login:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the query owner")
+
+    update_data = payload.model_dump(exclude_unset=True)
+    if update_data:
+        await db.execute(
+            update(SavedQueryModel).where(SavedQueryModel.id == query_id).values(**update_data)
+        )
+        await db.flush()
+        await db.refresh(saved)
+    return SavedQueryResponse.model_validate(saved)
+
+
+@router.delete("/saved/{query_id}", dependencies=[Depends(verify_csrf)])
+async def delete_saved_query(
+    query_id: int,
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    """Delete a saved query owned by the current user."""
+    result = await db.execute(select(SavedQueryModel).where(SavedQueryModel.id == query_id))
+    saved = result.scalar_one_or_none()
+    if not saved:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Saved query not found")
+    if saved.owner_login != current_user.github_login:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the query owner")
+    await db.delete(saved)
+    await db.flush()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ── Query Sharing ─────────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/saved/{query_id}/share",
+    response_model=SavedQueryResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def share_query(
+    query_id: int,
+    payload: ShareQueryRequest,
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> SavedQueryResponse:
+    """Share a saved query with other users by their GitHub logins."""
+    result = await db.execute(select(SavedQueryModel).where(SavedQueryModel.id == query_id))
+    saved = result.scalar_one_or_none()
+    if not saved:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Saved query not found")
+    if saved.owner_login != current_user.github_login:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the query owner")
+
+    existing: list[str] = saved.shared_with or []
+    merged = list(set(existing) | set(payload.logins))
+    await db.execute(
+        update(SavedQueryModel)
+        .where(SavedQueryModel.id == query_id)
+        .values(shared_with=merged, is_shared=True)
+    )
+    await db.flush()
+    await db.refresh(saved)
+    return SavedQueryResponse.model_validate(saved)
+
+
+@router.get("/shared", response_model=list[SavedQueryResponse])
+async def list_shared_queries(
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> list[SavedQueryResponse]:
+    """List queries that have been shared with the current user."""
+    login = current_user.github_login
+    result = await db.execute(
+        select(SavedQueryModel)
+        .where(
+            SavedQueryModel.is_shared.is_(True),
+            SavedQueryModel.owner_login != login,
+            or_(
+                SavedQueryModel.shared_with.contains([login]),
+                SavedQueryModel.shared_with.is_(None),
+            ),
+        )
+        .order_by(SavedQueryModel.updated_at.desc())
+    )
+    return [SavedQueryResponse.model_validate(row) for row in result.scalars().all()]
+
+
+# ── Query Scheduling ──────────────────────────────────────────────────────────
+
+
+@router.post(
+    "/saved/{query_id}/schedule",
+    response_model=SavedQueryResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def schedule_query(
+    query_id: int,
+    payload: ScheduleQueryRequest,
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+    db: AsyncSession = Depends(get_db),
+) -> SavedQueryResponse:
+    """Set or update a cron schedule for a saved query.
+
+    Stores schedule metadata — actual execution is handled by the beat worker.
+    """
+    result = await db.execute(select(SavedQueryModel).where(SavedQueryModel.id == query_id))
+    saved = result.scalar_one_or_none()
+    if not saved:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Saved query not found")
+    if saved.owner_login != current_user.github_login:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the query owner")
+
+    await db.execute(
+        update(SavedQueryModel)
+        .where(SavedQueryModel.id == query_id)
+        .values(schedule_cron=payload.cron, schedule_enabled=payload.enabled)
+    )
+    await db.flush()
+    await db.refresh(saved)
+    return SavedQueryResponse.model_validate(saved)
+
+
+# ── Schema Introspection ─────────────────────────────────────────────────────
+
+
+# Schema metadata for autocomplete — derived from the ALLOWED_TABLES
+# plus column definitions from the events/detections models.
+_SCHEMA_CACHE: list[SchemaTable] | None = None
+
+
+def _build_schema() -> list[SchemaTable]:
+    """Build schema metadata for the allowed query tables.
+
+    Returns table and column info for client-side autocomplete.
+    We hard-code columns rather than introspecting at runtime to avoid
+    requiring a live database connection and to keep the response fast.
+    """
+    schema_map: dict[str, list[SchemaColumn]] = {
+        "events": [
+            SchemaColumn(name="id", type="bigint"),
+            SchemaColumn(name="action", type="text"),
+            SchemaColumn(name="namespace", type="text"),
+            SchemaColumn(name="actor", type="text"),
+            SchemaColumn(name="org", type="text"),
+            SchemaColumn(name="repo", type="text"),
+            SchemaColumn(name="source_ip", type="inet"),
+            SchemaColumn(name="geo_country_code", type="text"),
+            SchemaColumn(name="geo_city", type="text"),
+            SchemaColumn(name="created_at", type="timestamptz"),
+            SchemaColumn(name="data", type="jsonb"),
+        ],
+        "detections": [
+            SchemaColumn(name="id", type="bigint"),
+            SchemaColumn(name="title", type="text"),
+            SchemaColumn(name="severity", type="text"),
+            SchemaColumn(name="status", type="text"),
+            SchemaColumn(name="actor", type="text"),
+            SchemaColumn(name="org", type="text"),
+            SchemaColumn(name="repo", type="text"),
+            SchemaColumn(name="triggered_at", type="timestamptz"),
+        ],
+        "events_hourly": [
+            SchemaColumn(name="bucket_hour", type="timestamptz"),
+            SchemaColumn(name="org", type="text"),
+            SchemaColumn(name="namespace", type="text"),
+            SchemaColumn(name="action", type="text"),
+            SchemaColumn(name="event_count", type="bigint"),
+        ],
+        "events_daily_actor": [
+            SchemaColumn(name="bucket_day", type="timestamptz"),
+            SchemaColumn(name="actor", type="text"),
+            SchemaColumn(name="org", type="text"),
+            SchemaColumn(name="namespace", type="text"),
+            SchemaColumn(name="event_count", type="bigint"),
+        ],
+        "detections_daily": [
+            SchemaColumn(name="bucket_day", type="timestamptz"),
+            SchemaColumn(name="severity", type="text"),
+            SchemaColumn(name="status", type="text"),
+            SchemaColumn(name="detection_count", type="bigint"),
+        ],
+        "behavioral_baselines": [
+            SchemaColumn(name="id", type="bigint"),
+            SchemaColumn(name="actor", type="text"),
+            SchemaColumn(name="org", type="text"),
+            SchemaColumn(name="feature", type="text"),
+            SchemaColumn(name="baseline_value", type="float"),
+            SchemaColumn(name="updated_at", type="timestamptz"),
+        ],
+    }
+    tables: list[SchemaTable] = []
+    for tbl_name in sorted(ALLOWED_TABLES):
+        columns = schema_map.get(tbl_name, [])
+        tables.append(SchemaTable(table=tbl_name, columns=columns))
+    return tables
+
+
+@router.get("/schema", response_model=list[SchemaTable])
+async def get_schema(
+    current_user: AuthenticatedUser = Depends(require_permission("queries", "execute")),
+) -> list[SchemaTable]:
+    """Return available tables and columns for query editor autocomplete."""
+    global _SCHEMA_CACHE  # noqa: PLW0603
+    if _SCHEMA_CACHE is None:
+        _SCHEMA_CACHE = _build_schema()
+    return _SCHEMA_CACHE
 
 
 # ── Natural language query ────────────────────────────────────────────────────

--- a/backend/app/schemas/query.py
+++ b/backend/app/schemas/query.py
@@ -62,3 +62,71 @@ class QueryTemplateCreate(BaseModel):
     description: str | None = Field(None, max_length=1000)
     sql: str = Field(..., min_length=10, max_length=50_000)
     org_slug: str | None = Field(None, max_length=255)
+
+
+# ── Saved Queries ─────────────────────────────────────────────────────────────
+
+
+class SavedQueryCreate(BaseModel):
+    """Request body for saving a query."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = Field(None, max_length=2000)
+    sql_text: str = Field(..., min_length=10, max_length=50_000)
+    tags: list[str] | None = Field(None, max_length=20)
+
+
+class SavedQueryUpdate(BaseModel):
+    """Request body for updating a saved query."""
+
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = Field(None, max_length=2000)
+    sql_text: str | None = Field(None, min_length=10, max_length=50_000)
+    tags: list[str] | None = None
+
+
+class SavedQueryResponse(BaseModel):
+    """Response schema for a saved query."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    description: str | None = None
+    sql_text: str
+    owner_login: str
+    is_shared: bool = False
+    shared_with: list[str] | None = None
+    tags: list[str] | None = None
+    schedule_cron: str | None = None
+    schedule_enabled: bool = False
+    last_run_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime | None = None
+
+
+class ShareQueryRequest(BaseModel):
+    """Request body for sharing a query with other users."""
+
+    logins: list[str] = Field(..., min_length=1, max_length=50)
+
+
+class ScheduleQueryRequest(BaseModel):
+    """Request body for scheduling a saved query."""
+
+    cron: str = Field(..., min_length=5, max_length=100)
+    enabled: bool = True
+
+
+class SchemaColumn(BaseModel):
+    """A column in a database table schema."""
+
+    name: str
+    type: str
+
+
+class SchemaTable(BaseModel):
+    """A table in the database schema with its columns."""
+
+    table: str
+    columns: list[SchemaColumn]

--- a/backend/tests/test_saved_query_router.py
+++ b/backend/tests/test_saved_query_router.py
@@ -1,0 +1,493 @@
+"""Tests for saved query endpoints in the query router.
+
+Covers:
+- POST /query/saved — create a saved query
+- GET /query/saved — list user's saved queries
+- PUT /query/saved/{id} — update a saved query
+- DELETE /query/saved/{id} — delete a saved query
+- POST /query/saved/{id}/share — share a query
+- GET /query/shared — list shared queries
+- POST /query/saved/{id}/schedule — schedule a query
+- GET /query/schema — return schema metadata
+- Ownership checks (403 for non-owners)
+- 404 for non-existent queries
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt as pyjwt
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.deps import get_db, get_valkey
+from app.models.saved_query import SavedQuery as SavedQueryModel
+from app.routers import query as query_router_module
+
+SECRET = "testsecretkey_for_unit_tests_only_32ch"
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_jwt(
+    sub: str = "testuser",
+    jti: str = "test-jti",
+    expired: bool = False,
+) -> str:
+    now = datetime.now(UTC)
+    exp = now - timedelta(hours=1) if expired else now + timedelta(hours=1)
+    payload = {"sub": sub, "github_id": 12345, "jti": jti, "exp": exp, "iat": now}
+    return pyjwt.encode(payload, SECRET, algorithm="HS256")
+
+
+def _make_session(
+    login: str = "testuser",
+    roles: list[str] | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "github_login": login,
+            "github_id": 12345,
+            "roles": roles or ["analyst"],
+            "scoped_orgs": ["my-org"],
+            "scoped_repos": [],
+            "scope_type": "scoped",
+            "session_expires_at": "2099-01-01T00:00:00+00:00",
+        }
+    )
+
+
+def _make_mock_db() -> AsyncMock:
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.fetchall.return_value = []
+    mock_result.scalar_one_or_none.return_value = None
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=mock_result)
+    return db
+
+
+def _make_saved_query(
+    query_id: int = 1,
+    name: str = "Test Saved Query",
+    sql_text: str = "SELECT id FROM events LIMIT 10",
+    owner_login: str = "testuser",
+    description: str | None = None,
+    is_shared: bool = False,
+    shared_with: list[str] | None = None,
+    tags: list[str] | None = None,
+    schedule_cron: str | None = None,
+    schedule_enabled: bool = False,
+) -> SavedQueryModel:
+    """Create a SavedQueryModel instance for testing."""
+    now = datetime.now(UTC)
+    return SavedQueryModel(
+        id=query_id,
+        name=name,
+        description=description,
+        sql_text=sql_text,
+        owner_login=owner_login,
+        is_shared=is_shared,
+        shared_with=shared_with,
+        tags=tags,
+        schedule_cron=schedule_cron,
+        schedule_enabled=schedule_enabled,
+        last_run_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _build_query_app(
+    valkey_get_return: str | None = None,
+) -> tuple[FastAPI, AsyncMock, AsyncMock]:
+    app = FastAPI()
+    app.include_router(query_router_module.router, prefix="/api/v1")
+
+    mock_db = _make_mock_db()
+    mock_valkey = AsyncMock()
+    mock_valkey.get = AsyncMock(return_value=valkey_get_return)
+    mock_valkey.delete = AsyncMock(return_value=1)
+
+    async def override_db():
+        yield mock_db
+
+    async def override_valkey():
+        yield mock_valkey
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_valkey] = override_valkey
+
+    return app, mock_db, mock_valkey
+
+
+# ─── POST /query/saved ───────────────────────────────────────────────────────
+
+
+class TestCreateSavedQuery:
+    """Tests for POST /query/saved."""
+
+    def test_create_saved_query_success(self):
+        """POST /query/saved creates a new saved query."""
+        jti = "saved-create"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        now = datetime.now(UTC)
+
+        # After flush+refresh, the mock should return the saved object
+        mock_db.refresh = AsyncMock(return_value=None)
+
+        # Mock the add to capture the object
+        added_objects: list[SavedQueryModel] = []
+
+        def capture_add(obj: SavedQueryModel) -> None:
+            added_objects.append(obj)
+            # Set attributes that would be set by DB
+            obj.id = 1
+            obj.created_at = now
+            obj.updated_at = now
+            obj.is_shared = False
+            obj.schedule_enabled = False
+
+        mock_db.add = capture_add
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/v1/query/saved",
+            json={
+                "name": "My Query",
+                "description": "Test desc",
+                "sql_text": "SELECT id FROM events LIMIT 10",
+                "tags": ["security", "audit"],
+            },
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "My Query"
+        assert data["description"] == "Test desc"
+        assert data["owner_login"] == "testuser"
+        assert data["tags"] == ["security", "audit"]
+
+    def test_create_saved_query_no_auth(self):
+        """POST /query/saved without auth returns 401."""
+        app, _, _ = _build_query_app(valkey_get_return=None)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/v1/query/saved",
+            json={
+                "name": "x",
+                "sql_text": "SELECT id FROM events LIMIT 10",
+            },
+        )
+        assert resp.status_code == 401
+
+
+# ─── GET /query/saved ─────────────────────────────────────────────────────────
+
+
+class TestListSavedQueries:
+    """Tests for GET /query/saved."""
+
+    def test_list_saved_queries_empty(self):
+        """GET /query/saved returns empty list when no saved queries."""
+        jti = "saved-list-empty"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/v1/query/saved",
+            cookies={"access_token": token, "csrf_token": "tok"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_list_saved_queries_returns_data(self):
+        """GET /query/saved returns user's saved queries."""
+        jti = "saved-list-data"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        saved = _make_saved_query(query_id=1, name="Q1")
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [saved]
+        mock_db.execute = AsyncMock(return_value=result)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/v1/query/saved",
+            cookies={"access_token": token, "csrf_token": "tok"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "Q1"
+
+
+# ─── PUT /query/saved/{id} ───────────────────────────────────────────────────
+
+
+class TestUpdateSavedQuery:
+    """Tests for PUT /query/saved/{id}."""
+
+    def test_update_saved_query_not_found(self):
+        """PUT /query/saved/{id} returns 404 for non-existent query."""
+        jti = "saved-update-404"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.put(
+            "/api/v1/query/saved/999",
+            json={"name": "Updated"},
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 404
+
+    def test_update_saved_query_not_owner(self):
+        """PUT /query/saved/{id} returns 403 if not owner."""
+        jti = "saved-update-403"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        saved = _make_saved_query(query_id=1, owner_login="otheruser")
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = saved
+        mock_db.execute = AsyncMock(return_value=result)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.put(
+            "/api/v1/query/saved/1",
+            json={"name": "Updated"},
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 403
+
+
+# ─── DELETE /query/saved/{id} ─────────────────────────────────────────────────
+
+
+class TestDeleteSavedQuery:
+    """Tests for DELETE /query/saved/{id}."""
+
+    def test_delete_saved_query_not_found(self):
+        """DELETE /query/saved/{id} returns 404 for non-existent query."""
+        jti = "saved-del-404"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.delete(
+            "/api/v1/query/saved/999",
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 404
+
+    def test_delete_saved_query_not_owner(self):
+        """DELETE /query/saved/{id} returns 403 if not owner."""
+        jti = "saved-del-403"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        saved = _make_saved_query(query_id=1, owner_login="otheruser")
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = saved
+        mock_db.execute = AsyncMock(return_value=result)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.delete(
+            "/api/v1/query/saved/1",
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 403
+
+    def test_delete_saved_query_success(self):
+        """DELETE /query/saved/{id} returns 204 on success."""
+        jti = "saved-del-ok"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        saved = _make_saved_query(query_id=1, owner_login="testuser")
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = saved
+        mock_db.execute = AsyncMock(return_value=result)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.delete(
+            "/api/v1/query/saved/1",
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 204
+
+
+# ─── POST /query/saved/{id}/share ─────────────────────────────────────────────
+
+
+class TestShareQuery:
+    """Tests for POST /query/saved/{id}/share."""
+
+    def test_share_query_not_found(self):
+        """POST /query/saved/{id}/share returns 404 for non-existent query."""
+        jti = "share-404"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/v1/query/saved/999/share",
+            json={"logins": ["bob"]},
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 404
+
+    def test_share_query_not_owner(self):
+        """POST /query/saved/{id}/share returns 403 for non-owner."""
+        jti = "share-403"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        saved = _make_saved_query(query_id=1, owner_login="otheruser")
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = saved
+        mock_db.execute = AsyncMock(return_value=result)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/v1/query/saved/1/share",
+            json={"logins": ["bob"]},
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 403
+
+
+# ─── GET /query/shared ────────────────────────────────────────────────────────
+
+
+class TestListSharedQueries:
+    """Tests for GET /query/shared."""
+
+    def test_list_shared_queries_empty(self):
+        """GET /query/shared returns empty list by default."""
+        jti = "shared-list"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/v1/query/shared",
+            cookies={"access_token": token, "csrf_token": "tok"},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ─── POST /query/saved/{id}/schedule ──────────────────────────────────────────
+
+
+class TestScheduleQuery:
+    """Tests for POST /query/saved/{id}/schedule."""
+
+    def test_schedule_query_not_found(self):
+        """POST /query/saved/{id}/schedule returns 404 for non-existent query."""
+        jti = "sched-404"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/v1/query/saved/999/schedule",
+            json={"cron": "0 9 * * 1", "enabled": True},
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 404
+
+    def test_schedule_query_not_owner(self):
+        """POST /query/saved/{id}/schedule returns 403 for non-owner."""
+        jti = "sched-403"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, mock_db, _ = _build_query_app(valkey_get_return=session)
+
+        saved = _make_saved_query(query_id=1, owner_login="otheruser")
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = saved
+        mock_db.execute = AsyncMock(return_value=result)
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/api/v1/query/saved/1/schedule",
+            json={"cron": "0 9 * * 1", "enabled": True},
+            cookies={"access_token": token, "csrf_token": "tok"},
+            headers={"X-CSRF-Token": "tok"},
+        )
+        assert resp.status_code == 403
+
+
+# ─── GET /query/schema ────────────────────────────────────────────────────────
+
+
+class TestGetSchema:
+    """Tests for GET /query/schema."""
+
+    def test_get_schema_returns_tables(self):
+        """GET /query/schema returns allowed tables with columns."""
+        jti = "schema-get"
+        token = _make_jwt(jti=jti)
+        session = _make_session(roles=["analyst"])
+        app, _, _ = _build_query_app(valkey_get_return=session)
+
+        # Reset schema cache
+        query_router_module._SCHEMA_CACHE = None
+
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/v1/query/schema",
+            cookies={"access_token": token, "csrf_token": "tok"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        table_names = {t["table"] for t in data}
+        assert "events" in table_names
+        assert "detections" in table_names
+
+        # Check that events table has columns
+        events_table = next(t for t in data if t["table"] == "events")
+        col_names = {c["name"] for c in events_table["columns"]}
+        assert "id" in col_names
+        assert "action" in col_names
+        assert "actor" in col_names
+
+    def test_get_schema_no_auth(self):
+        """GET /query/schema without auth returns 401."""
+        app, _, _ = _build_query_app(valkey_get_return=None)
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/query/schema")
+        assert resp.status_code == 401

--- a/frontend/src/api/query.ts
+++ b/frontend/src/api/query.ts
@@ -4,6 +4,10 @@ import type {
   QueryRunResponse,
   QueryTemplate,
   QueryTemplateCreate,
+  SavedQuery,
+  SavedQueryCreate,
+  SavedQueryUpdate,
+  SchemaTable,
 } from '../types/query';
 
 export function runQuery(req: QueryRunRequest): Promise<QueryRunResponse> {
@@ -28,4 +32,43 @@ export function deleteTemplate(id: number): Promise<void> {
 
 export function runTemplate(id: number): Promise<QueryRunResponse> {
   return api.post<QueryRunResponse>(`/query/templates/${id}/run`);
+}
+
+// ── Saved Queries ────────────────────────────────────────────────────────────
+
+export function createSavedQuery(payload: SavedQueryCreate): Promise<SavedQuery> {
+  return api.post<SavedQuery>('/query/saved', payload);
+}
+
+export function listSavedQueries(): Promise<SavedQuery[]> {
+  return api.get<SavedQuery[]>('/query/saved');
+}
+
+export function updateSavedQuery(id: number, payload: SavedQueryUpdate): Promise<SavedQuery> {
+  return api.put<SavedQuery>(`/query/saved/${id}`, payload);
+}
+
+export function deleteSavedQuery(id: number): Promise<void> {
+  return api.delete<void>(`/query/saved/${id}`);
+}
+
+export function shareQuery(id: number, logins: string[]): Promise<SavedQuery> {
+  return api.post<SavedQuery>(`/query/saved/${id}/share`, { logins });
+}
+
+export function listSharedQueries(): Promise<SavedQuery[]> {
+  return api.get<SavedQuery[]>('/query/shared');
+}
+
+export function scheduleQuery(
+  id: number,
+  payload: { cron: string; enabled: boolean },
+): Promise<SavedQuery> {
+  return api.post<SavedQuery>(`/query/saved/${id}/schedule`, payload);
+}
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+export function getQuerySchema(): Promise<SchemaTable[]> {
+  return api.get<SchemaTable[]>('/query/schema');
 }

--- a/frontend/src/pages/Query/Query.module.css
+++ b/frontend/src/pages/Query/Query.module.css
@@ -562,3 +562,143 @@
   max-height: 60px;
   overflow: hidden;
 }
+
+/* ── Save Modal ──────────────────────────────────────────────────────────── */
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modalBox {
+  background: var(--canvas-default);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 20px;
+  width: 420px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modalTitle {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.modalLabel {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg-muted);
+}
+
+.modalInput {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  background: var(--canvas-subtle);
+  color: var(--fg);
+}
+
+.modalTextarea {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  background: var(--canvas-subtle);
+  color: var(--fg);
+  resize: vertical;
+  min-height: 60px;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+/* ── Saved Queries sidebar section ───────────────────────────────────────── */
+
+.savedQueryItem {
+  font-size: 13px;
+  padding: 4px 0;
+  cursor: pointer;
+  color: var(--fg);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.savedQueryItem:hover {
+  color: var(--accent);
+}
+
+.savedQueryActions {
+  margin-left: auto;
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+
+.savedQueryItem:hover .savedQueryActions {
+  opacity: 1;
+}
+
+.savedQueryActionBtn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 2px 4px;
+  color: var(--fg-muted);
+  border-radius: 4px;
+}
+
+.savedQueryActionBtn:hover {
+  color: var(--fg);
+  background: var(--canvas-default);
+}
+
+.sharedBadge {
+  font-size: 10px;
+  color: var(--fg-subtle);
+  font-style: italic;
+}
+
+/* ── Export buttons ──────────────────────────────────────────────────────── */
+
+.exportBar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+/* ── Schedule form ───────────────────────────────────────────────────────── */
+
+.scheduleSelect {
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  background: var(--canvas-subtle);
+  color: var(--fg);
+}
+
+.scheduleToggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}

--- a/frontend/src/pages/Query/Query.test.tsx
+++ b/frontend/src/pages/Query/Query.test.tsx
@@ -23,6 +23,27 @@ vi.mock('../../api/query', () => ({
     created_by: 'user',
     created_at: '2024-01-01T00:00:00Z',
   }),
+  listSavedQueries: vi.fn().mockResolvedValue([]),
+  createSavedQuery: vi.fn().mockResolvedValue({
+    id: 1,
+    name: 'Saved Q',
+    description: null,
+    sql_text: 'SELECT 1',
+    owner_login: 'user',
+    is_shared: false,
+    shared_with: null,
+    tags: null,
+    schedule_cron: null,
+    schedule_enabled: false,
+    last_run_at: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  }),
+  updateSavedQuery: vi.fn().mockResolvedValue({}),
+  deleteSavedQuery: vi.fn().mockResolvedValue(undefined),
+  shareQuery: vi.fn().mockResolvedValue({}),
+  listSharedQueries: vi.fn().mockResolvedValue([]),
+  scheduleQuery: vi.fn().mockResolvedValue({}),
 }));
 
 describe('QueryPage', () => {
@@ -47,7 +68,7 @@ describe('QueryPage', () => {
   it('renders Run, Save, and History toolbar buttons', () => {
     renderWithProviders(<QueryPage />);
     expect(screen.getByRole('button', { name: /Run/ })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Save/ })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'History' })).toBeInTheDocument();
   });
 
@@ -226,31 +247,25 @@ describe('QueryPage', () => {
 
   // --- Save Button ---
 
-  it('prompts for name and calls createTemplate when Save is clicked', async () => {
-    const { createTemplate } = await import('../../api/query');
+  it('opens save modal when Save button is clicked in toolbar', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'prompt').mockReturnValue('My saved query');
     renderWithProviders(<QueryPage />);
 
-    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await user.click(screen.getByRole('button', { name: /Save/ }));
 
-    expect(window.prompt).toHaveBeenCalledWith('Query name:', 'Untitled query');
-    expect(createTemplate).toHaveBeenCalledWith({
-      name: 'My saved query',
-      sql: expect.stringContaining('SELECT'),
-    });
+    expect(screen.getByText('Save Query')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('My query')).toBeInTheDocument();
   });
 
-  it('does not call createTemplate when prompt is cancelled', async () => {
-    const { createTemplate } = await import('../../api/query');
+  it('closes save modal when Cancel is clicked', async () => {
     const user = userEvent.setup();
-    vi.spyOn(window, 'prompt').mockReturnValue(null);
     renderWithProviders(<QueryPage />);
 
-    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await user.click(screen.getByRole('button', { name: /Save/ }));
+    expect(screen.getByText('Save Query')).toBeInTheDocument();
 
-    expect(window.prompt).toHaveBeenCalled();
-    expect(createTemplate).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Save Query')).not.toBeInTheDocument();
   });
 
   // --- History ---
@@ -1010,6 +1025,49 @@ describe('QueryPage', () => {
       });
 
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Save Modal ---
+
+  describe('Save Modal', () => {
+    it('opens save modal when Save button is clicked', async () => {
+      renderWithProviders(<QueryPage />);
+      const user = userEvent.setup();
+
+      const saveBtn = screen.getByRole('button', { name: /Save/ });
+      await user.click(saveBtn);
+
+      expect(screen.getByText('Save Query')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText('My query')).toBeInTheDocument();
+    });
+
+    it('closes save modal on Cancel', async () => {
+      renderWithProviders(<QueryPage />);
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: /Save/ }));
+      expect(screen.getByText('Save Query')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(screen.queryByText('Save Query')).not.toBeInTheDocument();
+    });
+  });
+
+  // --- Export ---
+
+  describe('Export', () => {
+    it('renders export buttons after query runs', async () => {
+      renderWithProviders(<QueryPage />);
+      const user = userEvent.setup();
+
+      await user.click(screen.getByRole('button', { name: /Run/ }));
+      await waitFor(() => {
+        expect(screen.getByText('1 row')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('button', { name: 'Export CSV' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Export JSON' })).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/Query/index.tsx
+++ b/frontend/src/pages/Query/index.tsx
@@ -1,11 +1,21 @@
-import { useState, useRef, useMemo } from 'react';
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
-import { runQuery, listTemplates, createTemplate } from '../../api/query';
+import {
+  runQuery,
+  listTemplates,
+  listSavedQueries,
+  createSavedQuery,
+  updateSavedQuery,
+  deleteSavedQuery,
+  shareQuery,
+  listSharedQueries,
+  scheduleQuery,
+} from '../../api/query';
 import { translateNLQuery } from '../../api/nlQuery';
 import type { NLInterpretation } from '../../api/nlQuery';
-import type { QueryRunResponse } from '../../types/query';
+import type { QueryRunResponse, SavedQuery } from '../../types/query';
 import { useToast } from '../../hooks/useToast';
 import { PageHeader } from '../../components/common/PageHeader';
 import { Button } from '../../components/primitives/Button';
@@ -842,6 +852,54 @@ function saveHistory(entries: HistoryEntry[]): void {
   localStorage.setItem(HISTORY_KEY, JSON.stringify(entries.slice(0, MAX_HISTORY)));
 }
 
+// ── Export Helpers ─────────────────────────────────────────────────────────────
+
+function exportCsv(columns: readonly string[], rows: readonly (readonly unknown[])[]): void {
+  const escape = (val: unknown): string => {
+    const s = val == null ? '' : String(val);
+    if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+      return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+  };
+  const header = columns.map(escape).join(',');
+  const body = rows.map((row) => row.map(escape).join(',')).join('\n');
+  const csv = `${header}\n${body}`;
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `query-results-${new Date().toISOString().slice(0, 19)}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function exportJson(columns: readonly string[], rows: readonly (readonly unknown[])[]): void {
+  const data = rows.map((row) => {
+    const obj: Record<string, unknown> = {};
+    columns.forEach((col, i) => {
+      obj[col] = row[i];
+    });
+    return obj;
+  });
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `query-results-${new Date().toISOString().slice(0, 19)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// ── Schedule helpers ──────────────────────────────────────────────────────────
+
+const SCHEDULE_PRESETS: { label: string; cron: string }[] = [
+  { label: 'Daily at 9 AM', cron: '0 9 * * *' },
+  { label: 'Weekly (Monday 9 AM)', cron: '0 9 * * 1' },
+  { label: 'Monthly (1st at 9 AM)', cron: '0 9 1 * *' },
+];
+
 export function QueryPage() {
   const [searchParams] = useSearchParams();
   const { showToast } = useToast();
@@ -859,6 +917,24 @@ export function QueryPage() {
   const queryClient = useQueryClient();
   const [nlInput, setNlInput] = useState('');
   const [nlResults, setNlResults] = useState<NLInterpretation[]>([]);
+
+  // ── Save modal state ────────────────────────────────────────────────────
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [saveName, setSaveName] = useState('');
+  const [saveDescription, setSaveDescription] = useState('');
+  const [saveTags, setSaveTags] = useState('');
+  const [editingQuery, setEditingQuery] = useState<SavedQuery | null>(null);
+
+  // ── Share modal state ──────────────────────────────────────────────────
+  const [showShareModal, setShowShareModal] = useState(false);
+  const [shareTargetId, setShareTargetId] = useState<number | null>(null);
+  const [shareLogins, setShareLogins] = useState('');
+
+  // ── Schedule modal state ──────────────────────────────────────────────
+  const [showScheduleModal, setShowScheduleModal] = useState(false);
+  const [scheduleTargetId, setScheduleTargetId] = useState<number | null>(null);
+  const [scheduleCron, setScheduleCron] = useState('0 9 * * 1');
+  const [scheduleEnabled, setScheduleEnabled] = useState(true);
 
   type QueryResultRow = Record<string, unknown>;
 
@@ -926,15 +1002,70 @@ export function QueryPage() {
     },
   });
 
-  const saveMutation = useMutation({
-    mutationFn: (name: string) => createTemplate({ name, sql }),
+  // ── Saved query queries/mutations ────────────────────────────────────
+  const { data: savedQueries } = useQuery({
+    queryKey: ['saved-queries'],
+    queryFn: listSavedQueries,
+  });
+
+  const { data: sharedQueries } = useQuery({
+    queryKey: ['shared-queries'],
+    queryFn: listSharedQueries,
+  });
+
+  const createSavedMutation = useMutation({
+    mutationFn: (payload: { name: string; description?: string; tags?: string[] }) =>
+      createSavedQuery({ ...payload, sql_text: sql }),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['query-templates'] });
-      showToast('Template saved successfully', 'success');
+      void queryClient.invalidateQueries({ queryKey: ['saved-queries'] });
+      showToast('Query saved', 'success');
+      setShowSaveModal(false);
     },
-    onError: () => {
-      showToast('Failed to save template', 'error');
+    onError: () => showToast('Failed to save query', 'error'),
+  });
+
+  const updateSavedMutation = useMutation({
+    mutationFn: (params: {
+      id: number;
+      payload: { name?: string; description?: string; sql_text?: string; tags?: string[] };
+    }) => updateSavedQuery(params.id, params.payload),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['saved-queries'] });
+      showToast('Query updated', 'success');
+      setShowSaveModal(false);
+      setEditingQuery(null);
     },
+    onError: () => showToast('Failed to update query', 'error'),
+  });
+
+  const deleteSavedMutation = useMutation({
+    mutationFn: deleteSavedQuery,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['saved-queries'] });
+      showToast('Query deleted', 'success');
+    },
+    onError: () => showToast('Failed to delete query', 'error'),
+  });
+
+  const shareMutation = useMutation({
+    mutationFn: (params: { id: number; logins: string[] }) => shareQuery(params.id, params.logins),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['saved-queries'] });
+      showToast('Query shared', 'success');
+      setShowShareModal(false);
+    },
+    onError: () => showToast('Failed to share query', 'error'),
+  });
+
+  const scheduleMutation = useMutation({
+    mutationFn: (params: { id: number; cron: string; enabled: boolean }) =>
+      scheduleQuery(params.id, { cron: params.cron, enabled: params.enabled }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['saved-queries'] });
+      showToast('Schedule updated', 'success');
+      setShowScheduleModal(false);
+    },
+    onError: () => showToast('Failed to update schedule', 'error'),
   });
 
   const nlMutation = useMutation({
@@ -1063,11 +1194,103 @@ export function QueryPage() {
   }
 
   function handleSave() {
-    const name = window.prompt('Query name:', 'Untitled query');
-    if (name) {
-      saveMutation.mutate(name);
-    }
+    setSaveName('');
+    setSaveDescription('');
+    setSaveTags('');
+    setEditingQuery(null);
+    setShowSaveModal(true);
   }
+
+  const handleSaveSubmit = useCallback(() => {
+    const tags = saveTags
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+    if (editingQuery) {
+      updateSavedMutation.mutate({
+        id: editingQuery.id,
+        payload: {
+          name: saveName,
+          description: saveDescription || undefined,
+          sql_text: sql,
+          tags: tags.length > 0 ? tags : undefined,
+        },
+      });
+    } else {
+      createSavedMutation.mutate({
+        name: saveName,
+        description: saveDescription || undefined,
+        tags: tags.length > 0 ? tags : undefined,
+      });
+    }
+  }, [
+    saveName,
+    saveDescription,
+    saveTags,
+    sql,
+    editingQuery,
+    createSavedMutation,
+    updateSavedMutation,
+  ]);
+
+  function handleEditSavedQuery(q: SavedQuery) {
+    setSaveName(q.name);
+    setSaveDescription(q.description ?? '');
+    setSaveTags(q.tags?.join(', ') ?? '');
+    setEditingQuery(q);
+    setSql(q.sql_text);
+    setShowSaveModal(true);
+  }
+
+  function handleLoadSavedQuery(q: SavedQuery) {
+    setSql(q.sql_text);
+    setAcItems([]);
+    setAcPartial('');
+  }
+
+  function handleOpenShare(id: number) {
+    setShareTargetId(id);
+    setShareLogins('');
+    setShowShareModal(true);
+  }
+
+  function handleShareSubmit() {
+    if (shareTargetId == null) return;
+    const logins = shareLogins
+      .split(',')
+      .map((l) => l.trim())
+      .filter(Boolean);
+    if (logins.length === 0) return;
+    shareMutation.mutate({ id: shareTargetId, logins });
+  }
+
+  function handleOpenSchedule(q: SavedQuery) {
+    setScheduleTargetId(q.id);
+    setScheduleCron(q.schedule_cron ?? '0 9 * * 1');
+    setScheduleEnabled(q.schedule_enabled);
+    setShowScheduleModal(true);
+  }
+
+  function handleScheduleSubmit() {
+    if (scheduleTargetId == null) return;
+    scheduleMutation.mutate({
+      id: scheduleTargetId,
+      cron: scheduleCron,
+      enabled: scheduleEnabled,
+    });
+  }
+
+  // Ctrl+S to save shortcut
+  useEffect(() => {
+    function handleGlobalKeyDown(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        handleSave();
+      }
+    }
+    window.addEventListener('keydown', handleGlobalKeyDown);
+    return () => window.removeEventListener('keydown', handleGlobalKeyDown);
+  }, []);
 
   function handleHistorySelect(entry: HistoryEntry) {
     setSql(entry.sql);
@@ -1196,6 +1419,89 @@ export function QueryPage() {
               ))}
             </>
           )}
+
+          {/* Saved Queries */}
+          {savedQueries && savedQueries.length > 0 && (
+            <>
+              <div className={styles.schemaTitle} style={{ marginTop: 16 }}>
+                Saved Queries
+              </div>
+              {savedQueries.map((q) => (
+                <div key={q.id} className={styles.savedQueryItem}>
+                  <span
+                    onClick={() => handleLoadSavedQuery(q)}
+                    title={q.description ?? q.name}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleLoadSavedQuery(q);
+                    }}
+                  >
+                    {q.name}
+                  </span>
+                  <span className={styles.savedQueryActions}>
+                    <button
+                      className={styles.savedQueryActionBtn}
+                      onClick={() => handleEditSavedQuery(q)}
+                      title="Edit query"
+                    >
+                      ✏️
+                    </button>
+                    <button
+                      className={styles.savedQueryActionBtn}
+                      onClick={() => handleOpenShare(q.id)}
+                      title="Share query"
+                    >
+                      🔗
+                    </button>
+                    <button
+                      className={styles.savedQueryActionBtn}
+                      onClick={() => handleOpenSchedule(q)}
+                      title="Schedule query"
+                    >
+                      ⏰
+                    </button>
+                    <button
+                      className={styles.savedQueryActionBtn}
+                      onClick={() => {
+                        if (window.confirm(`Delete "${q.name}"?`)) {
+                          deleteSavedMutation.mutate(q.id);
+                        }
+                      }}
+                      title="Delete query"
+                    >
+                      🗑️
+                    </button>
+                  </span>
+                </div>
+              ))}
+            </>
+          )}
+
+          {/* Shared With Me */}
+          {sharedQueries && sharedQueries.length > 0 && (
+            <>
+              <div className={styles.schemaTitle} style={{ marginTop: 16 }}>
+                Shared with Me
+              </div>
+              {sharedQueries.map((q) => (
+                <div key={q.id} className={styles.savedQueryItem}>
+                  <span
+                    onClick={() => handleLoadSavedQuery(q)}
+                    title={q.description ?? q.name}
+                    role="button"
+                    tabIndex={0}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleLoadSavedQuery(q);
+                    }}
+                  >
+                    {q.name}
+                  </span>
+                  <span className={styles.sharedBadge}>by {q.owner_login}</span>
+                </div>
+              ))}
+            </>
+          )}
         </div>
 
         {/* Editor */}
@@ -1223,10 +1529,10 @@ export function QueryPage() {
                 <Button
                   size="sm"
                   onClick={handleSave}
-                  disabled={saveMutation.isPending}
-                  title="Save this query as a reusable template"
+                  disabled={createSavedMutation.isPending}
+                  title={`Save this query (${IS_MAC ? '⌘' : 'Ctrl'}+S)`}
                 >
-                  {saveMutation.isPending ? '…' : 'Save'}
+                  {createSavedMutation.isPending ? '…' : '💾 Save'}
                 </Button>
                 <div className={styles.historyWrap}>
                   <Button
@@ -1346,6 +1652,22 @@ export function QueryPage() {
                 {results.truncated && (
                   <span style={{ color: 'var(--attention)' }}> (truncated)</span>
                 )}
+                <span className={styles.exportBar}>
+                  <Button
+                    size="sm"
+                    onClick={() => exportCsv(results.columns, results.rows)}
+                    title="Download results as CSV"
+                  >
+                    Export CSV
+                  </Button>
+                  <Button
+                    size="sm"
+                    onClick={() => exportJson(results.columns, results.rows)}
+                    title="Download results as JSON"
+                  >
+                    Export JSON
+                  </Button>
+                </span>
               </div>
               <div className={styles.resultsTable} ref={resultsTableRef}>
                 <DataTable<QueryResultRow>
@@ -1382,6 +1704,159 @@ export function QueryPage() {
           </p>
         </Drawer>
       )}
+
+      {/* Save Query Modal */}
+      {showSaveModal &&
+        createPortal(
+          <div
+            className={styles.modalOverlay}
+            onClick={() => setShowSaveModal(false)}
+            role="dialog"
+            aria-label="Save query"
+          >
+            <div className={styles.modalBox} onClick={(e) => e.stopPropagation()}>
+              <h3 className={styles.modalTitle}>
+                {editingQuery ? 'Edit Saved Query' : 'Save Query'}
+              </h3>
+              <label className={styles.modalLabel}>
+                Name
+                <input
+                  className={styles.modalInput}
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  placeholder="My query"
+                  autoFocus
+                />
+              </label>
+              <label className={styles.modalLabel}>
+                Description
+                <textarea
+                  className={styles.modalTextarea}
+                  value={saveDescription}
+                  onChange={(e) => setSaveDescription(e.target.value)}
+                  placeholder="What does this query do?"
+                />
+              </label>
+              <label className={styles.modalLabel}>
+                Tags (comma-separated)
+                <input
+                  className={styles.modalInput}
+                  value={saveTags}
+                  onChange={(e) => setSaveTags(e.target.value)}
+                  placeholder="security, audit, weekly"
+                />
+              </label>
+              <div className={styles.modalActions}>
+                <Button size="sm" onClick={() => setShowSaveModal(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={handleSaveSubmit}
+                  disabled={
+                    !saveName.trim() ||
+                    createSavedMutation.isPending ||
+                    updateSavedMutation.isPending
+                  }
+                >
+                  {editingQuery ? 'Update' : 'Save'}
+                </Button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+
+      {/* Share Query Modal */}
+      {showShareModal &&
+        createPortal(
+          <div
+            className={styles.modalOverlay}
+            onClick={() => setShowShareModal(false)}
+            role="dialog"
+            aria-label="Share query"
+          >
+            <div className={styles.modalBox} onClick={(e) => e.stopPropagation()}>
+              <h3 className={styles.modalTitle}>Share Query</h3>
+              <label className={styles.modalLabel}>
+                GitHub logins (comma-separated)
+                <input
+                  className={styles.modalInput}
+                  value={shareLogins}
+                  onChange={(e) => setShareLogins(e.target.value)}
+                  placeholder="alice, bob"
+                  autoFocus
+                />
+              </label>
+              <div className={styles.modalActions}>
+                <Button size="sm" onClick={() => setShowShareModal(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={handleShareSubmit}
+                  disabled={!shareLogins.trim() || shareMutation.isPending}
+                >
+                  {shareMutation.isPending ? '…' : 'Share'}
+                </Button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
+
+      {/* Schedule Query Modal */}
+      {showScheduleModal &&
+        createPortal(
+          <div
+            className={styles.modalOverlay}
+            onClick={() => setShowScheduleModal(false)}
+            role="dialog"
+            aria-label="Schedule query"
+          >
+            <div className={styles.modalBox} onClick={(e) => e.stopPropagation()}>
+              <h3 className={styles.modalTitle}>Schedule Query</h3>
+              <label className={styles.modalLabel}>
+                Frequency
+                <select
+                  className={styles.scheduleSelect}
+                  value={scheduleCron}
+                  onChange={(e) => setScheduleCron(e.target.value)}
+                >
+                  {SCHEDULE_PRESETS.map((p) => (
+                    <option key={p.cron} value={p.cron}>
+                      {p.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className={styles.scheduleToggle}>
+                <input
+                  type="checkbox"
+                  checked={scheduleEnabled}
+                  onChange={(e) => setScheduleEnabled(e.target.checked)}
+                />
+                Enabled
+              </label>
+              <div className={styles.modalActions}>
+                <Button size="sm" onClick={() => setShowScheduleModal(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  size="sm"
+                  variant="primary"
+                  onClick={handleScheduleSubmit}
+                  disabled={scheduleMutation.isPending}
+                >
+                  {scheduleMutation.isPending ? '…' : 'Save Schedule'}
+                </Button>
+              </div>
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   );
 }

--- a/frontend/src/types/query.ts
+++ b/frontend/src/types/query.ts
@@ -27,3 +27,47 @@ export interface QueryTemplateCreate {
   description?: string;
   sql: string;
 }
+
+// ── Saved Queries ────────────────────────────────────────────────────────────
+
+export interface SavedQuery {
+  readonly id: number;
+  readonly name: string;
+  readonly description: string | null;
+  readonly sql_text: string;
+  readonly owner_login: string;
+  readonly is_shared: boolean;
+  readonly shared_with: readonly string[] | null;
+  readonly tags: readonly string[] | null;
+  readonly schedule_cron: string | null;
+  readonly schedule_enabled: boolean;
+  readonly last_run_at: string | null;
+  readonly created_at: string;
+  readonly updated_at: string | null;
+}
+
+export interface SavedQueryCreate {
+  name: string;
+  description?: string;
+  sql_text: string;
+  tags?: string[];
+}
+
+export interface SavedQueryUpdate {
+  name?: string;
+  description?: string;
+  sql_text?: string;
+  tags?: string[];
+}
+
+// ── Schema ──────────────────────────────────────────────────────────────────
+
+export interface SchemaColumn {
+  readonly name: string;
+  readonly type: string;
+}
+
+export interface SchemaTable {
+  readonly table: string;
+  readonly columns: readonly SchemaColumn[];
+}


### PR DESCRIPTION
Saved queries CRUD, user sharing, CSV/JSON export, query scheduling, schema autocomplete. Migration 0053.
Closes #131