### PR TITLE
fix: Add threat intel feed refresh to celery beat schedule

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -108,6 +108,12 @@ app.config_from_object(
                 "schedule": crontab(hour=4, minute=0),
                 "options": {"queue": "baseline"},
             },
+            # Threat intel feed refresh — every 30 minutes
+            "refresh-threat-intel-feeds": {
+                "task": "app.workers.threat_intel_worker.refresh_threat_intel_feeds",
+                "schedule": crontab(minute="*/30"),
+                "options": {"queue": "baseline"},
+            },
         },
     }
 )


### PR DESCRIPTION
The threat intel feed refresh task was registered and routed to the `baseline` queue but had **no beat schedule entry**, so feeds were never refreshed automatically after being added via the UI.

### Problem
- User adds a feed → UI calls `POST /feeds/{id}/refresh` → sets `last_fetch_status = 'refreshing'` in DB
- Worker task exists but was never scheduled → feed stays stuck at 'Refreshing' forever
- Even if manually triggered via `send_task()`, baseline workers are saturated with workflow scans

### Fix
- Adds `refresh-threat-intel-feeds` to `beat_schedule` running every 30 minutes
- This matches the worker's query logic which checks for feeds with `last_fetched_at IS NULL OR overdue`