### PR TITLE
fix: Exec dashboard Metrics That Matter shows no data

### DIFF
--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -585,8 +585,7 @@ async def get_metrics_that_matter(
             JOIN (
                 SELECT repo, data->>'number' AS pr_num, created_at
                 FROM events
-                WHERE action = 'pull_request.closed'
-                  AND data->>'merged' = 'true'
+                WHERE action = 'pull_request.merged'
                   AND created_at >= :start
             ) c ON o.repo = c.repo AND o.pr_num = c.pr_num
             WHERE c.created_at > o.created_at
@@ -960,8 +959,7 @@ async def get_metrics_that_matter(
             COUNT(*) FILTER (WHERE actor LIKE '%%[bot]' OR actor LIKE '%%bot%%') * 100.0 /
             NULLIF(COUNT(*), 0) AS automation_rate_pct
         FROM events
-        WHERE action = 'pull_request.closed'
-          AND data->>'merged' = 'true'
+        WHERE action = 'pull_request.merged'
           AND created_at >= :start
           {org_filter}
     """)


### PR DESCRIPTION
## Problem
The 'Metrics That Matter' section on the executive dashboard shows no data. All PR lifecycle and automation metrics return null.

## Root Cause
The SQL queries join `pull_request.opened` events to `pull_request.closed` events filtered by `data->>'merged' = 'true'`. However, OctoWatch ingests merged PRs as **`pull_request.merged`** action events — not as `pull_request.closed` with a merged flag. Zero `pull_request.closed` events have `merged=true` in the database, so the join always returns empty.

## Fix
Changed two queries in `report_service.py` to join/filter on `action = 'pull_request.merged'` instead:
1. PR lifecycle calculation (avg hours open→merge)
2. Automation merge rate (bot vs human merge ratio)

Two other `pull_request.closed` queries (lines 704, 771) were left unchanged as they correctly count closed PRs regardless of merge status.