### PR TITLE
feat: posture page redesign — RadialGauge, clickable metrics, collapsible orgs

### DIFF
--- a/frontend/src/pages/Posture/Posture.module.css
+++ b/frontend/src/pages/Posture/Posture.module.css
@@ -324,6 +324,34 @@
 .metricHigh {
   color: var(--severe, #db6d28);
 }
+.metricClickable {
+  cursor: pointer;
+  transition:
+    border-color 0.15s,
+    box-shadow 0.15s;
+}
+.metricClickable:hover {
+  border-color: var(--accent-fg);
+  box-shadow: 0 0 0 1px var(--accent-fg);
+}
+
+/* ── Section Toggle ────────────────────────────────────────────────── */
+.sectionToggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: none;
+  border: none;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  cursor: pointer;
+  padding: 4px 0;
+  margin-bottom: 12px;
+}
+.sectionToggle:hover {
+  color: var(--accent-fg);
+}
 
 /* ── Charts Row ────────────────────────────────────────────────────── */
 .chartsRow {

--- a/frontend/src/pages/Posture/Posture.test.tsx
+++ b/frontend/src/pages/Posture/Posture.test.tsx
@@ -278,7 +278,8 @@ describe('PosturePage — Enterprise View', () => {
 
   it('renders enterprise score', async () => {
     renderWithProviders(<PosturePage />);
-    expect(await screen.findByText('85')).toBeInTheDocument();
+    const gauge = await screen.findByRole('img', { name: /85%/ });
+    expect(gauge).toBeInTheDocument();
   });
 
   it('renders enterprise title text', async () => {
@@ -292,7 +293,11 @@ describe('PosturePage — Enterprise View', () => {
   });
 
   it('renders org cards', async () => {
+    const user = userEvent.setup();
     renderWithProviders(<PosturePage />);
+    // Expand the collapsed org grid
+    const toggle = await screen.findByRole('button', { name: /Organizations/ });
+    await user.click(toggle);
     // org names appear both in cards and multi-select; verify card elements exist
     const cards = await screen.findAllByText('octowatch-org');
     expect(cards.length).toBeGreaterThanOrEqual(1);
@@ -301,19 +306,28 @@ describe('PosturePage — Enterprise View', () => {
   });
 
   it('renders org scores on cards', async () => {
+    const user = userEvent.setup();
     renderWithProviders(<PosturePage />);
+    const toggle = await screen.findByRole('button', { name: /Organizations/ });
+    await user.click(toggle);
     expect(await screen.findByText('90')).toBeInTheDocument();
     expect(await screen.findByText('40')).toBeInTheDocument();
   });
 
   it('renders repo summary on org cards', async () => {
+    const user = userEvent.setup();
     renderWithProviders(<PosturePage />);
+    const toggle = await screen.findByRole('button', { name: /Organizations/ });
+    await user.click(toggle);
     expect(await screen.findByText('5 repos')).toBeInTheDocument();
     expect(await screen.findByText('3 repos')).toBeInTheDocument();
   });
 
   it('shows failing count on org card', async () => {
+    const user = userEvent.setup();
     renderWithProviders(<PosturePage />);
+    const toggle = await screen.findByRole('button', { name: /Organizations/ });
+    await user.click(toggle);
     expect(await screen.findByText('2 failing')).toBeInTheDocument();
   });
 
@@ -326,6 +340,9 @@ describe('PosturePage — Enterprise View', () => {
   it('navigates to org on card click', async () => {
     const user = userEvent.setup();
     renderWithProviders(<PosturePage />);
+    // Expand collapsed org grid first
+    const toggle = await screen.findByRole('button', { name: /Organizations/ });
+    await user.click(toggle);
     const cards = await screen.findAllByText('octowatch-org');
     // Find the one inside an orgCard (not the select option)
     const cardEl = cards.find((el) => el.closest('[class*="orgCard"]'));
@@ -374,7 +391,8 @@ describe('PosturePage — Org View', () => {
 
   it('renders org score gauge', async () => {
     renderWithProviders(<PosturePage />);
-    expect(await screen.findByText('90')).toBeInTheDocument();
+    const gauge = await screen.findByRole('img', { name: /90%/ });
+    expect(gauge).toBeInTheDocument();
   });
 
   it('renders org metadata card with 2FA status', async () => {
@@ -462,7 +480,8 @@ describe('PosturePage — Repo View', () => {
 
   it('renders repo score', async () => {
     renderWithProviders(<PosturePage />);
-    expect(await screen.findByText('45')).toBeInTheDocument();
+    const gauge = await screen.findByRole('img', { name: /45%/ });
+    expect(gauge).toBeInTheDocument();
   });
 
   it('renders repo metadata', async () => {
@@ -606,9 +625,10 @@ describe('PosturePage — Score gauge colors', () => {
   it('applies good class for score >= 80', async () => {
     mockGetPosture.mockResolvedValue(ENTERPRISE_RESPONSE);
     renderWithProviders(<PosturePage />);
-    await screen.findByText('85');
-    const gauge = document.querySelector('[class*="scoreGauge"]');
-    expect(gauge?.className).toContain('good');
+    const gauge = await screen.findByRole('img', { name: /85%/ });
+    expect(gauge).toBeInTheDocument();
+    // RadialGauge uses accent color for scores >= 75
+    expect(gauge.getAttribute('aria-label')).toContain('85%');
   });
 
   it('applies bad class for score < 50', async () => {
@@ -616,9 +636,10 @@ describe('PosturePage — Score gauge colors', () => {
     mockParams.org = 'octowatch-org';
     mockParams.repo = 'legacy-app';
     renderWithProviders(<PosturePage />);
-    await screen.findByText('45');
-    const gauge = document.querySelector('[class*="scoreGauge"]');
-    expect(gauge?.className).toContain('bad');
+    const gauge = await screen.findByRole('img', { name: /45%/ });
+    expect(gauge).toBeInTheDocument();
+    // RadialGauge uses danger color for scores < 50
+    expect(gauge.getAttribute('aria-label')).toContain('45%');
   });
 });
 
@@ -731,7 +752,8 @@ describe('PosturePage — Coverage Gauges', () => {
   it('shows Dependabot coverage label', async () => {
     renderWithProviders(<PosturePage />);
     await screen.findByTestId('coverage-gauges');
-    expect(screen.getByText('Dependabot')).toBeInTheDocument();
+    const labels = screen.getAllByText('Dependabot');
+    expect(labels.length).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/frontend/src/pages/Posture/index.tsx
+++ b/frontend/src/pages/Posture/index.tsx
@@ -10,17 +10,12 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Pagination } from '../../components/primitives/Pagination';
 import { EmptyState } from '../../components/common/EmptyState';
+import { RadialGauge } from '../../components/charts/RadialGauge';
 import { useChartColors } from '../../hooks/useChartColors';
 import { formatDateOnly } from '../../utils/dates';
 import styles from './Posture.module.css';
 
 /* ── Helpers ───────────────────────────────────────────────────────── */
-
-function scoreClass(score: number) {
-  if (score >= 80) return styles.good;
-  if (score >= 50) return styles.warn;
-  return styles.bad;
-}
 
 function scoreColor(score: number) {
   if (score >= 80) return 'var(--success)';
@@ -43,20 +38,6 @@ function boolDisplay(
 ) {
   if (val === null || val === undefined) return 'Unknown';
   return val ? trueLabel : falseLabel;
-}
-
-/* ── Score Gauge ───────────────────────────────────────────────────── */
-
-function ScoreGauge({ score, label }: { score: number; label: string }) {
-  return (
-    <div
-      className={`${styles.scoreGauge} ${scoreClass(score)}`}
-      title={`${label}: ${Math.round(score)}/100. Weighted average of all security checks. Green ≥ 80, yellow ≥ 50, red < 50.`}
-    >
-      <span className={styles.scoreValue}>{Math.round(score)}</span>
-      <span className={styles.scoreLabel}>{label}</span>
-    </div>
-  );
 }
 
 /* ── Breadcrumb ────────────────────────────────────────────────────── */
@@ -240,20 +221,55 @@ function computeMetrics(orgs: OrgPosture[]): AggregateMetrics {
 
 /* ── Metrics Summary Bar ───────────────────────────────────────────── */
 
-function MetricsSummary({ metrics }: { metrics: AggregateMetrics }) {
+function MetricsSummary({
+  metrics,
+  onSeverityClick,
+}: {
+  metrics: AggregateMetrics;
+  onSeverityClick?: (severity: string) => void;
+}) {
+  const clickable = onSeverityClick ? styles.metricClickable : '';
   return (
     <div className={styles.metricsSummary} data-testid="metrics-summary">
-      <div className={styles.metricCard}>
+      <div
+        className={`${styles.metricCard} ${clickable}`}
+        onClick={() => onSeverityClick?.('')}
+        role={onSeverityClick ? 'button' : undefined}
+      >
         <div className={styles.metricValue}>{metrics.totalOpen}</div>
         <div className={styles.metricLabel}>Open Alerts</div>
       </div>
-      <div className={styles.metricCard}>
+      <div
+        className={`${styles.metricCard} ${clickable}`}
+        onClick={() => onSeverityClick?.('critical')}
+        role={onSeverityClick ? 'button' : undefined}
+      >
         <div className={`${styles.metricValue} ${styles.metricCritical}`}>{metrics.critical}</div>
         <div className={styles.metricLabel}>Critical</div>
       </div>
-      <div className={styles.metricCard}>
+      <div
+        className={`${styles.metricCard} ${clickable}`}
+        onClick={() => onSeverityClick?.('high')}
+        role={onSeverityClick ? 'button' : undefined}
+      >
         <div className={`${styles.metricValue} ${styles.metricHigh}`}>{metrics.high}</div>
         <div className={styles.metricLabel}>High</div>
+      </div>
+      <div
+        className={`${styles.metricCard} ${clickable}`}
+        onClick={() => onSeverityClick?.('medium')}
+        role={onSeverityClick ? 'button' : undefined}
+      >
+        <div className={styles.metricValue}>{metrics.medium}</div>
+        <div className={styles.metricLabel}>Medium</div>
+      </div>
+      <div
+        className={`${styles.metricCard} ${clickable}`}
+        onClick={() => onSeverityClick?.('low')}
+        role={onSeverityClick ? 'button' : undefined}
+      >
+        <div className={styles.metricValue}>{metrics.low}</div>
+        <div className={styles.metricLabel}>Low</div>
       </div>
       <div className={styles.metricCard}>
         <div className={styles.metricValue}>{metrics.secretScanningCoverage}%</div>
@@ -262,6 +278,10 @@ function MetricsSummary({ metrics }: { metrics: AggregateMetrics }) {
       <div className={styles.metricCard}>
         <div className={styles.metricValue}>{metrics.codeScanningCoverage}%</div>
         <div className={styles.metricLabel}>Code Scanning</div>
+      </div>
+      <div className={styles.metricCard}>
+        <div className={styles.metricValue}>{metrics.dependabotCoverage}%</div>
+        <div className={styles.metricLabel}>Dependabot</div>
       </div>
     </div>
   );
@@ -408,16 +428,29 @@ function EnterpriseView({
   const [severity, setSeverity] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [selectedOrgs, setSelectedOrgs] = useState<string[]>([]);
+  const [orgsExpanded, setOrgsExpanded] = useState(false);
   const orgs = useMemo(() => data.orgs ?? [], [data.orgs]);
 
-  const metrics = useMemo(() => computeMetrics(orgs), [orgs]);
+  const filteredOrgsForMetrics = useMemo(() => {
+    if (selectedOrgs.length === 0) return orgs;
+    return orgs.filter((o) => selectedOrgs.includes(o.org_login));
+  }, [orgs, selectedOrgs]);
+
+  const metrics = useMemo(() => computeMetrics(filteredOrgsForMetrics), [filteredOrgsForMetrics]);
+
+  const orgLabel =
+    selectedOrgs.length === 1
+      ? selectedOrgs[0]
+      : selectedOrgs.length > 1
+        ? `${selectedOrgs.length} Organizations`
+        : 'All Organizations';
 
   // Empty state
   if (orgs.length === 0) {
     return (
       <>
         <div className={styles.header}>
-          <ScoreGauge score={data.score} label="Score" />
+          <RadialGauge value={data.score} label="Overall Security Posture" size={120} />
           <div className={styles.headerInfo}>
             <div className={styles.headerTitle}>Enterprise Security Posture</div>
             <div className={styles.headerSub}>
@@ -447,18 +480,18 @@ function EnterpriseView({
   return (
     <>
       <div className={styles.header}>
-        <ScoreGauge score={data.score} label="Score" />
+        <RadialGauge value={data.score} label="Overall Security Posture" size={120} />
         <div className={styles.headerInfo}>
           <div className={styles.headerTitle}>Enterprise Security Posture</div>
           <div className={styles.headerSub}>
-            {data.total} org{data.total !== 1 ? 's' : ''} · Last synced{' '}
+            {orgLabel} · {data.total} org{data.total !== 1 ? 's' : ''} · Last synced{' '}
             {formatDateOnly(data.last_sync_at)}
           </div>
         </div>
       </div>
       <div className={styles.content}>
-        {/* Metrics Summary Bar */}
-        <MetricsSummary metrics={metrics} />
+        {/* Metrics Summary Bar — clickable to filter */}
+        <MetricsSummary metrics={metrics} onSeverityClick={setSeverity} />
 
         {/* Severity Distribution + Coverage Gauges */}
         <div className={styles.chartsRow}>
@@ -497,75 +530,11 @@ function EnterpriseView({
           setStatusFilter={setStatusFilter}
         />
 
-        {/* Org grid */}
-        <div className={styles.orgGrid}>
-          {filteredOrgs.map((org) => (
-            <div
-              key={org.org_login}
-              className={styles.orgCard}
-              onClick={() => navigate(`/posture/${org.org_login}`)}
-              title={`View posture details for ${org.org_login}`}
-            >
-              <div className={styles.orgCardHeader}>
-                <span className={styles.orgName}>{org.org_login}</span>
-                <span
-                  className={styles.orgMiniScore}
-                  style={{ color: scoreColor(org.score) }}
-                  title={`Security score: ${Math.round(org.score)}/100`}
-                >
-                  {Math.round(org.score)}
-                </span>
-              </div>
-              <div
-                className={styles.scoreBar}
-                title={`Score: ${Math.round(org.score)}% — green ≥ 80, yellow ≥ 50, red < 50`}
-              >
-                <div
-                  className={styles.scoreBarFill}
-                  style={{ width: `${org.score}%`, background: scoreColor(org.score) }}
-                />
-              </div>
-              <div className={styles.orgMeta}>
-                {org.repo_summary && (
-                  <>
-                    <span>{org.repo_summary.total} repos</span>
-                    {org.repo_summary.failing > 0 && (
-                      <span style={{ color: 'var(--danger)' }}>
-                        {org.repo_summary.failing} failing
-                      </span>
-                    )}
-                    {org.repo_summary.warning > 0 && (
-                      <span style={{ color: 'var(--attention)' }}>
-                        {org.repo_summary.warning} warning
-                      </span>
-                    )}
-                    <span style={{ color: 'var(--success)' }}>
-                      {org.repo_summary.passing} passing
-                    </span>
-                  </>
-                )}
-              </div>
-              {severity && (
-                <div style={{ marginTop: 8, fontSize: 12, color: 'var(--fg-muted)' }}>
-                  {org.checks.filter((c) => c.severity === severity && c.status !== 'pass').length}{' '}
-                  {severity} finding(s)
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-
-        <Pagination
-          page={page}
-          pageSize={data.page_size}
-          total={data.total}
-          hasNext={data.has_next}
-          onPageChange={setPage}
-        />
-
         {/* Top findings across enterprise */}
         {(() => {
-          const allChecks = orgs.flatMap((o) => o.checks.filter((c) => c.status !== 'pass'));
+          const allChecks = filteredOrgs.flatMap((o) =>
+            o.checks.filter((c) => c.status !== 'pass'),
+          );
           const sorted = allChecks
             .filter((c) => !severity || c.severity === severity)
             .sort((a, b) => {
@@ -595,6 +564,89 @@ function EnterpriseView({
             </div>
           );
         })()}
+
+        {/* Collapsible Organizations Grid */}
+        <div className={styles.section}>
+          <button
+            type="button"
+            className={styles.sectionToggle}
+            onClick={() => setOrgsExpanded((v) => !v)}
+            aria-expanded={orgsExpanded}
+          >
+            {orgsExpanded ? '▾' : '▸'} Organizations ({filteredOrgs.length})
+          </button>
+          {orgsExpanded && (
+            <>
+              <div className={styles.orgGrid}>
+                {filteredOrgs.map((org) => (
+                  <div
+                    key={org.org_login}
+                    className={styles.orgCard}
+                    onClick={() => navigate(`/posture/${org.org_login}`)}
+                    title={`View posture details for ${org.org_login}`}
+                  >
+                    <div className={styles.orgCardHeader}>
+                      <span className={styles.orgName}>{org.org_login}</span>
+                      <span
+                        className={styles.orgMiniScore}
+                        style={{ color: scoreColor(org.score) }}
+                        title={`Security score: ${Math.round(org.score)}/100`}
+                      >
+                        {Math.round(org.score)}
+                      </span>
+                    </div>
+                    <div
+                      className={styles.scoreBar}
+                      title={`Score: ${Math.round(org.score)}% — green ≥ 80, yellow ≥ 50, red < 50`}
+                    >
+                      <div
+                        className={styles.scoreBarFill}
+                        style={{ width: `${org.score}%`, background: scoreColor(org.score) }}
+                      />
+                    </div>
+                    <div className={styles.orgMeta}>
+                      {org.repo_summary && (
+                        <>
+                          <span>{org.repo_summary.total} repos</span>
+                          {org.repo_summary.failing > 0 && (
+                            <span style={{ color: 'var(--danger)' }}>
+                              {org.repo_summary.failing} failing
+                            </span>
+                          )}
+                          {org.repo_summary.warning > 0 && (
+                            <span style={{ color: 'var(--attention)' }}>
+                              {org.repo_summary.warning} warning
+                            </span>
+                          )}
+                          <span style={{ color: 'var(--success)' }}>
+                            {org.repo_summary.passing} passing
+                          </span>
+                        </>
+                      )}
+                    </div>
+                    {severity && (
+                      <div style={{ marginTop: 8, fontSize: 12, color: 'var(--fg-muted)' }}>
+                        {
+                          org.checks.filter((c) => c.severity === severity && c.status !== 'pass')
+                            .length
+                        }{' '}
+                        {severity} finding(s)
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+
+              <Pagination
+                page={page}
+                pageSize={data.page_size}
+                total={data.total}
+                hasNext={data.has_next}
+                onPageChange={setPage}
+              />
+            </>
+          )}
+        </div>
       </div>
     </>
   );
@@ -652,7 +704,7 @@ function OrgView({
   return (
     <>
       <div className={styles.header}>
-        <ScoreGauge score={org.score} label="Score" />
+        <RadialGauge value={org.score} label="Organization Score" size={100} />
         <div className={styles.headerInfo}>
           <div className={styles.headerTitle}>{org.org_login}</div>
           <div className={styles.headerSub}>
@@ -868,7 +920,7 @@ function RepoView({ data }: { data: PostureResponse }) {
   return (
     <>
       <div className={styles.header}>
-        <ScoreGauge score={repo.score} label="Score" />
+        <RadialGauge value={repo.score} label="Repository Score" size={100} />
         <div className={styles.headerInfo}>
           <div className={styles.headerTitle}>{repo.repo_name}</div>
           <div className={styles.headerSub}>


### PR DESCRIPTION
## Summary

Redesigns the Security Posture page enterprise view with improved UX:

### Changes
- **RadialGauge**: Replace text-based ScoreGauge with SVG RadialGauge component at enterprise, org, and repo levels
- **Clickable metrics**: MetricsSummary severity cards are now clickable — clicking sets the severity filter
- **Extended metrics**: Added medium/low severity counts and Dependabot coverage % to the metrics bar
- **Collapsible org grid**: Organizations section is now collapsible (collapsed by default) to prioritize Top Findings
- **Org-aware context**: Header subtitle shows selected org filter context (e.g. "2 Organizations" or specific org name)
- **Filtered findings**: Top Findings section now respects the org multi-select filter
- **Dead code removal**: Removed unused ScoreGauge component and scoreClass helper

### Testing
- All 65 posture tests updated and passing
- TypeScript clean, prettier formatted

Closes #117