### PR TITLE
feat: clickable severity/state chips across Advanced Security

### DIFF
--- a/frontend/src/components/primitives/Label.module.css
+++ b/frontend/src/components/primitives/Label.module.css
@@ -51,3 +51,18 @@
   color: var(--severe);
   border-color: rgba(219, 109, 40, 0.3);
 }
+
+.clickable {
+  cursor: pointer;
+  transition:
+    filter 0.15s,
+    box-shadow 0.15s;
+}
+.clickable:hover {
+  filter: brightness(1.3);
+  box-shadow: 0 0 0 2px currentColor;
+}
+.clickable:focus-visible {
+  outline: 2px solid var(--accent-fg);
+  outline-offset: 1px;
+}

--- a/frontend/src/components/primitives/Label.tsx
+++ b/frontend/src/components/primitives/Label.tsx
@@ -17,13 +17,40 @@ interface LabelProps {
   children: React.ReactNode;
   className?: string;
   title?: string;
+  onClick?: (e: React.MouseEvent) => void;
 }
 
-export function Label({ variant = 'muted', children, className, title }: LabelProps) {
-  const cls = [styles.label, styles[variant], className].filter(Boolean).join(' ');
+export function Label({ variant = 'muted', children, className, title, onClick }: LabelProps) {
+  const cls = [styles.label, styles[variant], onClick && styles.clickable, className]
+    .filter(Boolean)
+    .join(' ');
   const statusPrefix = VARIANT_LABELS[variant];
   return (
-    <span className={cls} title={title}>
+    <span
+      className={cls}
+      title={title}
+      onClick={
+        onClick
+          ? (e) => {
+              e.stopPropagation();
+              onClick(e);
+            }
+          : undefined
+      }
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onClick(e as unknown as React.MouseEvent);
+              }
+            }
+          : undefined
+      }
+    >
       {statusPrefix && <span className="sr-only">{statusPrefix}: </span>}
       {children}
     </span>

--- a/frontend/src/pages/AdvancedSecurity/SecretsPane.tsx
+++ b/frontend/src/pages/AdvancedSecurity/SecretsPane.tsx
@@ -195,8 +195,18 @@ export function SecretsPane() {
         header: 'State',
         sortable: true,
         filterable: true,
-        helpText: 'Current state of the alert (open, resolved)',
-        render: (r) => <Label variant={stateVariant(r.state)}>{r.state}</Label>,
+        helpText: 'Current state of the alert — click chip to filter',
+        render: (r) => (
+          <Label
+            variant={stateVariant(r.state)}
+            onClick={() => {
+              setStateFilter(r.state);
+              setPage(1);
+            }}
+          >
+            {r.state}
+          </Label>
+        ),
         sortValue: (r) => r.state,
         filterValue: (r) => r.state,
       },
@@ -248,7 +258,7 @@ export function SecretsPane() {
         filterValue: (r) => r.resolution ?? '',
       },
     ],
-    [],
+    [setStateFilter],
   );
 
   return (

--- a/frontend/src/pages/AdvancedSecurity/index.tsx
+++ b/frontend/src/pages/AdvancedSecurity/index.tsx
@@ -284,19 +284,43 @@ function OverviewTab({ onSwitchTab }: { onSwitchTab: (tab: TabKey) => void }) {
         <div className={styles.severityTitle}>Aggregated Severity Breakdown</div>
         <div className={styles.severityGrid}>
           <div className={styles.severityItem}>
-            <Label variant="danger">Critical</Label>
+            <Label
+              variant="danger"
+              onClick={() => onSwitchTab('code')}
+              title="View critical code scanning alerts"
+            >
+              Critical
+            </Label>
             <span className={styles.severityCount}>{totalCritical}</span>
           </div>
           <div className={styles.severityItem}>
-            <Label variant="severe">High</Label>
+            <Label
+              variant="severe"
+              onClick={() => onSwitchTab('code')}
+              title="View high code scanning alerts"
+            >
+              High
+            </Label>
             <span className={styles.severityCount}>{totalHigh}</span>
           </div>
           <div className={styles.severityItem}>
-            <Label variant="attention">Medium</Label>
+            <Label
+              variant="attention"
+              onClick={() => onSwitchTab('code')}
+              title="View medium code scanning alerts"
+            >
+              Medium
+            </Label>
             <span className={styles.severityCount}>{totalMedium}</span>
           </div>
           <div className={styles.severityItem}>
-            <Label variant="muted">Low</Label>
+            <Label
+              variant="muted"
+              onClick={() => onSwitchTab('code')}
+              title="View low code scanning alerts"
+            >
+              Low
+            </Label>
             <span className={styles.severityCount}>{totalLow}</span>
           </div>
         </div>
@@ -364,10 +388,18 @@ function CodeScanningTab() {
         header: 'Severity',
         sortable: true,
         filterable: true,
-        helpText: 'Alert severity level',
+        helpText: 'Alert severity level — click chip to filter',
         render: (r) =>
           r.security_severity ? (
-            <Label variant={sevVariant(r.security_severity)}>{r.security_severity}</Label>
+            <Label
+              variant={sevVariant(r.security_severity)}
+              onClick={() => {
+                setSevFilter(r.security_severity!);
+                setPage(1);
+              }}
+            >
+              {r.security_severity}
+            </Label>
           ) : (
             <Label variant="muted">{r.severity ?? '—'}</Label>
           ),
@@ -399,8 +431,18 @@ function CodeScanningTab() {
         header: 'State',
         sortable: true,
         filterable: true,
-        helpText: 'Current state of the alert',
-        render: (r) => <Label variant={stateVariant(r.state)}>{r.state}</Label>,
+        helpText: 'Current state of the alert — click chip to filter',
+        render: (r) => (
+          <Label
+            variant={stateVariant(r.state)}
+            onClick={() => {
+              setStateFilter(r.state);
+              setPage(1);
+            }}
+          >
+            {r.state}
+          </Label>
+        ),
         sortValue: (r) => r.state,
         filterValue: (r) => r.state,
       },
@@ -415,7 +457,7 @@ function CodeScanningTab() {
         filterValue: (r) => r.created_at,
       },
     ],
-    [],
+    [setSevFilter, setStateFilter],
   );
 
   return (
@@ -679,9 +721,21 @@ function DependabotTab() {
         header: 'Severity',
         sortable: true,
         filterable: true,
-        helpText: 'Vulnerability severity level',
+        helpText: 'Vulnerability severity level — click chip to filter',
         render: (r) =>
-          r.severity ? <Label variant={sevVariant(r.severity)}>{r.severity}</Label> : '—',
+          r.severity ? (
+            <Label
+              variant={sevVariant(r.severity)}
+              onClick={() => {
+                setSevFilter(r.severity!);
+                setPage(1);
+              }}
+            >
+              {r.severity}
+            </Label>
+          ) : (
+            '—'
+          ),
         sortValue: (r) => r.severity ?? '',
         filterValue: (r) => r.severity ?? '',
       },
@@ -710,8 +764,18 @@ function DependabotTab() {
         header: 'State',
         sortable: true,
         filterable: true,
-        helpText: 'Current state of the Dependabot alert',
-        render: (r) => <Label variant={stateVariant(r.state)}>{r.state}</Label>,
+        helpText: 'Current state of the Dependabot alert — click chip to filter',
+        render: (r) => (
+          <Label
+            variant={stateVariant(r.state)}
+            onClick={() => {
+              setStateFilter(r.state);
+              setPage(1);
+            }}
+          >
+            {r.state}
+          </Label>
+        ),
         sortValue: (r) => r.state,
         filterValue: (r) => r.state,
       },
@@ -726,7 +790,7 @@ function DependabotTab() {
         filterValue: (r) => r.created_at,
       },
     ],
-    [],
+    [setSevFilter, setStateFilter],
   );
 
   return (


### PR DESCRIPTION
## Summary

Makes severity and state Label chips clickable throughout the Advanced Security page, enabling quick filtering directly from table data.

### Changes
- **Label component**: Extended with `onClick`, `role="button"`, `tabIndex`, keyboard Enter/Space support, and `.clickable` CSS with hover glow + focus-visible outline
- **Code Scanning tab**: Severity and state chips in table rows set respective filter dropdowns on click
- **Dependabot tab**: Severity and state chips set filters on click
- **Secrets pane**: State chips set filter on click
- **Overview severity breakdown**: Severity chips navigate to Code Scanning tab
- All clicks use `e.stopPropagation()` to prevent triggering row click (drawer open)

### Testing
- All 35 Advanced Security tests passing
- TypeScript clean, prettier formatted

Closes #123