### PR TITLE
perf: switch Events Explorer to cursor-based pagination

### DIFF
--- a/frontend/src/pages/Events/Events.test.tsx
+++ b/frontend/src/pages/Events/Events.test.tsx
@@ -473,12 +473,14 @@ describe('EventsPage', () => {
       page: 1,
       page_size: 20,
       has_next: true,
+      count_is_estimated: false,
+      next_cursor: 'cursor_abc',
     });
 
     renderWithProviders(<EventsPage />);
     await screen.findByText('repo.create');
 
-    expect(screen.getByText('Page 1 of 5')).toBeInTheDocument();
+    expect(screen.getByText('Page 1')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '← Prev' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Next →' })).not.toBeDisabled();
   });
@@ -487,7 +489,7 @@ describe('EventsPage', () => {
     renderWithProviders(<EventsPage />);
     await screen.findByText('repo.create');
 
-    expect(screen.queryByText(/Page \d+ of/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^Page \d+$/)).not.toBeInTheDocument();
   });
 
   it('chip parser handles repo, since, and until keys', async () => {
@@ -528,18 +530,20 @@ describe('EventsPage', () => {
       page: 1,
       page_size: 20,
       has_next: true,
+      count_is_estimated: false,
+      next_cursor: 'cursor_page2',
     });
 
     renderWithProviders(<EventsPage />);
-    await screen.findByText('Page 1 of 3');
+    await screen.findByText('Page 1');
 
     await user.click(screen.getByRole('button', { name: 'Next →' }));
 
-    // Should call API with page 2
-    const callsAfterNext = listEventsMock.mock.calls.filter(
-      (call: unknown[]) => (call[0] as Record<string, unknown>).page === 2,
+    // Should call API with cursor param
+    const callsWithCursor = listEventsMock.mock.calls.filter(
+      (call: unknown[]) => (call[0] as Record<string, unknown>).cursor === 'cursor_page2',
     );
-    expect(callsAfterNext.length).toBeGreaterThan(0);
+    expect(callsWithCursor.length).toBeGreaterThan(0);
   });
 
   it('shows the second event details when its row is clicked', async () => {
@@ -700,20 +704,5 @@ describe('EventsPage', () => {
 
     renderWithProviders(<EventsPage />);
     expect(await screen.findByText(/Showing first 5,000 results/)).toBeInTheDocument();
-  });
-
-  it('caps page count at 100 for large result sets', async () => {
-    listEventsMock.mockResolvedValue({
-      items: MOCK_EVENTS,
-      total: 100000,
-      page: 1,
-      page_size: 20,
-      has_next: true,
-      count_is_estimated: false,
-      next_cursor: null,
-    });
-
-    renderWithProviders(<EventsPage />);
-    expect(await screen.findByText('Page 1 of 100')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Events/index.tsx
+++ b/frontend/src/pages/Events/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { listEvents } from '../../api/events';
@@ -165,12 +165,12 @@ export function EventsPage() {
   // Parse real-time search input for key:value filters
   const searchFilters = parseSearchFilters(debouncedSearch);
 
-  // Reset cursor stack when filters change
-  const chipsKey = chips.join('|');
-  useEffect(() => {
+  // Wrap chip additions to reset cursors on filter changes
+  const addChip = useCallback((chip: string) => {
+    setChips((prev) => [...prev, chip]);
     setCursors([]);
     setPage(1);
-  }, [chipsKey, debouncedSearch]);
+  }, []);
 
   const currentCursor = cursors.length > 0 ? cursors[cursors.length - 1] : undefined;
 
@@ -224,7 +224,7 @@ export function EventsPage() {
               ev.stopPropagation();
               const chip = `action:${e.action}`;
               if (!chips.includes(chip)) {
-                setChips((prev) => [...prev, chip]);
+                addChip(chip);
                 setPage(1);
               }
             }}
@@ -233,7 +233,7 @@ export function EventsPage() {
                 ev.stopPropagation();
                 const chip = `action:${e.action}`;
                 if (!chips.includes(chip)) {
-                  setChips((prev) => [...prev, chip]);
+                  addChip(chip);
                   setPage(1);
                 }
               }
@@ -263,7 +263,7 @@ export function EventsPage() {
               ev.stopPropagation();
               const chip = `actor:${e.actor}`;
               if (!chips.includes(chip)) {
-                setChips((prev) => [...prev, chip]);
+                addChip(chip);
                 setPage(1);
               }
             }}
@@ -273,7 +273,7 @@ export function EventsPage() {
                 ev.stopPropagation();
                 const chip = `actor:${e.actor}`;
                 if (!chips.includes(chip)) {
-                  setChips((prev) => [...prev, chip]);
+                  addChip(chip);
                   setPage(1);
                 }
               }
@@ -305,7 +305,7 @@ export function EventsPage() {
                 ev.stopPropagation();
                 const chip = `${chipKey}:${val}`;
                 if (!chips.includes(chip)) {
-                  setChips((prev) => [...prev, chip]);
+                  addChip(chip);
                   setPage(1);
                 }
               }}
@@ -315,7 +315,7 @@ export function EventsPage() {
                   ev.stopPropagation();
                   const chip = `${chipKey}:${val}`;
                   if (!chips.includes(chip)) {
-                    setChips((prev) => [...prev, chip]);
+                    addChip(chip);
                     setPage(1);
                   }
                 }
@@ -344,7 +344,7 @@ export function EventsPage() {
         filterValue: (e) => [e.source_ip ?? '', e.geo_country_code ?? ''].join(' ').trim(),
       },
     ],
-    [chips],
+    [chips, addChip],
   );
 
   return (
@@ -361,10 +361,14 @@ export function EventsPage() {
           </svg>
           <EventSearchInput
             value={search}
-            onChange={setSearch}
+            onChange={(val) => {
+              setSearch(val);
+              setCursors([]);
+              setPage(1);
+            }}
             onSubmit={(val) => {
               if (val.trim() && !chips.includes(val.trim())) {
-                setChips((prev) => [...prev, val.trim()]);
+                addChip(val.trim());
               }
               setSearch('');
             }}

--- a/frontend/src/pages/Events/index.tsx
+++ b/frontend/src/pages/Events/index.tsx
@@ -32,9 +32,6 @@ function actionVariant(action: string) {
   return 'muted' as const;
 }
 
-/** Maximum page depth for offset pagination. Beyond this, users must narrow filters. */
-const MAX_NAVIGABLE_PAGE = 100;
-
 /** Threshold at which we show a "narrow your filters" message. */
 const LARGE_RESULT_THRESHOLD = 5_000;
 
@@ -85,6 +82,7 @@ export function EventsPage() {
     return urlChips;
   });
   const [page, setPage] = useState(1);
+  const [cursors, setCursors] = useState<string[]>([]);
   const [sortKey] = useState<NonNullable<EventListParams['sort']>>('created_at_desc');
   const [detailEvent, setDetailEvent] = useState<EventResponse | null>(null);
   const clearedUrlParams = useRef(false);
@@ -167,10 +165,25 @@ export function EventsPage() {
   // Parse real-time search input for key:value filters
   const searchFilters = parseSearchFilters(debouncedSearch);
 
+  // Reset cursor stack when filters change
+  const chipsKey = chips.join('|');
+  useEffect(() => {
+    setCursors([]);
+    setPage(1);
+  }, [chipsKey, debouncedSearch]);
+
+  const currentCursor = cursors.length > 0 ? cursors[cursors.length - 1] : undefined;
+
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ['events', chips, debouncedSearch, page, sortKey],
+    queryKey: ['events', chips, debouncedSearch, currentCursor, sortKey],
     queryFn: () =>
-      listEvents({ ...chipParams, ...searchFilters, sort: sortKey, page, page_size: 20 }),
+      listEvents({
+        ...chipParams,
+        ...searchFilters,
+        sort: sortKey,
+        cursor: currentCursor,
+        page_size: 20,
+      }),
   });
 
   const items = data?.items ?? [];
@@ -180,6 +193,7 @@ export function EventsPage() {
   function removeChip(chip: string) {
     setChips((prev) => prev.filter((c) => c !== chip));
     setPage(1);
+    setCursors([]);
   }
 
   const eventColumns: ColumnDef<EventResponse>[] = useMemo(
@@ -434,16 +448,26 @@ export function EventsPage() {
 
         {data && data.total > 20 && (
           <div className={styles.pagination}>
-            <Button size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
-              ← Prev
-            </Button>
-            <span className={styles.pageInfo}>
-              Page {page} of {Math.min(Math.ceil(total / 20), MAX_NAVIGABLE_PAGE)}
-            </span>
             <Button
               size="sm"
-              disabled={!data.has_next || page >= MAX_NAVIGABLE_PAGE}
-              onClick={() => setPage((p) => p + 1)}
+              disabled={page <= 1}
+              onClick={() => {
+                setCursors((prev) => prev.slice(0, -1));
+                setPage((p) => p - 1);
+              }}
+            >
+              ← Prev
+            </Button>
+            <span className={styles.pageInfo}>Page {page}</span>
+            <Button
+              size="sm"
+              disabled={!data.has_next || !data.next_cursor}
+              onClick={() => {
+                if (data.next_cursor) {
+                  setCursors((prev) => [...prev, data.next_cursor!]);
+                  setPage((p) => p + 1);
+                }
+              }}
             >
               Next →
             </Button>


### PR DESCRIPTION
## Summary

Replaces offset-based pagination with cursor-based pagination in the Events Explorer, leveraging the existing backend `next_cursor` support for better query performance on large tables.

### Changes
- **Cursor navigation**: Forward navigation uses `next_cursor` from API response instead of `page` offset parameter
- **Cursor history stack**: Maintains a stack of cursors for back navigation
- **Auto-reset**: Cursors reset when search filters or chips change
- **Removed MAX_NAVIGABLE_PAGE**: No longer needed since cursor pagination doesn't suffer from deep offset performance issues
- **Page display**: Shows 'Page N' instead of 'Page N of M' (cursor pagination doesn't know total pages upfront)

### Performance impact
Backend already has keyset pagination in `event_service.py` — this change makes the frontend actually use it. OFFSET-based queries degrade with depth (O(offset)); cursor-based queries maintain constant performance regardless of depth.

### Testing
- 76 Events tests passing (52 page + 24 detail)
- Updated 3 tests for new pagination behavior, removed 1 obsolete test

Closes #119