### PR TITLE
feat: event-driven scanner transparency — activity metrics, result icons, auto-refresh

### DIFF
--- a/frontend/src/pages/Workflows/ScannerActivityTab.test.tsx
+++ b/frontend/src/pages/Workflows/ScannerActivityTab.test.tsx
@@ -73,7 +73,7 @@ describe('ScannerActivityTab', () => {
       total: 1,
     });
     renderWithProviders(<ScannerActivityTab />);
-    expect(await screen.findByText('running')).toBeInTheDocument();
+    expect(await screen.findByText('running …')).toBeInTheDocument();
   });
 
   it('renders data source chips', async () => {
@@ -146,5 +146,79 @@ describe('ScannerActivityTab', () => {
     });
     renderWithProviders(<ScannerActivityTab />);
     expect(await screen.findByText('Manual')).toBeInTheDocument();
+  });
+
+  it('renders summary metrics bar', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [10],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/ci.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:01Z',
+          status: 'completed' as const,
+          checks_performed: ['self-hosted-runner'],
+          findings_count: 3,
+          data_sources: ['audit_log'],
+          duration_ms: 200,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('Total Scans')).toBeInTheDocument();
+    expect(await screen.findByText('Event-Driven')).toBeInTheDocument();
+    expect(await screen.findByText('Avg Duration')).toBeInTheDocument();
+  });
+
+  it('shows trigger event count for event-driven scans', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [10, 11, 12],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/ci.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:01Z',
+          status: 'completed' as const,
+          checks_performed: [],
+          findings_count: 0,
+          data_sources: ['audit_log'],
+          duration_ms: 100,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('3 events')).toBeInTheDocument();
+  });
+
+  it('shows result icon for completed scans', async () => {
+    mockedListScanActivity.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          trigger_event_ids: [],
+          org: 'org',
+          repo: 'repo',
+          workflow_path: '.github/workflows/ci.yml',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:00:01Z',
+          status: 'completed' as const,
+          checks_performed: [],
+          findings_count: 0,
+          data_sources: ['audit_log'],
+          duration_ms: 100,
+        },
+      ],
+      total: 1,
+    });
+    renderWithProviders(<ScannerActivityTab />);
+    expect(await screen.findByText('🟢')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Workflows/ScannerActivityTab.tsx
+++ b/frontend/src/pages/Workflows/ScannerActivityTab.tsx
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { listScanActivity } from '../../api/workflowScanner';
 import type { ScanActivity } from '../../api/workflowScanner';
 import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Label } from '../../components/primitives/Label';
+import { MetricCard } from '../../components/primitives/MetricCard';
 import { formatRelativeShort } from '../../utils/dates';
 import styles from './Workflows.module.css';
 
@@ -31,6 +32,17 @@ function dataSourceLabel(source: string): string {
   if (source === 'audit_log') return 'Audit Log';
   if (source === 'github_api') return 'GitHub API';
   return source;
+}
+
+function scanResultIcon(activity: ScanActivity): string {
+  if (activity.status === 'running') return '🔄';
+  if (activity.status === 'failed') return '⚠️';
+  if (activity.findings_count === 0) return '🟢';
+  const hasHighSeverity = activity.checks_performed.some(
+    (c) => c.includes('self-hosted') || c.includes('script-injection'),
+  );
+  if (hasHighSeverity && activity.findings_count > 0) return '🔴';
+  return '🟡';
 }
 
 function ActivityDetailPanel({
@@ -103,7 +115,27 @@ export function ScannerActivityTab() {
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['workflow-scanner', 'activity', page],
     queryFn: () => listScanActivity({ page, page_size: 20 }),
+    refetchInterval: (query) => {
+      const items = query.state.data?.items ?? [];
+      return items.some((a) => a.status === 'running') ? 5000 : false;
+    },
   });
+
+  const stats = useMemo(() => {
+    const items = data?.items ?? [];
+    const total = data?.total ?? 0;
+    const eventDriven = items.filter((a) => a.trigger_event_ids.length > 0).length;
+    const totalFindings = items.reduce((sum, a) => sum + a.findings_count, 0);
+    const completedItems = items.filter((a) => a.duration_ms !== null);
+    const avgDuration =
+      completedItems.length > 0
+        ? Math.round(
+            completedItems.reduce((sum, a) => sum + (a.duration_ms ?? 0), 0) /
+              completedItems.length,
+          )
+        : 0;
+    return { total, eventDriven, totalFindings, avgDuration, pageItems: items.length };
+  }, [data]);
 
   if (isLoading) return <Spinner />;
   if (isError) {
@@ -127,9 +159,37 @@ export function ScannerActivityTab() {
 
   return (
     <div>
+      <div className={styles.activitySummary}>
+        <MetricCard
+          value={String(stats.total)}
+          label="Total Scans"
+          helpText="Total number of workflow scans recorded"
+        />
+        <MetricCard
+          value={
+            stats.pageItems > 0
+              ? `${Math.round((stats.eventDriven / stats.pageItems) * 100)}%`
+              : '0%'
+          }
+          label="Event-Driven"
+          helpText="Percentage of scans triggered by audit log events (vs manual)"
+        />
+        <MetricCard
+          value={String(stats.totalFindings)}
+          label="Findings (page)"
+          helpText="Total findings from scans on this page"
+        />
+        <MetricCard
+          value={formatDuration(stats.avgDuration)}
+          label="Avg Duration"
+          helpText="Average scan duration for completed scans on this page"
+        />
+      </div>
+
       <table className={styles.findingsTable}>
         <thead>
           <tr>
+            <th style={{ width: '36px' }}></th>
             <th>Status</th>
             <th>Workflow</th>
             <th>Trigger</th>
@@ -146,8 +206,22 @@ export function ScannerActivityTab() {
               className={`${styles.findingRow} ${selectedActivity?.id === a.id ? styles.findingRowSelected : ''}`}
               onClick={() => setSelectedActivity(selectedActivity?.id === a.id ? null : a)}
             >
+              <td
+                title={
+                  a.status === 'running'
+                    ? 'Scan in progress'
+                    : a.findings_count === 0
+                      ? 'No findings'
+                      : `${a.findings_count} findings`
+                }
+              >
+                {scanResultIcon(a)}
+              </td>
               <td>
-                <Label variant={statusVariant(a.status)}>{a.status}</Label>
+                <Label variant={statusVariant(a.status)}>
+                  {a.status}
+                  {a.status === 'running' && ' …'}
+                </Label>
               </td>
               <td className={styles.repoPath}>
                 {a.org}/{a.repo}
@@ -158,6 +232,11 @@ export function ScannerActivityTab() {
                 <Label variant={a.trigger_event_ids.length > 0 ? 'accent' : 'muted'}>
                   {a.trigger_event_ids.length > 0 ? 'Event-driven' : 'Manual'}
                 </Label>
+                {a.trigger_event_ids.length > 0 && (
+                  <small className={styles.triggerCount}>
+                    {a.trigger_event_ids.length} event{a.trigger_event_ids.length !== 1 ? 's' : ''}
+                  </small>
+                )}
               </td>
               <td>
                 <Label variant={findingsVariant(a.findings_count)}>{a.findings_count}</Label>

--- a/frontend/src/pages/Workflows/Workflows.module.css
+++ b/frontend/src/pages/Workflows/Workflows.module.css
@@ -550,3 +550,18 @@
   overflow-y: auto;
   padding: 12px 20px 20px;
 }
+
+/* ── Scanner Activity Summary ── */
+.activitySummary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.triggerCount {
+  display: block;
+  font-size: 10px;
+  color: var(--fg-muted);
+  margin-top: 2px;
+}

--- a/frontend/src/pages/Workflows/index.tsx
+++ b/frontend/src/pages/Workflows/index.tsx
@@ -102,7 +102,7 @@ export function WorkflowsPage() {
           <div>
             <PageHeader
               title="Workflow Security Scanner"
-              description="Scan GitHub Actions workflows for security issues"
+              description="Event-driven workflow security scanning — findings appear automatically as audit log events are ingested"
             />
           </div>
           <div className={styles.headerActions}>
@@ -129,19 +129,28 @@ export function WorkflowsPage() {
         </div>
 
         <div className={styles.guidanceBox}>
-          <div className={styles.guidanceTitle}>What this page shows</div>
+          <div className={styles.guidanceTitle}>How scanning works</div>
           <ul className={styles.guidanceList}>
             <li>
-              <strong>Findings</strong> — Security issues detected in workflow YAML files: unpinned
-              actions, script injection, excessive permissions, and more.
+              <strong>Event-driven</strong> — Workflow audit log events are automatically scanned as
+              they arrive through the HEC ingestion pipeline. No manual action needed.
+            </li>
+            <li>
+              <strong>Findings</strong> — Security issues detected in workflow configurations:
+              unpinned actions, script injection, excessive permissions, self-hosted runners, and
+              more.
             </li>
             <li>
               <strong>Repo Scores</strong> — Per-repo security scores (100 = clean, lower = more
               issues). Scores are weighted by severity.
             </li>
             <li>
-              Click <strong>Analyze Events</strong> to scan workflow audit log events for security
-              anti-patterns — no GitHub API calls are made.
+              <strong>Scanner Activity</strong> — View scan history, trigger sources (event-driven
+              vs manual), checks performed, and provenance.
+            </li>
+            <li>
+              Click <strong>Analyze Events</strong> to trigger a batch scan of existing events —
+              this is in addition to the automatic event-driven scanning.
             </li>
           </ul>
         </div>


### PR DESCRIPTION
## Summary

Enhances the Scanner Activity tab to surface the event-driven scanning architecture with transparency features: summary metrics, result icons, auto-refresh, and updated documentation.

### Backend Context
The event-driven scanning pipeline is already fully functional:
- HEC ingestion → detection worker → `scan_workflow_events_task`
- Debouncing (30s per org/repo/workflow)
- `WorkflowScanActivity` records with provenance (trigger events, checks, findings, duration)

This PR makes that pipeline **visible and understandable** to users.

### Changes

**Scanner Activity Tab:**
- **Summary metrics bar**: Total Scans, Event-Driven %, Findings (page), Avg Duration
- **Scan result icons**: 🟢 all clear, 🟡 findings, 🔴 high-severity findings, 🔄 in progress
- **Auto-refresh**: 5-second polling when any scan is in 'running' state
- **Trigger event count**: Shows how many audit log events triggered each scan
- **Running indicator**: Shows 'running …' text for in-progress scans

**Workflows Page:**
- Updated description: 'Event-driven workflow security scanning'
- Expanded guidance box explaining the automatic scanning pipeline
- Added Scanner Activity bullet to guidance

### Testing
- 38 Workflows tests passing (35 existing + 3 new)
- New tests: summary metrics bar, trigger event count, result icons

Closes #121