### PR TITLE
feat: contextual help & in-app documentation (#150)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -205,3 +205,4 @@ addopts = "--cov=app --cov-report=term-missing --cov-fail-under=10"
 filterwarnings = [
     "ignore::DeprecationWarning",
 ]
+

--- a/frontend/src/components/common/HelpPanel.module.css
+++ b/frontend/src/components/common/HelpPanel.module.css
@@ -1,0 +1,169 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(1, 4, 9, 0.56);
+  z-index: 1100;
+}
+
+.panel {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(440px, 100vw);
+  background: var(--canvas-default, #0d1117);
+  border-left: 1px solid var(--border);
+  box-shadow: -16px 0 40px rgba(1, 4, 9, 0.3);
+  display: flex;
+  flex-direction: column;
+  animation: slideIn 0.18s ease;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 20px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.eyebrow {
+  margin: 0 0 6px;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.title {
+  margin: 0;
+  font-size: 22px;
+  color: var(--fg);
+}
+
+.closeButton {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-muted);
+  border-radius: 999px;
+  width: 32px;
+  height: 32px;
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.closeButton:hover {
+  background: rgba(177, 186, 196, 0.12);
+  color: var(--fg);
+}
+
+.body {
+  padding: 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section h3 {
+  margin: 0;
+  font-size: 14px;
+  color: var(--fg);
+}
+
+.section p {
+  margin: 0;
+  color: var(--fg-muted);
+  line-height: 1.6;
+}
+
+.definitionList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin: 0;
+}
+
+.definitionItem {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--canvas-subtle, rgba(177, 186, 196, 0.05));
+}
+
+.definitionItem dt {
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 6px;
+}
+
+.definitionItem dd {
+  margin: 0;
+  color: var(--fg-muted);
+  line-height: 1.5;
+}
+
+.taskList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.taskCard {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--canvas-subtle, rgba(177, 186, 196, 0.05));
+}
+
+.taskCard h4 {
+  margin: 0 0 8px;
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.taskCard ol {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--fg-muted);
+  line-height: 1.6;
+}
+
+.relatedList {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.relatedList a {
+  color: var(--accent-fg, #58a6ff);
+  text-decoration: none;
+}
+
+.relatedList a:hover {
+  text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+  .panel {
+    width: 100vw;
+    border-left: none;
+  }
+}

--- a/frontend/src/components/common/HelpPanel.test.tsx
+++ b/frontend/src/components/common/HelpPanel.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HelpPanel } from './HelpPanel';
+import type { HelpContent } from './helpContent';
+
+const sampleContent: HelpContent = {
+  title: 'Dashboard',
+  description: 'Review operational signals for your organizations.',
+  concepts: [{ term: 'Views', definition: 'Switch between tailored dashboard views.' }],
+  tasks: [{ title: 'Review activity', steps: ['Open the page', 'Inspect the summary cards'] }],
+  relatedPages: [{ title: 'Threats', path: '/threats' }],
+};
+
+describe('HelpPanel', () => {
+  it('renders contextual sections when open', () => {
+    render(<HelpPanel open={true} onClose={() => {}} content={sampleContent} />);
+
+    expect(screen.getByRole('dialog', { name: 'Dashboard' })).toBeInTheDocument();
+    expect(screen.getByText('About this page')).toBeInTheDocument();
+    expect(screen.getByText('Key concepts')).toBeInTheDocument();
+    expect(screen.getByText('Common tasks')).toBeInTheDocument();
+    expect(screen.getByText('Related pages')).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(<HelpPanel open={false} onClose={() => {}} content={sampleContent} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when clicking the close button', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(<HelpPanel open={true} onClose={onClose} content={sampleContent} />);
+    await user.click(screen.getByRole('button', { name: /close help panel/i }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when pressing Escape', () => {
+    const onClose = vi.fn();
+
+    render(<HelpPanel open={true} onClose={onClose} content={sampleContent} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when clicking the overlay', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(<HelpPanel open={true} onClose={onClose} content={sampleContent} />);
+    await user.click(screen.getByTestId('help-panel-overlay'));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/src/components/common/HelpPanel.tsx
+++ b/frontend/src/components/common/HelpPanel.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useId, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import type { HelpContent } from './helpContent';
+import styles from './HelpPanel.module.css';
+
+interface HelpPanelProps {
+  open: boolean;
+  onClose: () => void;
+  content: HelpContent | null;
+}
+
+export function HelpPanel({ open, onClose, content }: HelpPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<Element | null>(null);
+  const titleId = useId();
+
+  const handleEsc = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const handleFocusTrap = useCallback((event: KeyboardEvent) => {
+    if (event.key !== 'Tab' || !panelRef.current) return;
+
+    const focusableElements = panelRef.current.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), textarea, input:not([disabled]), select, [tabindex]:not([tabindex="-1"])',
+    );
+
+    if (focusableElements.length === 0) return;
+
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last?.focus();
+      return;
+    }
+
+    if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first?.focus();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+      return;
+    }
+
+    previousFocusRef.current = document.activeElement;
+    document.addEventListener('keydown', handleEsc);
+    document.addEventListener('keydown', handleFocusTrap);
+
+    requestAnimationFrame(() => {
+      panelRef.current?.querySelector<HTMLElement>('button, a[href]')?.focus();
+    });
+
+    return () => {
+      document.removeEventListener('keydown', handleEsc);
+      document.removeEventListener('keydown', handleFocusTrap);
+    };
+  }, [open, handleEsc, handleFocusTrap]);
+
+  if (!open || !content) {
+    return null;
+  }
+
+  return createPortal(
+    <div className={styles.overlay} onClick={onClose} data-testid="help-panel-overlay">
+      <aside
+        ref={panelRef}
+        className={styles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className={styles.header}>
+          <div>
+            <p className={styles.eyebrow}>Contextual help</p>
+            <h2 className={styles.title} id={titleId}>
+              {content.title}
+            </h2>
+          </div>
+          <button className={styles.closeButton} onClick={onClose} aria-label="Close help panel">
+            ×
+          </button>
+        </div>
+
+        <div className={styles.body}>
+          <section className={styles.section}>
+            <h3>About this page</h3>
+            <p>{content.description}</p>
+          </section>
+
+          <section className={styles.section}>
+            <h3>Key concepts</h3>
+            <dl className={styles.definitionList}>
+              {content.concepts.map((concept) => (
+                <div key={concept.term} className={styles.definitionItem}>
+                  <dt>{concept.term}</dt>
+                  <dd>{concept.definition}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className={styles.section}>
+            <h3>Common tasks</h3>
+            <div className={styles.taskList}>
+              {content.tasks.map((task) => (
+                <div key={task.title} className={styles.taskCard}>
+                  <h4>{task.title}</h4>
+                  <ol>
+                    {task.steps.map((step) => (
+                      <li key={step}>{step}</li>
+                    ))}
+                  </ol>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className={styles.section}>
+            <h3>Related pages</h3>
+            <ul className={styles.relatedList}>
+              {content.relatedPages.map((page) => (
+                <li key={page.path}>
+                  <a href={page.path}>{page.title}</a>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      </aside>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/common/InfoTooltip.module.css
+++ b/frontend/src/components/common/InfoTooltip.module.css
@@ -1,0 +1,50 @@
+.wrapper {
+  display: inline-flex;
+  align-items: center;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-muted);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: help;
+  padding: 0;
+}
+
+.trigger:hover,
+.trigger:focus-visible {
+  color: var(--fg);
+  border-color: var(--accent-fg, #58a6ff);
+  outline: none;
+}
+
+.tooltip {
+  position: fixed;
+  max-width: min(280px, calc(100vw - 16px));
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: var(--chart-tooltip-bg, #161b22);
+  border: 1px solid var(--chart-tooltip-border, #30363d);
+  color: var(--chart-tooltip-fg, #e6edf3);
+  box-shadow: 0 12px 24px rgba(1, 4, 9, 0.24);
+  font-size: 12px;
+  line-height: 1.5;
+  z-index: 1200;
+}
+
+.tooltip strong {
+  font-weight: 700;
+}
+
+.tooltip a {
+  color: #8cc8ff;
+}

--- a/frontend/src/components/common/InfoTooltip.test.tsx
+++ b/frontend/src/components/common/InfoTooltip.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { InfoTooltip } from './InfoTooltip';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('InfoTooltip', () => {
+  it('shows tooltip content on hover with formatting', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <InfoTooltip content="**Important** details live in the [docs](https://example.com)." />,
+    );
+
+    await user.hover(screen.getByRole('button', { name: /more information/i }));
+
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    expect(screen.getByText('Important').tagName).toBe('STRONG');
+    expect(screen.getByRole('link', { name: 'docs' })).toHaveAttribute(
+      'href',
+      'https://example.com',
+    );
+  });
+
+  it('chooses bottom placement when there is not enough room above', async () => {
+    const user = userEvent.setup();
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+      const testId = this.getAttribute('data-testid');
+      if (testId === 'info-tooltip-trigger') {
+        return {
+          x: 20,
+          y: 4,
+          width: 18,
+          height: 18,
+          top: 4,
+          right: 38,
+          bottom: 22,
+          left: 20,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+
+      if (testId === 'info-tooltip-panel') {
+        return {
+          x: 0,
+          y: 0,
+          width: 180,
+          height: 80,
+          top: 0,
+          right: 180,
+          bottom: 80,
+          left: 0,
+          toJSON: () => ({}),
+        } as DOMRect;
+      }
+
+      return {
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => ({}),
+      } as DOMRect;
+    });
+
+    render(<InfoTooltip content="Placement example" />);
+    await user.hover(screen.getByRole('button', { name: /more information/i }));
+
+    expect(screen.getByRole('tooltip')).toHaveAttribute('data-placement', 'bottom');
+  });
+
+  it('hides the tooltip after hover leaves', async () => {
+    const user = userEvent.setup();
+
+    render(<InfoTooltip content="Hidden when inactive" />);
+    const trigger = screen.getByRole('button', { name: /more information/i });
+
+    await user.hover(trigger);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    await user.unhover(trigger);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/InfoTooltip.test.tsx
+++ b/frontend/src/components/common/InfoTooltip.test.tsx
@@ -28,7 +28,9 @@ describe('InfoTooltip', () => {
   it('chooses bottom placement when there is not enough room above', async () => {
     const user = userEvent.setup();
 
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (this: HTMLElement) {
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+      this: HTMLElement,
+    ) {
       const testId = this.getAttribute('data-testid');
       if (testId === 'info-tooltip-trigger') {
         return {

--- a/frontend/src/components/common/InfoTooltip.tsx
+++ b/frontend/src/components/common/InfoTooltip.tsx
@@ -43,12 +43,7 @@ function renderFormattedText(content: string) {
     }
 
     parts.push(
-      <a
-        key={`link-${linkMatch.index}`}
-        href={linkMatch[2]}
-        target="_blank"
-        rel="noreferrer"
-      >
+      <a key={`link-${linkMatch.index}`} href={linkMatch[2]} target="_blank" rel="noreferrer">
         {linkMatch[1]}
       </a>,
     );
@@ -78,8 +73,7 @@ export function InfoTooltip({ content, label = 'More information', className }: 
     const gap = 12;
 
     const fitsTop = triggerRect.top >= tooltipRect.height + gap;
-    const fitsBottom =
-      window.innerHeight - triggerRect.bottom >= tooltipRect.height + gap;
+    const fitsBottom = window.innerHeight - triggerRect.bottom >= tooltipRect.height + gap;
     const fitsRight = window.innerWidth - triggerRect.right >= tooltipRect.width + gap;
 
     let nextPlacement = 'left';

--- a/frontend/src/components/common/InfoTooltip.tsx
+++ b/frontend/src/components/common/InfoTooltip.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import styles from './InfoTooltip.module.css';
+
+interface InfoTooltipProps {
+  content: string;
+  label?: string;
+  className?: string;
+}
+
+function renderFormattedText(content: string) {
+  const linkPattern = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
+
+  const parts: ReactNode[] = [];
+  let linkMatch: RegExpExecArray | null;
+  let lastIndex = 0;
+
+  const renderBoldText = (text: string, keyPrefix: string) => {
+    const boldPattern = /\*\*([^*]+)\*\*/g;
+    const boldParts: ReactNode[] = [];
+    let boldMatch: RegExpExecArray | null;
+    let boldLastIndex = 0;
+
+    while ((boldMatch = boldPattern.exec(text)) !== null) {
+      if (boldMatch.index > boldLastIndex) {
+        boldParts.push(text.slice(boldLastIndex, boldMatch.index));
+      }
+
+      boldParts.push(<strong key={`${keyPrefix}-bold-${boldMatch.index}`}>{boldMatch[1]}</strong>);
+      boldLastIndex = boldMatch.index + boldMatch[0].length;
+    }
+
+    if (boldLastIndex < text.length) {
+      boldParts.push(text.slice(boldLastIndex));
+    }
+
+    return boldParts;
+  };
+
+  while ((linkMatch = linkPattern.exec(content)) !== null) {
+    if (linkMatch.index > lastIndex) {
+      parts.push(...renderBoldText(content.slice(lastIndex, linkMatch.index), `text-${lastIndex}`));
+    }
+
+    parts.push(
+      <a
+        key={`link-${linkMatch.index}`}
+        href={linkMatch[2]}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {linkMatch[1]}
+      </a>,
+    );
+    lastIndex = linkMatch.index + linkMatch[0].length;
+  }
+
+  if (lastIndex < content.length) {
+    parts.push(...renderBoldText(content.slice(lastIndex), `text-${lastIndex}`));
+  }
+
+  return parts;
+}
+
+export function InfoTooltip({ content, label = 'More information', className }: InfoTooltipProps) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+
+  const formattedContent = useMemo(() => renderFormattedText(content), [content]);
+
+  useEffect(() => {
+    if (!open || !triggerRef.current || !tooltipRef.current) return;
+
+    const tooltip = tooltipRef.current;
+    const triggerRect = triggerRef.current.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const gap = 12;
+
+    const fitsTop = triggerRect.top >= tooltipRect.height + gap;
+    const fitsBottom =
+      window.innerHeight - triggerRect.bottom >= tooltipRect.height + gap;
+    const fitsRight = window.innerWidth - triggerRect.right >= tooltipRect.width + gap;
+
+    let nextPlacement = 'left';
+    if (fitsTop) {
+      nextPlacement = 'top';
+    } else if (fitsBottom) {
+      nextPlacement = 'bottom';
+    } else if (fitsRight) {
+      nextPlacement = 'right';
+    }
+
+    let top = 0;
+    let left = 0;
+
+    if (nextPlacement === 'top') {
+      top = triggerRect.top - tooltipRect.height - gap;
+      left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+    } else if (nextPlacement === 'bottom') {
+      top = triggerRect.bottom + gap;
+      left = triggerRect.left + triggerRect.width / 2 - tooltipRect.width / 2;
+    } else if (nextPlacement === 'right') {
+      top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2;
+      left = triggerRect.right + gap;
+    } else {
+      top = triggerRect.top + triggerRect.height / 2 - tooltipRect.height / 2;
+      left = triggerRect.left - tooltipRect.width - gap;
+    }
+
+    tooltip.dataset.placement = nextPlacement;
+    tooltip.style.top = `${Math.max(8, Math.min(top, window.innerHeight - tooltipRect.height - 8))}px`;
+    tooltip.style.left = `${Math.max(8, Math.min(left, window.innerWidth - tooltipRect.width - 8))}px`;
+  }, [open]);
+
+  return (
+    <span className={[styles.wrapper, className].filter(Boolean).join(' ')}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={styles.trigger}
+        aria-label={label}
+        aria-expanded={open}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        data-testid="info-tooltip-trigger"
+      >
+        i
+      </button>
+      {open &&
+        createPortal(
+          <div
+            ref={tooltipRef}
+            className={styles.tooltip}
+            role="tooltip"
+            data-placement="top"
+            data-testid="info-tooltip-panel"
+            onMouseEnter={() => setOpen(true)}
+            onMouseLeave={() => setOpen(false)}
+          >
+            {formattedContent}
+          </div>,
+          document.body,
+        )}
+    </span>
+  );
+}

--- a/frontend/src/components/common/PageHeader.module.css
+++ b/frontend/src/components/common/PageHeader.module.css
@@ -47,6 +47,13 @@
   margin: 2px 0 0;
 }
 
+.right {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
 .actions {
   display: flex;
   gap: 8px;
@@ -67,4 +74,11 @@
   .actions {
     flex-wrap: wrap;
   }
+}
+
+.helpButton {
+  min-width: 30px;
+  padding-inline: 0;
+  border-radius: 999px;
+  font-weight: 700;
 }

--- a/frontend/src/components/common/PageHeader.test.tsx
+++ b/frontend/src/components/common/PageHeader.test.tsx
@@ -3,6 +3,29 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { PageHeader } from './PageHeader';
 
+vi.mock('../../hooks/useHelp', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    useHelp: () => {
+      const [isHelpOpen, setIsHelpOpen] = React.useState(false);
+
+      return {
+        helpContent: {
+          title: 'Test Help',
+          description: 'Helpful context for this header.',
+          concepts: [{ term: 'Concept', definition: 'Definition' }],
+          tasks: [{ title: 'Task', steps: ['Step'] }],
+          relatedPages: [{ title: 'Related', path: '/related' }],
+        },
+        openHelp: () => setIsHelpOpen(true),
+        closeHelp: () => setIsHelpOpen(false),
+        isHelpOpen,
+      };
+    },
+  };
+});
+
 describe('PageHeader', () => {
   it('renders title', () => {
     render(<PageHeader title="Dashboard" />);
@@ -54,5 +77,14 @@ describe('PageHeader', () => {
       <PageHeader title="T" actions={[{ label: 'Save', onClick: vi.fn(), disabled: true }]} />,
     );
     expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('renders help button and opens the help panel', async () => {
+    render(<PageHeader title="Dashboard" showHelp />);
+
+    await userEvent.click(screen.getByRole('button', { name: /open help panel/i }));
+
+    expect(screen.getByRole('dialog', { name: 'Test Help' })).toBeInTheDocument();
+    expect(screen.getByText('About this page')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -1,4 +1,6 @@
 import { Button } from '../primitives/Button';
+import { HelpPanel } from './HelpPanel';
+import { useHelp } from '../../hooks/useHelp';
 import styles from './PageHeader.module.css';
 
 export interface PageAction {
@@ -22,13 +24,39 @@ interface PageHeaderProps {
   actions?: PageAction[];
   /** Breadcrumb trail above the title. */
   breadcrumbs?: Breadcrumb[];
+  /** Show contextual help for the current page. */
+  showHelp?: boolean;
+}
+
+function PageHeaderHelp() {
+  const { helpContent, openHelp, closeHelp, isHelpOpen } = useHelp();
+
+  if (!helpContent) {
+    return null;
+  }
+
+  return (
+    <>
+      <Button
+        size="sm"
+        className={styles.helpButton}
+        onClick={openHelp}
+        aria-label="Open help panel"
+      >
+        ?
+      </Button>
+      <HelpPanel open={isHelpOpen} onClose={closeHelp} content={helpContent} />
+    </>
+  );
 }
 
 /**
  * PageHeader — consistent page header with title, description,
  * optional breadcrumbs, and action buttons.
  */
-export function PageHeader({ title, description, actions, breadcrumbs }: PageHeaderProps) {
+export function PageHeader({ title, description, actions, breadcrumbs, showHelp }: PageHeaderProps) {
+  const hasRightContent = showHelp || (actions && actions.length > 0);
+
   return (
     <div className={styles.header}>
       <div className={styles.left}>
@@ -45,19 +73,24 @@ export function PageHeader({ title, description, actions, breadcrumbs }: PageHea
         <h1 className={styles.title}>{title}</h1>
         {description && <p className={styles.description}>{description}</p>}
       </div>
-      {actions && actions.length > 0 && (
-        <div className={styles.actions}>
-          {actions.map((action) => (
-            <Button
-              key={action.label}
-              variant={action.variant ?? 'default'}
-              size="sm"
-              onClick={action.onClick}
-              disabled={action.disabled}
-            >
-              {action.label}
-            </Button>
-          ))}
+      {hasRightContent && (
+        <div className={styles.right}>
+          {showHelp && <PageHeaderHelp />}
+          {actions && actions.length > 0 && (
+            <div className={styles.actions}>
+              {actions.map((action) => (
+                <Button
+                  key={action.label}
+                  variant={action.variant ?? 'default'}
+                  size="sm"
+                  onClick={action.onClick}
+                  disabled={action.disabled}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -54,7 +54,13 @@ function PageHeaderHelp() {
  * PageHeader — consistent page header with title, description,
  * optional breadcrumbs, and action buttons.
  */
-export function PageHeader({ title, description, actions, breadcrumbs, showHelp }: PageHeaderProps) {
+export function PageHeader({
+  title,
+  description,
+  actions,
+  breadcrumbs,
+  showHelp,
+}: PageHeaderProps) {
   const hasRightContent = showHelp || (actions && actions.length > 0);
 
   return (

--- a/frontend/src/components/common/helpContent.ts
+++ b/frontend/src/components/common/helpContent.ts
@@ -1,0 +1,515 @@
+export interface HelpConcept {
+  term: string;
+  definition: string;
+}
+
+export interface HelpTask {
+  title: string;
+  steps: string[];
+}
+
+export interface HelpRelatedPage {
+  title: string;
+  path: string;
+}
+
+export interface HelpContent {
+  title: string;
+  description: string;
+  concepts: HelpConcept[];
+  tasks: HelpTask[];
+  relatedPages: HelpRelatedPage[];
+}
+
+export const HELP_CONTENT_REGISTRY: Record<string, HelpContent> = {
+  '/dashboard': {
+    title: 'Dashboard',
+    description:
+      'Use the dashboard to monitor platform health, security activity, event volume, and workflow performance across your connected organizations.',
+    concepts: [
+      {
+        term: 'Views',
+        definition:
+          'Switch between Operations, Executive, Security Engineering, and CI/CD views to focus on the metrics that matter to each audience.',
+      },
+      {
+        term: 'Activity signals',
+        definition:
+          'Cards and charts summarize recent detections, raw events, and workflow activity pulled from synchronized GitHub telemetry.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Check the latest sync state',
+        steps: [
+          'Review the subtitle under the page title for the last sync timestamp.',
+          'Scan the summary cards for sudden drops or spikes in activity.',
+          'Switch views if you need a security, executive, or CI/CD specific perspective.',
+        ],
+      },
+      {
+        title: 'Investigate a trend',
+        steps: [
+          'Use the cards or charts to identify the metric that changed.',
+          'Open the related detail page from the dashboard navigation.',
+          'Filter the detail view to isolate the affected organization, period, or severity.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Threat Detections', path: '/threats' },
+      { title: 'Events Explorer', path: '/events' },
+      { title: 'Engineering Velocity', path: '/velocity' },
+    ],
+  },
+  '/threats': {
+    title: 'Threat Detections',
+    description:
+      'Threat Detections surfaces rule-based and ML-assisted findings generated from audit log activity so analysts can triage suspicious behavior quickly.',
+    concepts: [
+      {
+        term: 'Detection severity',
+        definition:
+          'Severity reflects the rule impact and urgency. Critical and high findings usually deserve immediate review.',
+      },
+      {
+        term: 'Status buckets',
+        definition:
+          'Open, acknowledged, and closed counts help you understand triage progress across the current filter set.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Prioritize urgent detections',
+        steps: [
+          'Filter by severity to show only critical or high findings.',
+          'Sort or scan the list for recent activity spikes.',
+          'Open a detection record and capture remediation or acknowledgement details.',
+        ],
+      },
+      {
+        title: 'Review activity by organization',
+        steps: [
+          'Select an organization from the organization filter.',
+          'Compare the detection totals and statuses for that tenant.',
+          'Use related pages to pivot into raw events or posture context.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Events Explorer', path: '/events' },
+      { title: 'Security Posture', path: '/posture' },
+      { title: 'Detection Rules', path: '/rules' },
+    ],
+  },
+  '/events': {
+    title: 'Events Explorer',
+    description:
+      'Events Explorer lets you search raw audit log events across organizations, actors, repositories, and actions for fast investigation workflows.',
+    concepts: [
+      {
+        term: 'Search chips',
+        definition:
+          'Submitted search expressions become removable chips so you can build structured filters incrementally.',
+      },
+      {
+        term: 'Estimated counts',
+        definition:
+          'Some result totals are approximate when the backend optimizes large queries for speed.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Find suspicious activity',
+        steps: [
+          'Enter an action, actor, organization, or repository filter in the search bar.',
+          'Submit the query to add it as a chip.',
+          'Review matching rows and open an event for complete metadata.',
+        ],
+      },
+      {
+        title: 'Refine a noisy search',
+        steps: [
+          'Remove broad chips that return too many events.',
+          'Add more specific action, actor, or namespace filters.',
+          'Use the table columns to confirm IP, location, and organization details.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Threat Detections', path: '/threats' },
+      { title: 'Cross-Organization Correlation', path: '/crossorg' },
+      { title: 'Dashboard', path: '/dashboard' },
+    ],
+  },
+  '/posture': {
+    title: 'Security Posture',
+    description:
+      'Security Posture rolls up enterprise, organization, and repository security checks so you can see where controls are passing or failing.',
+    concepts: [
+      {
+        term: 'Score',
+        definition:
+          'The posture score summarizes configured checks and security signals into an easy-to-scan percentage.',
+      },
+      {
+        term: 'Hierarchy',
+        definition:
+          'You can drill from enterprise to organization to repository views while keeping the same posture model.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Find weak security areas',
+        steps: [
+          'Review the overall score and failing counts at the current hierarchy level.',
+          'Filter by severity or status to focus on the riskiest checks.',
+          'Open an organization or repository to inspect the failing control details.',
+        ],
+      },
+      {
+        title: 'Trace a failing check to detections',
+        steps: [
+          'Locate the failing check row in the current view.',
+          'Open any linked detection when available.',
+          'Use the linked detection to review the underlying events and response steps.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Threat Detections', path: '/threats' },
+      { title: 'Compliance Center', path: '/compliance' },
+      { title: 'Settings', path: '/settings' },
+    ],
+  },
+  '/workflows': {
+    title: 'Workflow Security Scanner',
+    description:
+      'Workflow Security Scanner analyzes workflow activity and highlights automation behavior that could introduce operational or security risk.',
+    concepts: [
+      {
+        term: 'Analysis queue',
+        definition:
+          'Manual analysis requests enqueue a scan. Results appear after backend processing completes.',
+      },
+      {
+        term: 'Findings',
+        definition:
+          'Scanner results focus on risky workflow patterns, suspicious execution context, and related workflow health issues.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Run a fresh analysis',
+        steps: [
+          'Click Analyze Events in the header actions.',
+          'Wait for the queued confirmation message.',
+          'Refresh or revisit the findings panes after ingestion completes.',
+        ],
+      },
+      {
+        title: 'Pivot to operational health',
+        steps: [
+          'Use the cross-link near the top of the page.',
+          'Open Workflow Health for failure and throughput metrics.',
+          'Compare security findings with workflow reliability issues.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Workflow Health', path: '/workflows/health' },
+      { title: 'Engineering Velocity', path: '/velocity' },
+      { title: 'Reports', path: '/reports' },
+    ],
+  },
+  '/crossorg': {
+    title: 'Cross-Organization Correlation',
+    description:
+      'Cross-Organization Correlation helps you identify actors and activity patterns that span multiple organizations.',
+    concepts: [
+      {
+        term: 'High-risk actors',
+        definition:
+          'Actors with elevated scores or broad organization access may indicate automation abuse, compromised credentials, or misuse.',
+      },
+      {
+        term: 'Correlation window',
+        definition:
+          'Scores and summaries reflect a rolling time window so you can compare consistent slices of activity.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Review cross-org actor behavior',
+        steps: [
+          'Locate actors with elevated risk or unusually broad organization reach.',
+          'Open a row to inspect per-organization activity.',
+          'Verify whether the activity is expected for that user or automation token.',
+        ],
+      },
+      {
+        title: 'Investigate anomalies',
+        steps: [
+          'Use the guidance box to understand what patterns matter most.',
+          'Compare volume, organizations, and time windows across the actor summaries.',
+          'Pivot into Events Explorer if you need full raw event detail.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Events Explorer', path: '/events' },
+      { title: 'Threat Detections', path: '/threats' },
+      { title: 'Dashboard', path: '/dashboard' },
+    ],
+  },
+  '/copilot': {
+    title: 'Copilot Insights',
+    description:
+      'Copilot Insights tracks usage, adoption, blockers, and licensing trends for GitHub Copilot across your organization.',
+    concepts: [
+      {
+        term: 'Active tab',
+        definition:
+          'Tabs break the experience into overview, adoption, models, teams, blockers, license, and ROI views.',
+      },
+      {
+        term: 'Seat utilization',
+        definition:
+          'Seat trends help you understand whether paid access is being used effectively.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Measure adoption',
+        steps: [
+          'Start with the Overview or Adoption tab.',
+          'Compare seat allocation, active users, and recent changes.',
+          'Review blockers or license detail if usage is lower than expected.',
+        ],
+      },
+      {
+        title: 'Investigate blocked users',
+        steps: [
+          'Switch to the Blockers tab.',
+          'Review the users or teams affected by setup and policy issues.',
+          'Coordinate changes through Settings or support processes as needed.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Settings', path: '/settings' },
+      { title: 'Reports', path: '/reports' },
+      { title: 'Dashboard', path: '/dashboard' },
+    ],
+  },
+  '/velocity': {
+    title: 'Engineering Velocity',
+    description:
+      'Engineering Velocity summarizes CI/CD throughput, delivery speed, and leadership-focused development metrics.',
+    concepts: [
+      {
+        term: 'Velocity views',
+        definition:
+          'Metric and Leadership tabs tailor the same data set for hands-on engineering teams or broader stakeholders.',
+      },
+      {
+        term: 'Flow metrics',
+        definition:
+          'Lead time, throughput, and related measures show how efficiently work moves through the delivery pipeline.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Monitor delivery throughput',
+        steps: [
+          'Stay on the Metrics tab to review current engineering indicators.',
+          'Look for drops in deployment volume or rising cycle times.',
+          'Use related pages to compare workflow failures or report trends.',
+        ],
+      },
+      {
+        title: 'Prepare a leadership snapshot',
+        steps: [
+          'Switch to the Leadership tab.',
+          'Review trend summaries and high-level KPIs.',
+          'Cross-check the same period in Reports if you need more detail.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Workflow Health', path: '/workflows/health' },
+      { title: 'Reports', path: '/reports' },
+      { title: 'Dashboard', path: '/dashboard' },
+    ],
+  },
+  '/reports': {
+    title: 'Reports',
+    description:
+      'Reports combines built-in analytics and custom report building so teams can review activity over configurable windows.',
+    concepts: [
+      {
+        term: 'Window selector',
+        definition:
+          'The header controls let you switch between common reporting periods without rebuilding the page.',
+      },
+      {
+        term: 'Custom reports',
+        definition:
+          'Custom reports let you tailor charting and exports for the audience or workflow you need to support.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Compare reporting windows',
+        steps: [
+          'Use the 30d, 60d, or 90d controls in the header.',
+          'Watch the summary charts and tables refresh.',
+          'Export data once you have the desired reporting period selected.',
+        ],
+      },
+      {
+        title: 'Build a custom report',
+        steps: [
+          'Click New Custom Report.',
+          'Choose the metrics and filters needed for your audience.',
+          'Save or export the result for recurring review.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Dashboard', path: '/dashboard' },
+      { title: 'Engineering Velocity', path: '/velocity' },
+      { title: 'Compliance Center', path: '/compliance' },
+    ],
+  },
+  '/compliance': {
+    title: 'Compliance Center',
+    description:
+      'Compliance Center tracks alignment with supported security frameworks and highlights control areas needing attention.',
+    concepts: [
+      {
+        term: 'Overall score',
+        definition:
+          'The overall score is a weighted rollup across enabled frameworks and the controls each framework evaluates.',
+      },
+      {
+        term: 'Framework posture',
+        definition:
+          'Each framework view shows how well your current settings and detections align with its requirements.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Review framework readiness',
+        steps: [
+          'Start with the summary strip at the top of the page.',
+          'Inspect frameworks with lower scores or more failing controls.',
+          'Open related posture or settings pages to address the underlying gaps.',
+        ],
+      },
+      {
+        title: 'Explain a compliance gap',
+        steps: [
+          'Locate the framework or control with the weakest score.',
+          'Check the mapped evidence and recommended remediation.',
+          'Validate the related control status in Posture or Settings.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Security Posture', path: '/posture' },
+      { title: 'Settings', path: '/settings' },
+      { title: 'Reports', path: '/reports' },
+    ],
+  },
+  '/rules': {
+    title: 'Detection Rules',
+    description:
+      'Detection Rules is the control plane for creating, editing, syncing, and reviewing automated detection logic.',
+    concepts: [
+      {
+        term: 'Rule library',
+        definition:
+          'The rule library helps you browse reusable patterns before promoting them into your active ruleset.',
+      },
+      {
+        term: 'Version history',
+        definition:
+          'Version history lets you inspect prior rule revisions and understand how detection behavior changed over time.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Create a new rule',
+        steps: [
+          'Open the create flow or wizard from the header actions.',
+          'Define the match logic, severity, and metadata.',
+          'Save the rule and watch for new detections once matching events arrive.',
+        ],
+      },
+      {
+        title: 'Sync or validate rule updates',
+        steps: [
+          'Use the sync action in the header.',
+          'Confirm the success banner or follow-up state.',
+          'Review recent detections to confirm the change behaves as expected.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Threat Detections', path: '/threats' },
+      { title: 'Events Explorer', path: '/events' },
+      { title: 'Settings', path: '/settings' },
+    ],
+  },
+  '/settings': {
+    title: 'Settings',
+    description:
+      'Settings centralizes product configuration, integrations, feature controls, and audit visibility for OctoWatch administrators.',
+    concepts: [
+      {
+        term: 'Tabs',
+        definition:
+          'Each settings tab focuses on a configuration area such as features, integrations, security controls, or audit history.',
+      },
+      {
+        term: 'Audit trail',
+        definition:
+          'Changes made in settings can be reviewed later so administrators can verify who changed what and when.',
+      },
+    ],
+    tasks: [
+      {
+        title: 'Update a configuration area',
+        steps: [
+          'Open the tab that matches the setting you want to manage.',
+          'Review current values and validation hints before saving.',
+          'Confirm any follow-up alerts, sync requirements, or audit entries.',
+        ],
+      },
+      {
+        title: 'Troubleshoot an integration or feature',
+        steps: [
+          'Open the relevant Features or Integrations tab.',
+          'Check whether required credentials or toggles are configured.',
+          'Use audit history or related pages to verify downstream impact.',
+        ],
+      },
+    ],
+    relatedPages: [
+      { title: 'Compliance Center', path: '/compliance' },
+      { title: 'Copilot Insights', path: '/copilot/overview' },
+      { title: 'Dashboard', path: '/dashboard' },
+    ],
+  },
+};
+
+const HELP_ROUTE_KEYS = Object.keys(HELP_CONTENT_REGISTRY).sort((a, b) => b.length - a.length);
+
+export function findHelpContent(pathname: string): HelpContent | null {
+  const matchedRoute = HELP_ROUTE_KEYS.find(
+    (route) => pathname === route || pathname.startsWith(`${route}/`),
+  );
+
+  return matchedRoute ? HELP_CONTENT_REGISTRY[matchedRoute] : null;
+}

--- a/frontend/src/hooks/useHelp.ts
+++ b/frontend/src/hooks/useHelp.ts
@@ -1,0 +1,28 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { findHelpContent } from '../components/common/helpContent';
+
+export function useHelp() {
+  const location = useLocation();
+  const [openPath, setOpenPath] = useState<string | null>(null);
+
+  const helpContent = useMemo(() => findHelpContent(location.pathname), [location.pathname]);
+  const isHelpOpen = openPath === location.pathname && helpContent !== null;
+
+  const openHelp = useCallback(() => {
+    if (helpContent) {
+      setOpenPath(location.pathname);
+    }
+  }, [helpContent, location.pathname]);
+
+  const closeHelp = useCallback(() => {
+    setOpenPath(null);
+  }, []);
+
+  return {
+    helpContent,
+    openHelp,
+    closeHelp,
+    isHelpOpen,
+  };
+}

--- a/frontend/src/pages/Dashboard/index.tsx
+++ b/frontend/src/pages/Dashboard/index.tsx
@@ -509,6 +509,7 @@ export function DashboardPage() {
             ? `Last synced: ${formatRelative(systemHealthQuery.data.last_event_at)}`
             : 'Activity across your organizations'
         }
+        showHelp
       />
 
       <div className={styles.viewToggle}>

--- a/frontend/src/pages/Events/index.tsx
+++ b/frontend/src/pages/Events/index.tsx
@@ -353,6 +353,7 @@ export function EventsPage() {
         <PageHeader
           title="Events Explorer"
           description="Search and explore raw audit log events across all organizations"
+          showHelp
         />
 
         <div className={styles.searchBar}>

--- a/frontend/src/pages/Posture/Posture.module.css
+++ b/frontend/src/pages/Posture/Posture.module.css
@@ -2,6 +2,10 @@
   padding: 0;
 }
 
+.pageHeader {
+  padding: 16px 24px 0;
+}
+
 /* ── Breadcrumb ────────────────────────────────────────────────────── */
 .breadcrumb {
   display: flex;
@@ -9,7 +13,8 @@
   gap: 6px;
   font-size: 13px;
   color: var(--fg-muted);
-  padding: 16px 24px 0;
+  padding: 0 24px;
+  margin-bottom: 12px;
 }
 .breadcrumb a {
   color: var(--accent-fg);

--- a/frontend/src/pages/Posture/index.tsx
+++ b/frontend/src/pages/Posture/index.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Pagination } from '../../components/primitives/Pagination';
 import { EmptyState } from '../../components/common/EmptyState';
+import { PageHeader } from '../../components/common/PageHeader';
 import { RadialGauge } from '../../components/charts/RadialGauge';
 import { useChartColors } from '../../hooks/useChartColors';
 import { formatDateOnly } from '../../utils/dates';
@@ -1021,21 +1022,38 @@ export function PosturePage() {
     setSearch('');
   };
 
+  const pageHeader = (
+    <div className={styles.pageHeader}>
+      <PageHeader
+        title="Security Posture"
+        description="Review enterprise, organization, and repository security posture"
+        showHelp
+      />
+    </div>
+  );
+
   if (isLoading)
     return (
-      <div className={styles.loading}>
-        <Spinner />
+      <div className={styles.page}>
+        {pageHeader}
+        <div className={styles.loading}>
+          <Spinner />
+        </div>
       </div>
     );
   if (isError || !data)
     return (
-      <div className={styles.content}>
-        <ErrorBanner message="Failed to load posture data" onRetry={refetch} />
+      <div className={styles.page}>
+        {pageHeader}
+        <div className={styles.content}>
+          <ErrorBanner message="Failed to load posture data" onRetry={refetch} />
+        </div>
       </div>
     );
 
   return (
     <div className={styles.page}>
+      {pageHeader}
       <Breadcrumb items={data.breadcrumb} />
       {data.level === 'enterprise' && (
         <EnterpriseView

--- a/frontend/src/pages/Threats/index.tsx
+++ b/frontend/src/pages/Threats/index.tsx
@@ -12,6 +12,7 @@ import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Pagination } from '../../components/primitives/Pagination';
 import { Autocomplete } from '../../components/primitives/Autocomplete';
 import { PageHeader } from '../../components/common/PageHeader';
+import { InfoTooltip } from '../../components/common/InfoTooltip';
 import { EmptyState } from '../../components/common/EmptyState';
 import { DetectionDetailPane } from './DetectionDetailPane';
 import { ChainsPane } from './ChainsPane';
@@ -238,6 +239,7 @@ export function ThreatsPage() {
         <PageHeader
           title="Threat Detections"
           description="Rule-based and ML-powered detections from audit log analysis"
+          showHelp
         />
         <div className={styles.filterBar}>
           {/* Row 1: dropdowns */}
@@ -258,11 +260,8 @@ export function ThreatsPage() {
                 <option value="medium">Medium</option>
                 <option value="low">Low</option>
               </select>
-              <span
-                title="Detection severity as defined by the triggering rule. Critical = immediate response needed."
-                style={{ cursor: 'help', opacity: 0.5, fontSize: '0.8em', marginLeft: 4 }}
-              >
-                ⓘ
+              <span style={{ marginLeft: 4 }}>
+                <InfoTooltip content="**Severity** is defined by the triggering rule. Critical findings usually need immediate response." />
               </span>
             </label>
 


### PR DESCRIPTION
Closes #150

In-app contextual help system with slide-out help panel, tooltips, and per-page help content.

- HelpPanel component with page-specific content (concepts, tasks, related pages)
- InfoTooltip component for inline help
- useHelp hook with route-based content lookup
- Help content registry covering 12+ pages
- PageHeader integration with optional help button

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>