### PR TITLE
feat: PagerDuty & Microsoft Teams integration (#58)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ from app.routers import (
     maintenance,
     notifications,
     org_config,
+    pagerduty,
     playbooks,
     posture,
     query,
@@ -60,6 +61,7 @@ from app.routers import (
     slack,
     suggestions,
     sync,
+    teams,
     threat_intel,
     user_preferences,
     workflow_metrics,
@@ -706,6 +708,7 @@ def create_app() -> FastAPI:
     app.include_router(integrations.router, prefix=API_PREFIX)
     app.include_router(slack.router, prefix=API_PREFIX)
     app.include_router(notifications.router, prefix=API_PREFIX)
+    app.include_router(pagerduty.router, prefix=API_PREFIX)
     app.include_router(health_signals.router, prefix=API_PREFIX)
     app.include_router(copilot.router, prefix=API_PREFIX)
     app.include_router(features.router, prefix=API_PREFIX)
@@ -713,6 +716,7 @@ def create_app() -> FastAPI:
     app.include_router(sync.router, prefix=API_PREFIX + "/admin")
     app.include_router(setup.router, prefix=API_PREFIX)
     app.include_router(suggestions.router, prefix=API_PREFIX)
+    app.include_router(teams.router, prefix=API_PREFIX)
     app.include_router(dev_activity.router, prefix=API_PREFIX)
     app.include_router(threat_intel.router, prefix=API_PREFIX)
     app.include_router(actors.router, prefix=API_PREFIX)

--- a/backend/app/routers/detections.py
+++ b/backend/app/routers/detections.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
+import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import Response
 from sqlalchemy import func, select
@@ -22,6 +25,8 @@ from app.schemas.detection import (
 from app.services.audit_service import log_action
 from app.services.rbac_service import get_user_scope
 from app.utils.client_ip import get_client_ip
+
+logger = structlog.get_logger(__name__)
 
 router = APIRouter(prefix="/detections", tags=["detections"])
 
@@ -135,10 +140,37 @@ async def update_detection_status(
             detail=f"Cannot transition from '{detection.status}' to '{payload.status}'",
         )
 
+    previous_status = detection.status
     detection.status = payload.status
+    if payload.status == "resolved":
+        detection.resolved_at = datetime.now(UTC)
+        detection.resolved_by = current_user.github_login
+    elif previous_status == "resolved" and payload.status != "resolved":
+        detection.resolved_at = None
+        detection.resolved_by = None
+
     if payload.resolution_note:
         detection.resolution_note = payload.resolution_note
     await db.flush()
+
+    if payload.status == "resolved":
+        try:
+            import redis.asyncio as aioredis
+
+            from app.config import settings
+            from app.services.pagerduty_service import resolve_detection_incident
+
+            valkey = aioredis.from_url(settings.VALKEY_URL, decode_responses=True)
+            try:
+                await resolve_detection_incident(db, valkey, detection_id)
+            finally:
+                await valkey.aclose()
+        except Exception as exc:
+            logger.warning(
+                "detection.pagerduty_auto_resolve_failed",
+                detection_id=detection_id,
+                error=str(exc),
+            )
 
     ip = get_client_ip(request)
     await log_action(

--- a/backend/app/routers/pagerduty.py
+++ b/backend/app/routers/pagerduty.py
@@ -1,0 +1,71 @@
+"""PagerDuty integration router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import AuthenticatedUser, get_db, require_permission, verify_csrf
+from app.schemas.integration import (
+    PagerDutyConfigResponse,
+    PagerDutyConfigUpdate,
+    PagerDutyTestResponse,
+)
+from app.services import pagerduty_service
+
+router = APIRouter(prefix="/integrations/pagerduty", tags=["pagerduty"])
+
+
+@router.get("/config", response_model=PagerDutyConfigResponse)
+async def get_pagerduty_config(
+    current_user: AuthenticatedUser = Depends(require_permission("admin_settings", "admin")),
+    db: AsyncSession = Depends(get_db),
+) -> PagerDutyConfigResponse:
+    return PagerDutyConfigResponse.model_validate(await pagerduty_service.get_pagerduty_config(db))
+
+
+@router.put(
+    "/config",
+    response_model=PagerDutyConfigResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def update_pagerduty_config(
+    payload: PagerDutyConfigUpdate,
+    current_user: AuthenticatedUser = Depends(require_permission("admin_settings", "admin")),
+    db: AsyncSession = Depends(get_db),
+) -> PagerDutyConfigResponse:
+    config = await pagerduty_service.update_pagerduty_config(
+        db,
+        routing_key=payload.routing_key.strip() if payload.routing_key else None,
+        severity_mapping=payload.severity_mapping,
+        notification_settings=payload.notification_settings,
+        auto_resolve=payload.auto_resolve,
+        changed_by=current_user.github_login,
+    )
+    return PagerDutyConfigResponse.model_validate(config)
+
+
+@router.post(
+    "/test",
+    response_model=PagerDutyTestResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def test_pagerduty_connection(
+    current_user: AuthenticatedUser = Depends(require_permission("admin_settings", "admin")),
+    db: AsyncSession = Depends(get_db),
+) -> PagerDutyTestResponse:
+    config = await pagerduty_service.get_runtime_notification_config(db, "detections")
+    routing_key = str(config.get("routing_key") or "").strip()
+    if not routing_key:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="PagerDuty routing key is not configured",
+        )
+
+    await pagerduty_service.send_change_event(
+        "OctoWatch PagerDuty integration test",
+        source="octowatch",
+        routing_key=routing_key,
+        custom_details={"triggered_by": current_user.github_login},
+    )
+    return PagerDutyTestResponse(ok=True, message="Test event sent successfully")

--- a/backend/app/routers/teams.py
+++ b/backend/app/routers/teams.py
@@ -1,0 +1,111 @@
+"""Microsoft Teams integration router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Body, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import AuthenticatedUser, get_db, require_permission, verify_csrf
+from app.schemas.integration import (
+    TeamsConfigResponse,
+    TeamsConfigUpdate,
+    TeamsTestRequest,
+    TeamsTestResponse,
+)
+from app.services import teams_service
+
+router = APIRouter(prefix="/integrations/teams", tags=["teams"])
+
+
+@router.get("/config", response_model=TeamsConfigResponse)
+async def get_teams_config(
+    current_user: AuthenticatedUser = Depends(require_permission("admin_settings", "admin")),
+    db: AsyncSession = Depends(get_db),
+) -> TeamsConfigResponse:
+    return TeamsConfigResponse.model_validate(await teams_service.get_teams_config(db))
+
+
+@router.put(
+    "/config",
+    response_model=TeamsConfigResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def update_teams_config(
+    payload: TeamsConfigUpdate,
+    current_user: AuthenticatedUser = Depends(require_permission("admin_settings", "admin")),
+    db: AsyncSession = Depends(get_db),
+) -> TeamsConfigResponse:
+    config = await teams_service.update_teams_config(
+        db,
+        channel_webhooks=payload.channel_webhooks,
+        source_mappings=payload.source_mappings,
+        notification_settings=payload.notification_settings,
+        clear_channels=payload.clear_channels,
+        changed_by=current_user.github_login,
+    )
+    return TeamsConfigResponse.model_validate(config)
+
+
+@router.post(
+    "/test",
+    response_model=TeamsTestResponse,
+    dependencies=[Depends(verify_csrf)],
+)
+async def test_teams_connection(
+    payload: TeamsTestRequest | None = Body(default=None),
+    current_user: AuthenticatedUser = Depends(require_permission("admin_settings", "admin")),
+    db: AsyncSession = Depends(get_db),
+) -> TeamsTestResponse:
+    config = await teams_service.get_runtime_notification_config(db, "detections")
+    channel_webhooks = config["channel_webhooks"]
+    preferred_channel = (payload.channel if payload else None) or "default"
+    channel = (
+        preferred_channel
+        if channel_webhooks.get(preferred_channel)
+        else next(
+            (name for name, url in channel_webhooks.items() if url),
+            None,
+        )
+    )
+    if channel is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No Teams webhook is configured",
+        )
+
+    card = {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "size": "Large",
+                            "weight": "Bolder",
+                            "text": "Teams connection test",
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": (
+                                "OctoWatch successfully connected to Microsoft Teams "
+                                "and can send notifications."
+                            ),
+                            "wrap": True,
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": f"Triggered by {current_user.github_login}",
+                            "isSubtle": True,
+                        },
+                    ],
+                },
+            }
+        ],
+    }
+    await teams_service.send_adaptive_card(channel_webhooks[channel], card)
+    return TeamsTestResponse(ok=True, channel=channel, message="Test message sent successfully")

--- a/backend/app/schemas/integration.py
+++ b/backend/app/schemas/integration.py
@@ -38,7 +38,7 @@ class TicketingConfigResponse(BaseModel):
 
 
 class NotificationConfigCreate(BaseModel):
-    channel_type: str = Field(..., pattern=r"^(slack|email|webhook|pagerduty)$")
+    channel_type: str = Field(..., pattern=r"^(slack|email|webhook|pagerduty|teams)$")
     display_name: str = Field(..., min_length=1, max_length=255)
     target: str = Field(..., max_length=1000)
     credential_env_var: str | None = Field(None, max_length=255)
@@ -83,6 +83,50 @@ class SlackConfigResponse(BaseModel):
 
 
 class SlackTestResponse(BaseModel):
+    ok: bool
+    channel: str
+    message: str
+
+
+class PagerDutyConfigUpdate(BaseModel):
+    routing_key: str | None = Field(default=None, max_length=255)
+    severity_mapping: dict[str, str] = Field(default_factory=dict)
+    notification_settings: dict[str, bool] = Field(default_factory=dict)
+    auto_resolve: bool = False
+
+
+class PagerDutyConfigResponse(BaseModel):
+    routing_key_configured: bool
+    routing_key_masked: str | None = None
+    severity_mapping: dict[str, str] = Field(default_factory=dict)
+    notification_settings: dict[str, bool] = Field(default_factory=dict)
+    auto_resolve: bool = False
+
+
+class PagerDutyTestResponse(BaseModel):
+    ok: bool
+    message: str
+
+
+class TeamsConfigUpdate(BaseModel):
+    channel_webhooks: dict[str, str] = Field(default_factory=dict)
+    source_mappings: dict[str, str] = Field(default_factory=dict)
+    notification_settings: dict[str, bool] = Field(default_factory=dict)
+    clear_channels: list[str] = Field(default_factory=list)
+
+
+class TeamsConfigResponse(BaseModel):
+    channel_webhook_configured: dict[str, bool] = Field(default_factory=dict)
+    channel_webhooks_masked: dict[str, str | None] = Field(default_factory=dict)
+    source_mappings: dict[str, str] = Field(default_factory=dict)
+    notification_settings: dict[str, bool] = Field(default_factory=dict)
+
+
+class TeamsTestRequest(BaseModel):
+    channel: str | None = Field(default=None, max_length=100)
+
+
+class TeamsTestResponse(BaseModel):
     ok: bool
     channel: str
     message: str

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -25,11 +25,23 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.models.detection import Detection, RuleDefinition
 from app.models.integration import NotificationConfig
+from app.services.pagerduty_service import (
+    get_runtime_notification_config as get_runtime_pagerduty_config,
+)
+from app.services.pagerduty_service import (
+    send_pagerduty_notification as send_octowatch_pagerduty_notification,
+)
 from app.services.slack_service import (
     get_runtime_notification_config,
 )
 from app.services.slack_service import (
     send_slack_notification as send_octowatch_slack_notification,
+)
+from app.services.teams_service import (
+    get_runtime_notification_config as get_runtime_teams_config,
+)
+from app.services.teams_service import (
+    send_teams_notification as send_octowatch_teams_notification,
 )
 
 logger = structlog.get_logger(__name__)
@@ -178,6 +190,32 @@ async def send_detection_notifications(
         except Exception as exc:
             logger.error(
                 "notification.slack_global_failed",
+                detection_id=detection.id,
+                error=str(exc),
+            )
+
+    has_legacy_pagerduty = any(c.channel_type == "pagerduty" for c in matched_configs)
+    if not has_legacy_pagerduty:
+        try:
+            pagerduty_config = await get_runtime_pagerduty_config(session, "detections")
+            if pagerduty_config.get("enabled") and pagerduty_config.get("routing_key"):
+                await send_octowatch_pagerduty_notification(detection, pagerduty_config, valkey)
+        except Exception as exc:
+            logger.error(
+                "notification.pagerduty_global_failed",
+                detection_id=detection.id,
+                error=str(exc),
+            )
+
+    has_legacy_teams = any(c.channel_type == "teams" for c in matched_configs)
+    if not has_legacy_teams:
+        try:
+            teams_config = await get_runtime_teams_config(session, "detections")
+            if teams_config.get("enabled"):
+                await send_octowatch_teams_notification(detection, teams_config)
+        except Exception as exc:
+            logger.error(
+                "notification.teams_global_failed",
                 detection_id=detection.id,
                 error=str(exc),
             )

--- a/backend/app/services/pagerduty_service.py
+++ b/backend/app/services/pagerduty_service.py
@@ -1,0 +1,314 @@
+"""PagerDuty integration service for admin configuration and incident delivery."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import httpx
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.services.settings_service import get_setting, set_setting
+
+logger = structlog.get_logger(__name__)
+
+_PAGERDUTY_EVENTS_URL = "https://events.pagerduty.com/v2/enqueue"
+_PAGERDUTY_ROUTING_KEY_KEY = "pagerduty_routing_key"
+_PAGERDUTY_SEVERITY_MAPPING_KEY = "pagerduty_severity_mapping"
+_PAGERDUTY_NOTIFICATION_SETTINGS_KEY = "pagerduty_notification_settings"
+_PAGERDUTY_AUTO_RESOLVE_KEY = "pagerduty_auto_resolve"
+_PAGERDUTY_SOURCES = ("detections", "sync_errors", "system_health", "threat_intel")
+_DEFAULT_NOTIFICATION_SETTINGS: dict[str, bool] = {
+    "detections": True,
+    "sync_errors": True,
+    "system_health": True,
+    "threat_intel": False,
+}
+_DEFAULT_SEVERITY_MAPPING: dict[str, str] = {
+    "critical": "critical",
+    "high": "error",
+    "medium": "warning",
+    "low": "info",
+    "info": "info",
+}
+_VALID_PAGERDUTY_SEVERITIES = {"critical", "error", "warning", "info"}
+
+
+def _mask_secret(value: str | None) -> str | None:
+    if not value:
+        return None
+    if len(value) <= 8:
+        return "*" * len(value)
+    return f"{value[:4]}{'*' * max(len(value) - 8, 4)}{value[-4:]}"
+
+
+def _normalize_notification_settings(value: dict[str, Any] | None) -> dict[str, bool]:
+    normalized = dict(_DEFAULT_NOTIFICATION_SETTINGS)
+    if value:
+        for source in _PAGERDUTY_SOURCES:
+            if source in value:
+                normalized[source] = bool(value[source])
+    return normalized
+
+
+def _normalize_severity_mapping(value: dict[str, Any] | None) -> dict[str, str]:
+    normalized = dict(_DEFAULT_SEVERITY_MAPPING)
+    if value:
+        for severity in _DEFAULT_SEVERITY_MAPPING:
+            raw = str(value.get(severity, normalized[severity])).strip().lower()
+            normalized[severity] = (
+                raw if raw in _VALID_PAGERDUTY_SEVERITIES else _DEFAULT_SEVERITY_MAPPING[severity]
+            )
+    return normalized
+
+
+async def _get_json_setting(db: AsyncSession, key: str) -> dict[str, Any]:
+    raw = await get_setting(db, key)
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("pagerduty.settings_invalid_json", key=key)
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+async def get_pagerduty_config(db: AsyncSession) -> dict[str, Any]:
+    routing_key = await get_setting(db, _PAGERDUTY_ROUTING_KEY_KEY)
+    severity_mapping = _normalize_severity_mapping(
+        await _get_json_setting(db, _PAGERDUTY_SEVERITY_MAPPING_KEY)
+    )
+    notification_settings = _normalize_notification_settings(
+        await _get_json_setting(db, _PAGERDUTY_NOTIFICATION_SETTINGS_KEY)
+    )
+    auto_resolve = (await get_setting(db, _PAGERDUTY_AUTO_RESOLVE_KEY) or "false").lower() == "true"
+    return {
+        "routing_key_configured": bool(routing_key),
+        "routing_key_masked": _mask_secret(routing_key),
+        "severity_mapping": severity_mapping,
+        "notification_settings": notification_settings,
+        "auto_resolve": auto_resolve,
+    }
+
+
+async def update_pagerduty_config(
+    db: AsyncSession,
+    *,
+    routing_key: str | None,
+    severity_mapping: dict[str, Any],
+    notification_settings: dict[str, Any],
+    auto_resolve: bool,
+    changed_by: str,
+) -> dict[str, Any]:
+    if routing_key:
+        await set_setting(
+            db,
+            _PAGERDUTY_ROUTING_KEY_KEY,
+            routing_key,
+            category="integrations",
+            sensitivity="critical",
+            description="PagerDuty Events API routing key",
+            changed_by=changed_by,
+        )
+
+    await set_setting(
+        db,
+        _PAGERDUTY_SEVERITY_MAPPING_KEY,
+        json.dumps(_normalize_severity_mapping(severity_mapping)),
+        category="integrations",
+        sensitivity="config",
+        description="PagerDuty severity mapping by OctoWatch severity",
+        changed_by=changed_by,
+    )
+    await set_setting(
+        db,
+        _PAGERDUTY_NOTIFICATION_SETTINGS_KEY,
+        json.dumps(_normalize_notification_settings(notification_settings)),
+        category="integrations",
+        sensitivity="config",
+        description="PagerDuty notification enablement by OctoWatch source",
+        changed_by=changed_by,
+    )
+    await set_setting(
+        db,
+        _PAGERDUTY_AUTO_RESOLVE_KEY,
+        "true" if auto_resolve else "false",
+        category="integrations",
+        sensitivity="config",
+        description="Automatically resolve PagerDuty incidents when detections are resolved",
+        changed_by=changed_by,
+    )
+    await db.flush()
+    return await get_pagerduty_config(db)
+
+
+async def get_runtime_notification_config(db: AsyncSession, source: str) -> dict[str, Any]:
+    config = await get_pagerduty_config(db)
+    return {
+        "enabled": bool(config["notification_settings"].get(source, False)),
+        "routing_key": await get_setting(db, _PAGERDUTY_ROUTING_KEY_KEY),
+        "severity_mapping": config["severity_mapping"],
+        "auto_resolve": config["auto_resolve"],
+        "source": source,
+    }
+
+
+async def _post_event(payload: dict[str, Any]) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(_PAGERDUTY_EVENTS_URL, json=payload)
+        response.raise_for_status()
+    data = response.json()
+    if data.get("status") != "success":
+        raise RuntimeError(data.get("message", "pagerduty_api_error"))
+    return data
+
+
+async def create_incident(
+    title: str,
+    description: str,
+    severity: str,
+    source: str,
+    *,
+    routing_key: str | None = None,
+    dedup_key: str | None = None,
+    custom_details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    key = routing_key or getattr(settings.INTEGRATIONS, "PAGERDUTY_ROUTING_KEY", None)
+    if not key:
+        raise ValueError("PagerDuty routing key is not configured")
+
+    payload: dict[str, Any] = {
+        "routing_key": key,
+        "event_action": "trigger",
+        "payload": {
+            "summary": title,
+            "source": source,
+            "severity": severity,
+            "timestamp": datetime.now(UTC).isoformat(),
+            "custom_details": {
+                "description": description,
+                **(custom_details or {}),
+            },
+        },
+    }
+    if dedup_key:
+        payload["dedup_key"] = dedup_key
+    return await _post_event(payload)
+
+
+async def resolve_incident(
+    dedup_key: str,
+    *,
+    routing_key: str | None = None,
+    source: str = "octowatch",
+) -> dict[str, Any]:
+    key = routing_key or getattr(settings.INTEGRATIONS, "PAGERDUTY_ROUTING_KEY", None)
+    if not key:
+        raise ValueError("PagerDuty routing key is not configured")
+
+    return await _post_event(
+        {
+            "routing_key": key,
+            "event_action": "resolve",
+            "dedup_key": dedup_key,
+            "payload": {
+                "summary": f"Resolved: {dedup_key}",
+                "source": source,
+                "severity": "info",
+            },
+        }
+    )
+
+
+async def send_change_event(
+    summary: str,
+    source: str,
+    *,
+    routing_key: str | None = None,
+    custom_details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    key = routing_key or getattr(settings.INTEGRATIONS, "PAGERDUTY_ROUTING_KEY", None)
+    if not key:
+        raise ValueError("PagerDuty routing key is not configured")
+
+    return await _post_event(
+        {
+            "routing_key": key,
+            "event_action": "change",
+            "payload": {
+                "summary": summary,
+                "source": source,
+                "timestamp": datetime.now(UTC).isoformat(),
+                "custom_details": custom_details or {},
+            },
+        }
+    )
+
+
+async def send_pagerduty_notification(
+    notification: Any,
+    config: dict[str, Any],
+    valkey: Any | None = None,
+) -> dict[str, Any] | None:
+    if not config.get("enabled", True):
+        return None
+
+    routing_key = str(config.get("routing_key") or "").strip()
+    if not routing_key:
+        logger.debug("pagerduty.notification_skipped", reason="missing_routing_key")
+        return None
+
+    severity_mapping = _normalize_severity_mapping(config.get("severity_mapping"))
+    notification_severity = str(getattr(notification, "severity", "info")).lower()
+    pagerduty_severity = severity_mapping.get(notification_severity, "info")
+    dedup_key = f"octowatch-detection-{getattr(notification, 'id', 'notification')}"
+    custom_details = {
+        "detection_id": getattr(notification, "id", None),
+        "confidence": getattr(notification, "confidence", None),
+        "actor": getattr(notification, "actor", None),
+        "org": getattr(notification, "org", None),
+        "repo": getattr(notification, "repo", None),
+    }
+    response = await create_incident(
+        title=(
+            f"[{notification_severity.upper()}] "
+            f"{getattr(notification, 'title', 'OctoWatch notification')}"
+        ),
+        description=str(getattr(notification, "description", "No description provided.")),
+        severity=pagerduty_severity,
+        source="octowatch",
+        routing_key=routing_key,
+        dedup_key=dedup_key,
+        custom_details=custom_details,
+    )
+    if valkey is not None and getattr(notification, "id", None) is not None:
+        await valkey.set(f"pagerduty:dedup:{notification.id}", dedup_key, ex=86400 * 30)
+    logger.info(
+        "pagerduty.notification_sent",
+        dedup_key=dedup_key,
+        detection_id=getattr(notification, "id", None),
+    )
+    return response
+
+
+async def resolve_detection_incident(db: AsyncSession, valkey: Any, detection_id: int) -> bool:
+    config = await get_runtime_notification_config(db, "detections")
+    if not config.get("enabled") or not config.get("auto_resolve"):
+        return False
+
+    routing_key = str(config.get("routing_key") or "").strip()
+    if not routing_key:
+        return False
+
+    dedup_key = await valkey.get(f"pagerduty:dedup:{detection_id}")
+    if not dedup_key:
+        return False
+
+    await resolve_incident(str(dedup_key), routing_key=routing_key)
+    await valkey.delete(f"pagerduty:dedup:{detection_id}")
+    logger.info("pagerduty.incident_resolved", detection_id=detection_id, dedup_key=dedup_key)
+    return True

--- a/backend/app/services/teams_service.py
+++ b/backend/app/services/teams_service.py
@@ -1,0 +1,312 @@
+"""Microsoft Teams integration service for admin configuration and webhook delivery."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import settings
+from app.services.settings_service import get_setting, set_setting
+
+logger = structlog.get_logger(__name__)
+
+_TEAMS_CONFIG_KEY = "teams_channel_webhooks"
+_TEAMS_SOURCE_MAPPING_KEY = "teams_source_mappings"
+_TEAMS_NOTIFICATION_SETTINGS_KEY = "teams_notification_settings"
+_TEAMS_SOURCES = ("detections", "sync_errors", "system_health", "threat_intel")
+_TEAMS_CHANNELS = ("default", "detections", "sync_errors", "system_health", "threat_intel")
+_DEFAULT_SOURCE_MAPPINGS: dict[str, str] = {
+    "detections": "detections",
+    "sync_errors": "sync_errors",
+    "system_health": "system_health",
+    "threat_intel": "threat_intel",
+}
+_DEFAULT_NOTIFICATION_SETTINGS: dict[str, bool] = {
+    "detections": True,
+    "sync_errors": True,
+    "system_health": True,
+    "threat_intel": False,
+}
+
+
+def _mask_secret(value: str | None) -> str | None:
+    if not value:
+        return None
+    if len(value) <= 12:
+        return "*" * len(value)
+    return f"{value[:8]}{'*' * max(len(value) - 16, 4)}{value[-8:]}"
+
+
+async def _get_json_setting(db: AsyncSession, key: str) -> dict[str, Any]:
+    raw = await get_setting(db, key)
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("teams.settings_invalid_json", key=key)
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _normalize_channel_webhooks(value: dict[str, Any] | None) -> dict[str, str]:
+    channel_webhooks = dict.fromkeys(_TEAMS_CHANNELS, "")
+    if value:
+        for channel in _TEAMS_CHANNELS:
+            raw = value.get(channel, "")
+            channel_webhooks[channel] = str(raw).strip() if raw is not None else ""
+    return channel_webhooks
+
+
+def _normalize_source_mappings(value: dict[str, Any] | None) -> dict[str, str]:
+    mappings = dict(_DEFAULT_SOURCE_MAPPINGS)
+    if value:
+        for source in _TEAMS_SOURCES:
+            raw = str(value.get(source, mappings[source])).strip()
+            mappings[source] = raw if raw in _TEAMS_CHANNELS else _DEFAULT_SOURCE_MAPPINGS[source]
+    return mappings
+
+
+def _normalize_notification_settings(value: dict[str, Any] | None) -> dict[str, bool]:
+    normalized = dict(_DEFAULT_NOTIFICATION_SETTINGS)
+    if value:
+        for source in _TEAMS_SOURCES:
+            if source in value:
+                normalized[source] = bool(value[source])
+    return normalized
+
+
+async def get_teams_config(db: AsyncSession) -> dict[str, Any]:
+    channel_webhooks = _normalize_channel_webhooks(await _get_json_setting(db, _TEAMS_CONFIG_KEY))
+    source_mappings = _normalize_source_mappings(
+        await _get_json_setting(db, _TEAMS_SOURCE_MAPPING_KEY)
+    )
+    notification_settings = _normalize_notification_settings(
+        await _get_json_setting(db, _TEAMS_NOTIFICATION_SETTINGS_KEY)
+    )
+    return {
+        "channel_webhook_configured": {
+            channel: bool(url) for channel, url in channel_webhooks.items()
+        },
+        "channel_webhooks_masked": {
+            channel: _mask_secret(url) for channel, url in channel_webhooks.items()
+        },
+        "source_mappings": source_mappings,
+        "notification_settings": notification_settings,
+    }
+
+
+async def update_teams_config(
+    db: AsyncSession,
+    *,
+    channel_webhooks: dict[str, Any],
+    source_mappings: dict[str, Any],
+    notification_settings: dict[str, Any],
+    clear_channels: list[str],
+    changed_by: str,
+) -> dict[str, Any]:
+    existing_webhooks = _normalize_channel_webhooks(await _get_json_setting(db, _TEAMS_CONFIG_KEY))
+    updated_webhooks = dict(existing_webhooks)
+    for channel in clear_channels:
+        if channel in updated_webhooks:
+            updated_webhooks[channel] = ""
+    for channel, value in _normalize_channel_webhooks(channel_webhooks).items():
+        if value:
+            updated_webhooks[channel] = value
+
+    await set_setting(
+        db,
+        _TEAMS_CONFIG_KEY,
+        json.dumps(updated_webhooks),
+        category="integrations",
+        sensitivity="critical",
+        description="Microsoft Teams incoming webhook URLs by channel",
+        changed_by=changed_by,
+    )
+    await set_setting(
+        db,
+        _TEAMS_SOURCE_MAPPING_KEY,
+        json.dumps(_normalize_source_mappings(source_mappings)),
+        category="integrations",
+        sensitivity="config",
+        description="Microsoft Teams channel mapping by OctoWatch source",
+        changed_by=changed_by,
+    )
+    await set_setting(
+        db,
+        _TEAMS_NOTIFICATION_SETTINGS_KEY,
+        json.dumps(_normalize_notification_settings(notification_settings)),
+        category="integrations",
+        sensitivity="config",
+        description="Microsoft Teams notification enablement by OctoWatch source",
+        changed_by=changed_by,
+    )
+    await db.flush()
+    return await get_teams_config(db)
+
+
+async def get_runtime_notification_config(db: AsyncSession, source: str) -> dict[str, Any]:
+    channel_webhooks = _normalize_channel_webhooks(await _get_json_setting(db, _TEAMS_CONFIG_KEY))
+    source_mappings = _normalize_source_mappings(
+        await _get_json_setting(db, _TEAMS_SOURCE_MAPPING_KEY)
+    )
+    notification_settings = _normalize_notification_settings(
+        await _get_json_setting(db, _TEAMS_NOTIFICATION_SETTINGS_KEY)
+    )
+    return {
+        "enabled": bool(notification_settings.get(source, False)),
+        "channel_key": source_mappings.get(source, "default"),
+        "channel_webhooks": channel_webhooks,
+        "source_mappings": source_mappings,
+        "base_url": settings.AUTH.APP_BASE_URL,
+    }
+
+
+async def send_adaptive_card(webhook_url: str, card: dict[str, Any]) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        response = await client.post(webhook_url, json=card)
+        response.raise_for_status()
+    try:
+        return response.json()
+    except ValueError:
+        return {"ok": True, "response": response.text or "ok"}
+
+
+def format_notification_card(notification: Any, base_url: str | None = None) -> dict[str, Any]:
+    severity = str(getattr(notification, "severity", "info")).lower()
+    accent = {
+        "critical": "attention",
+        "high": "attention",
+        "medium": "warning",
+        "low": "accent",
+        "info": "default",
+    }.get(severity, "default")
+    title = str(getattr(notification, "title", "OctoWatch notification"))
+    description = str(getattr(notification, "description", "No description provided."))
+    detection_id = getattr(notification, "id", None)
+    action_url = f"{str(base_url).rstrip('/')}/threats" if base_url else None
+
+    actions: list[dict[str, Any]] = []
+    if action_url:
+        actions.append(
+            {
+                "type": "Action.OpenUrl",
+                "title": "Open in OctoWatch",
+                "url": action_url,
+            }
+        )
+
+    return {
+        "type": "message",
+        "attachments": [
+            {
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": {
+                    "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                    "type": "AdaptiveCard",
+                    "version": "1.4",
+                    "body": [
+                        {
+                            "type": "TextBlock",
+                            "size": "Large",
+                            "weight": "Bolder",
+                            "color": accent,
+                            "text": title,
+                            "wrap": True,
+                        },
+                        {
+                            "type": "ColumnSet",
+                            "columns": [
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {"type": "TextBlock", "text": "Severity", "isSubtle": True},
+                                        {
+                                            "type": "TextBlock",
+                                            "text": severity.upper(),
+                                            "weight": "Bolder",
+                                            "color": accent,
+                                        },
+                                    ],
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {"type": "TextBlock", "text": "Actor", "isSubtle": True},
+                                        {
+                                            "type": "TextBlock",
+                                            "text": str(
+                                                getattr(notification, "actor", None) or "N/A"
+                                            ),
+                                        },
+                                    ],
+                                },
+                                {
+                                    "type": "Column",
+                                    "width": "stretch",
+                                    "items": [
+                                        {"type": "TextBlock", "text": "Org", "isSubtle": True},
+                                        {
+                                            "type": "TextBlock",
+                                            "text": str(
+                                                getattr(notification, "org", None) or "N/A"
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                        {
+                            "type": "TextBlock",
+                            "text": description,
+                            "wrap": True,
+                        },
+                        {
+                            "type": "FactSet",
+                            "facts": [
+                                {"title": "Detection ID", "value": str(detection_id or "N/A")},
+                                {
+                                    "title": "Triggered",
+                                    "value": str(
+                                        getattr(notification, "triggered_at", None) or "N/A"
+                                    ),
+                                },
+                            ],
+                        },
+                    ],
+                    "actions": actions,
+                },
+            }
+        ],
+    }
+
+
+async def send_teams_notification(
+    notification: Any, config: dict[str, Any]
+) -> dict[str, Any] | None:
+    if not config.get("enabled", True):
+        return None
+
+    channel_key = str(config.get("channel_key") or "default")
+    channel_webhooks = _normalize_channel_webhooks(config.get("channel_webhooks"))
+    webhook_url = channel_webhooks.get(channel_key) or channel_webhooks.get("default", "")
+    if not webhook_url:
+        logger.debug(
+            "teams.notification_skipped", reason="missing_webhook", channel_key=channel_key
+        )
+        return None
+
+    card = format_notification_card(notification, base_url=config.get("base_url"))
+    response = await send_adaptive_card(webhook_url, card)
+    logger.info(
+        "teams.notification_sent",
+        detection_id=getattr(notification, "id", None),
+        channel_key=channel_key,
+    )
+    return response

--- a/frontend/src/api/pagerduty.ts
+++ b/frontend/src/api/pagerduty.ts
@@ -1,0 +1,44 @@
+import { api } from './client';
+
+export type PagerDutyNotificationSource =
+  | 'detections'
+  | 'sync_errors'
+  | 'system_health'
+  | 'threat_intel';
+
+export type PagerDutySeverity = 'critical' | 'error' | 'warning' | 'info';
+export type OctoWatchSeverity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export interface PagerDutyConfigResponse {
+  routing_key_configured: boolean;
+  routing_key_masked: string | null;
+  severity_mapping: Record<OctoWatchSeverity, PagerDutySeverity>;
+  notification_settings: Record<PagerDutyNotificationSource, boolean>;
+  auto_resolve: boolean;
+}
+
+export interface PagerDutyConfigUpdate {
+  routing_key?: string;
+  severity_mapping: Record<OctoWatchSeverity, PagerDutySeverity>;
+  notification_settings: Record<PagerDutyNotificationSource, boolean>;
+  auto_resolve: boolean;
+}
+
+export interface PagerDutyTestResponse {
+  ok: boolean;
+  message: string;
+}
+
+export function getPagerDutyConfig(): Promise<PagerDutyConfigResponse> {
+  return api.get<PagerDutyConfigResponse>('/integrations/pagerduty/config');
+}
+
+export function updatePagerDutyConfig(
+  payload: PagerDutyConfigUpdate,
+): Promise<PagerDutyConfigResponse> {
+  return api.put<PagerDutyConfigResponse>('/integrations/pagerduty/config', payload);
+}
+
+export function testPagerDutyConnection(): Promise<PagerDutyTestResponse> {
+  return api.post<PagerDutyTestResponse>('/integrations/pagerduty/test');
+}

--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -79,7 +79,12 @@ export type TeamsNotificationSource =
   | 'system_health'
   | 'threat_intel';
 
-export type TeamsChannelKey = 'default' | 'detections' | 'sync_errors' | 'system_health' | 'threat_intel';
+export type TeamsChannelKey =
+  | 'default'
+  | 'detections'
+  | 'sync_errors'
+  | 'system_health'
+  | 'threat_intel';
 
 export interface TeamsConfigResponse {
   channel_webhook_configured: Record<TeamsChannelKey, boolean>;

--- a/frontend/src/api/teams.ts
+++ b/frontend/src/api/teams.ts
@@ -72,3 +72,43 @@ export function assignTeamRole(teamId: number, roleId: number, orgSlug?: string)
 export function removeTeamRole(teamId: number, roleId: number): Promise<void> {
   return api.delete<void>(`/admin/teams/${teamId}/roles/${roleId}`);
 }
+
+export type TeamsNotificationSource =
+  | 'detections'
+  | 'sync_errors'
+  | 'system_health'
+  | 'threat_intel';
+
+export type TeamsChannelKey = 'default' | 'detections' | 'sync_errors' | 'system_health' | 'threat_intel';
+
+export interface TeamsConfigResponse {
+  channel_webhook_configured: Record<TeamsChannelKey, boolean>;
+  channel_webhooks_masked: Record<TeamsChannelKey, string | null>;
+  source_mappings: Record<TeamsNotificationSource, TeamsChannelKey>;
+  notification_settings: Record<TeamsNotificationSource, boolean>;
+}
+
+export interface TeamsConfigUpdate {
+  channel_webhooks: Record<TeamsChannelKey, string>;
+  source_mappings: Record<TeamsNotificationSource, TeamsChannelKey>;
+  notification_settings: Record<TeamsNotificationSource, boolean>;
+  clear_channels: TeamsChannelKey[];
+}
+
+export interface TeamsTestResponse {
+  ok: boolean;
+  channel: TeamsChannelKey;
+  message: string;
+}
+
+export function getTeamsConfig(): Promise<TeamsConfigResponse> {
+  return api.get<TeamsConfigResponse>('/integrations/teams/config');
+}
+
+export function updateTeamsConfig(payload: TeamsConfigUpdate): Promise<TeamsConfigResponse> {
+  return api.put<TeamsConfigResponse>('/integrations/teams/config', payload);
+}
+
+export function testTeamsConnection(channel?: TeamsChannelKey): Promise<TeamsTestResponse> {
+  return api.post<TeamsTestResponse>('/integrations/teams/test', channel ? { channel } : undefined);
+}

--- a/frontend/src/pages/Integrations/PagerDutyIntegration.module.css
+++ b/frontend/src/pages/Integrations/PagerDutyIntegration.module.css
@@ -1,0 +1,153 @@
+.panel {
+  border: 1px solid var(--border-subtle, #d0d7de);
+  border-radius: 16px;
+  background: var(--surface-raised, #fff);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.titleGroup {
+  display: grid;
+  gap: 6px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.description {
+  margin: 0;
+  color: var(--fg-muted, #667085);
+}
+
+.statusRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  background: var(--bg-subtle, #f2f4f7);
+  color: var(--fg-muted, #475467);
+}
+
+.badge[data-state='ready'] {
+  background: rgba(18, 183, 106, 0.12);
+  color: #027a48;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  border: 1px solid var(--border-subtle, #d0d7de);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font: inherit;
+  background: var(--surface-default, #fff);
+  color: var(--fg-default, #101828);
+}
+
+.help {
+  font-size: 0.875rem;
+  color: var(--fg-muted, #667085);
+}
+
+.mappingSection {
+  display: grid;
+  gap: 12px;
+}
+
+.mappingRow {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.4fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.testStatus {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.testStatus[data-state='success'] {
+  color: #027a48;
+}
+
+.testStatus[data-state='error'] {
+  color: #b42318;
+}
+
+.instructions {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-left: 20px;
+  color: var(--fg-muted, #667085);
+}
+
+.commandList {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.command {
+  font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  background: var(--bg-subtle, #f2f4f7);
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.error {
+  color: #b42318;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .mappingRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/Integrations/PagerDutyIntegration.test.tsx
+++ b/frontend/src/pages/Integrations/PagerDutyIntegration.test.tsx
@@ -38,7 +38,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockGetPagerDutyConfig.mockResolvedValue(config);
   mockUpdatePagerDutyConfig.mockResolvedValue(config);
-  mockTestPagerDutyConnection.mockResolvedValue({ ok: true, message: 'Test event sent successfully' });
+  mockTestPagerDutyConnection.mockResolvedValue({
+    ok: true,
+    message: 'Test event sent successfully',
+  });
 });
 
 describe('PagerDutyIntegration', () => {
@@ -50,7 +53,11 @@ describe('PagerDutyIntegration', () => {
     });
 
     expect(screen.getByRole('heading', { name: /pagerduty integration/i })).toBeInTheDocument();
-    expect(screen.getByRole('checkbox', { name: /resolve incidents when a detection is marked resolved/i })).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', {
+        name: /resolve incidents when a detection is marked resolved/i,
+      }),
+    ).toBeChecked();
   });
 
   it('saves updated PagerDuty settings', async () => {

--- a/frontend/src/pages/Integrations/PagerDutyIntegration.test.tsx
+++ b/frontend/src/pages/Integrations/PagerDutyIntegration.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/utils';
+import { PagerDutyIntegration } from './PagerDutyIntegration';
+import type { PagerDutyConfigResponse } from '../../api/pagerduty';
+
+const mockGetPagerDutyConfig = vi.fn<() => Promise<PagerDutyConfigResponse>>();
+const mockUpdatePagerDutyConfig = vi.fn();
+const mockTestPagerDutyConnection = vi.fn();
+
+vi.mock('../../api/pagerduty', () => ({
+  getPagerDutyConfig: (...args: unknown[]) => mockGetPagerDutyConfig(...(args as [])),
+  updatePagerDutyConfig: (...args: unknown[]) => mockUpdatePagerDutyConfig(...args),
+  testPagerDutyConnection: (...args: unknown[]) => mockTestPagerDutyConnection(...(args as [])),
+}));
+
+const config: PagerDutyConfigResponse = {
+  routing_key_configured: true,
+  routing_key_masked: 'abcd********wxyz',
+  severity_mapping: {
+    critical: 'critical',
+    high: 'error',
+    medium: 'warning',
+    low: 'info',
+    info: 'info',
+  },
+  notification_settings: {
+    detections: true,
+    sync_errors: true,
+    system_health: false,
+    threat_intel: true,
+  },
+  auto_resolve: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetPagerDutyConfig.mockResolvedValue(config);
+  mockUpdatePagerDutyConfig.mockResolvedValue(config);
+  mockTestPagerDutyConnection.mockResolvedValue({ ok: true, message: 'Test event sent successfully' });
+});
+
+describe('PagerDutyIntegration', () => {
+  it('renders PagerDuty configuration from the API', async () => {
+    renderWithProviders(<PagerDutyIntegration />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/critical severity mapping/i)).toHaveValue('critical');
+    });
+
+    expect(screen.getByRole('heading', { name: /pagerduty integration/i })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /resolve incidents when a detection is marked resolved/i })).toBeChecked();
+  });
+
+  it('saves updated PagerDuty settings', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PagerDutyIntegration />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/medium severity mapping/i)).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByLabelText(/medium severity mapping/i), 'error');
+    await user.click(screen.getByRole('checkbox', { name: /enable system health/i }));
+    await user.click(screen.getByRole('button', { name: /save pagerduty settings/i }));
+
+    await waitFor(() => {
+      expect(mockUpdatePagerDutyConfig).toHaveBeenCalledWith({
+        severity_mapping: {
+          critical: 'critical',
+          high: 'error',
+          medium: 'error',
+          low: 'info',
+          info: 'info',
+        },
+        notification_settings: {
+          detections: true,
+          sync_errors: true,
+          system_health: true,
+          threat_intel: true,
+        },
+        auto_resolve: true,
+        routing_key: undefined,
+      });
+    });
+  });
+
+  it('tests the PagerDuty connection and shows status', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PagerDutyIntegration />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /test connection/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /test connection/i }));
+
+    await waitFor(() => {
+      expect(mockTestPagerDutyConnection).toHaveBeenCalledOnce();
+    });
+
+    expect(screen.getByText('Test event sent successfully')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Integrations/PagerDutyIntegration.tsx
+++ b/frontend/src/pages/Integrations/PagerDutyIntegration.tsx
@@ -1,0 +1,218 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getPagerDutyConfig,
+  testPagerDutyConnection,
+  updatePagerDutyConfig,
+  type OctoWatchSeverity,
+  type PagerDutyConfigResponse,
+  type PagerDutyConfigUpdate,
+  type PagerDutyNotificationSource,
+  type PagerDutySeverity,
+} from '../../api/pagerduty';
+import { Button } from '../../components/primitives/Button';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { useToast } from '../../hooks/useToast';
+import styles from './PagerDutyIntegration.module.css';
+
+const SOURCE_LABELS: Record<PagerDutyNotificationSource, string> = {
+  detections: 'Detections',
+  sync_errors: 'Sync errors',
+  system_health: 'System health',
+  threat_intel: 'Threat intel',
+};
+
+const SEVERITY_OPTIONS: PagerDutySeverity[] = ['critical', 'error', 'warning', 'info'];
+const OCTOWATCH_SEVERITIES: OctoWatchSeverity[] = ['critical', 'high', 'medium', 'low', 'info'];
+
+function toFormState(config: PagerDutyConfigResponse): PagerDutyConfigUpdate {
+  return {
+    severity_mapping: config.severity_mapping,
+    notification_settings: config.notification_settings,
+    auto_resolve: config.auto_resolve,
+  };
+}
+
+export function PagerDutyIntegration() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [routingKey, setRoutingKey] = useState('');
+  const [draft, setDraft] = useState<PagerDutyConfigUpdate | null>(null);
+  const [testStatus, setTestStatus] = useState<{ state: 'success' | 'error'; message: string } | null>(null);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['pagerduty-config'],
+    queryFn: getPagerDutyConfig,
+  });
+
+  const form = draft ?? (data ? toFormState(data) : null);
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      updatePagerDutyConfig({
+        ...(form as PagerDutyConfigUpdate),
+        routing_key: routingKey.trim() || undefined,
+      }),
+    onSuccess: (response) => {
+      queryClient.setQueryData(['pagerduty-config'], response);
+      setDraft(null);
+      setRoutingKey('');
+      setTestStatus(null);
+      showToast('PagerDuty configuration saved', 'success');
+    },
+    onError: () => {
+      showToast('Failed to save PagerDuty configuration', 'error');
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationFn: testPagerDutyConnection,
+    onSuccess: (response) => {
+      setTestStatus({ state: 'success', message: response.message });
+      showToast('PagerDuty test sent', 'success');
+    },
+    onError: () => {
+      setTestStatus({ state: 'error', message: 'PagerDuty test failed. Check the routing key.' });
+      showToast('PagerDuty test failed', 'error');
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <div className={styles.panel}>
+          <Spinner />
+          <span>Loading PagerDuty integration…</span>
+        </div>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return <ErrorBanner message={error instanceof Error ? error.message : 'Failed to load PagerDuty integration'} />;
+  }
+
+  if (!data || !form) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <div className={styles.panel}>
+        <div className={styles.header}>
+          <div className={styles.titleGroup}>
+            <h2 className={styles.title}>PagerDuty integration</h2>
+            <p className={styles.description}>
+              Trigger PagerDuty incidents for OctoWatch alerts and optionally auto-resolve them when detections close.
+            </p>
+          </div>
+          <div className={styles.statusRow}>
+            <span className={styles.badge} data-state={data.routing_key_configured ? 'ready' : 'missing'}>
+              Routing key {data.routing_key_configured ? 'configured' : 'missing'}
+            </span>
+            <span className={styles.badge} data-state={form.auto_resolve ? 'ready' : 'missing'}>
+              Auto-resolve {form.auto_resolve ? 'enabled' : 'disabled'}
+            </span>
+          </div>
+        </div>
+
+        <div className={styles.grid}>
+          <div className={styles.field}>
+            <label className={styles.label} htmlFor="pagerduty-routing-key">
+              Routing key
+            </label>
+            <input
+              id="pagerduty-routing-key"
+              className={styles.input}
+              type="password"
+              value={routingKey}
+              onChange={(event) => setRoutingKey(event.target.value)}
+              placeholder={data.routing_key_masked ?? '••••••••••••'}
+            />
+            <span className={styles.help}>Leave blank to keep the existing PagerDuty integration key.</span>
+          </div>
+
+          <label className={styles.toggle}>
+            <input
+              type="checkbox"
+              checked={form.auto_resolve}
+              onChange={(event) => setDraft({ ...form, auto_resolve: event.target.checked })}
+            />
+            Resolve incidents when a detection is marked resolved
+          </label>
+        </div>
+
+        <div className={styles.mappingSection}>
+          <CardHeader>Severity mapping</CardHeader>
+          {OCTOWATCH_SEVERITIES.map((severity) => (
+            <div key={severity} className={styles.mappingRow}>
+              <label className={styles.label} htmlFor={`pagerduty-severity-${severity}`}>
+                {severity.charAt(0).toUpperCase() + severity.slice(1)}
+              </label>
+              <select
+                id={`pagerduty-severity-${severity}`}
+                className={styles.input}
+                aria-label={`${severity} severity mapping`}
+                value={form.severity_mapping[severity]}
+                onChange={(event) =>
+                  setDraft({
+                    ...form,
+                    severity_mapping: {
+                      ...form.severity_mapping,
+                      [severity]: event.target.value as PagerDutySeverity,
+                    },
+                  })
+                }
+              >
+                {SEVERITY_OPTIONS.map((option) => (
+                  <option key={option} value={option}>
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.mappingSection}>
+          <CardHeader>Notification sources</CardHeader>
+          {Object.entries(SOURCE_LABELS).map(([source, label]) => (
+            <label key={source} className={styles.toggle}>
+              <input
+                type="checkbox"
+                checked={form.notification_settings[source as PagerDutyNotificationSource]}
+                onChange={(event) =>
+                  setDraft({
+                    ...form,
+                    notification_settings: {
+                      ...form.notification_settings,
+                      [source]: event.target.checked,
+                    },
+                  })
+                }
+              />
+              Enable {label}
+            </label>
+          ))}
+        </div>
+
+        <div className={styles.actions}>
+          <Button variant="primary" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+            {saveMutation.isPending ? 'Saving…' : 'Save PagerDuty settings'}
+          </Button>
+          <Button onClick={() => testMutation.mutate()} disabled={testMutation.isPending}>
+            {testMutation.isPending ? 'Testing…' : 'Test connection'}
+          </Button>
+          {testStatus && (
+            <span className={styles.testStatus} data-state={testStatus.state}>
+              {testStatus.message}
+            </span>
+          )}
+          {saveMutation.isError && <span className={styles.error}>Unable to save PagerDuty settings.</span>}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Integrations/PagerDutyIntegration.tsx
+++ b/frontend/src/pages/Integrations/PagerDutyIntegration.tsx
@@ -40,7 +40,10 @@ export function PagerDutyIntegration() {
   const { showToast } = useToast();
   const [routingKey, setRoutingKey] = useState('');
   const [draft, setDraft] = useState<PagerDutyConfigUpdate | null>(null);
-  const [testStatus, setTestStatus] = useState<{ state: 'success' | 'error'; message: string } | null>(null);
+  const [testStatus, setTestStatus] = useState<{
+    state: 'success' | 'error';
+    message: string;
+  } | null>(null);
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['pagerduty-config'],
@@ -91,7 +94,11 @@ export function PagerDutyIntegration() {
   }
 
   if (isError) {
-    return <ErrorBanner message={error instanceof Error ? error.message : 'Failed to load PagerDuty integration'} />;
+    return (
+      <ErrorBanner
+        message={error instanceof Error ? error.message : 'Failed to load PagerDuty integration'}
+      />
+    );
   }
 
   if (!data || !form) {
@@ -105,11 +112,15 @@ export function PagerDutyIntegration() {
           <div className={styles.titleGroup}>
             <h2 className={styles.title}>PagerDuty integration</h2>
             <p className={styles.description}>
-              Trigger PagerDuty incidents for OctoWatch alerts and optionally auto-resolve them when detections close.
+              Trigger PagerDuty incidents for OctoWatch alerts and optionally auto-resolve them when
+              detections close.
             </p>
           </div>
           <div className={styles.statusRow}>
-            <span className={styles.badge} data-state={data.routing_key_configured ? 'ready' : 'missing'}>
+            <span
+              className={styles.badge}
+              data-state={data.routing_key_configured ? 'ready' : 'missing'}
+            >
               Routing key {data.routing_key_configured ? 'configured' : 'missing'}
             </span>
             <span className={styles.badge} data-state={form.auto_resolve ? 'ready' : 'missing'}>
@@ -131,7 +142,9 @@ export function PagerDutyIntegration() {
               onChange={(event) => setRoutingKey(event.target.value)}
               placeholder={data.routing_key_masked ?? '••••••••••••'}
             />
-            <span className={styles.help}>Leave blank to keep the existing PagerDuty integration key.</span>
+            <span className={styles.help}>
+              Leave blank to keep the existing PagerDuty integration key.
+            </span>
           </div>
 
           <label className={styles.toggle}>
@@ -199,7 +212,11 @@ export function PagerDutyIntegration() {
         </div>
 
         <div className={styles.actions}>
-          <Button variant="primary" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button
+            variant="primary"
+            onClick={() => saveMutation.mutate()}
+            disabled={saveMutation.isPending}
+          >
             {saveMutation.isPending ? 'Saving…' : 'Save PagerDuty settings'}
           </Button>
           <Button onClick={() => testMutation.mutate()} disabled={testMutation.isPending}>
@@ -210,7 +227,9 @@ export function PagerDutyIntegration() {
               {testStatus.message}
             </span>
           )}
-          {saveMutation.isError && <span className={styles.error}>Unable to save PagerDuty settings.</span>}
+          {saveMutation.isError && (
+            <span className={styles.error}>Unable to save PagerDuty settings.</span>
+          )}
         </div>
       </div>
     </Card>

--- a/frontend/src/pages/Integrations/TeamsIntegration.module.css
+++ b/frontend/src/pages/Integrations/TeamsIntegration.module.css
@@ -1,0 +1,159 @@
+.panel {
+  border: 1px solid var(--border-subtle, #d0d7de);
+  border-radius: 16px;
+  background: var(--surface-raised, #fff);
+  padding: 24px;
+  display: grid;
+  gap: 20px;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.titleGroup {
+  display: grid;
+  gap: 6px;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.description {
+  margin: 0;
+  color: var(--fg-muted, #667085);
+}
+
+.statusRow {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  background: var(--bg-subtle, #f2f4f7);
+  color: var(--fg-muted, #475467);
+}
+
+.badge[data-state='ready'] {
+  background: rgba(18, 183, 106, 0.12);
+  color: #027a48;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.field {
+  display: grid;
+  gap: 6px;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  border: 1px solid var(--border-subtle, #d0d7de);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font: inherit;
+  background: var(--surface-default, #fff);
+  color: var(--fg-default, #101828);
+}
+
+.help {
+  font-size: 0.875rem;
+  color: var(--fg-muted, #667085);
+}
+
+.mappingSection {
+  display: grid;
+  gap: 12px;
+}
+
+.mappingRow {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(220px, 1.4fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.inputGroup {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.testStatus {
+  font-size: 0.875rem;
+  font-weight: 600;
+}
+
+.testStatus[data-state='success'] {
+  color: #027a48;
+}
+
+.testStatus[data-state='error'] {
+  color: #b42318;
+}
+
+.instructions {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding-left: 20px;
+  color: var(--fg-muted, #667085);
+}
+
+.commandList {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.command {
+  font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.875rem;
+  background: var(--bg-subtle, #f2f4f7);
+  border-radius: 999px;
+  padding: 6px 10px;
+}
+
+.error {
+  color: #b42318;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .mappingRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/Integrations/TeamsIntegration.test.tsx
+++ b/frontend/src/pages/Integrations/TeamsIntegration.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/utils';
+import { TeamsIntegration } from './TeamsIntegration';
+import type { TeamsConfigResponse } from '../../api/teams';
+
+const mockGetTeamsConfig = vi.fn<() => Promise<TeamsConfigResponse>>();
+const mockUpdateTeamsConfig = vi.fn();
+const mockTestTeamsConnection = vi.fn();
+
+vi.mock('../../api/teams', () => ({
+  getTeamsConfig: (...args: unknown[]) => mockGetTeamsConfig(...(args as [])),
+  updateTeamsConfig: (...args: unknown[]) => mockUpdateTeamsConfig(...args),
+  testTeamsConnection: (...args: unknown[]) => mockTestTeamsConnection(...args),
+}));
+
+const config: TeamsConfigResponse = {
+  channel_webhook_configured: {
+    default: true,
+    detections: true,
+    sync_errors: false,
+    system_health: false,
+    threat_intel: true,
+  },
+  channel_webhooks_masked: {
+    default: 'https://o*******1234',
+    detections: 'https://d*******5678',
+    sync_errors: null,
+    system_health: null,
+    threat_intel: 'https://t*******9999',
+  },
+  source_mappings: {
+    detections: 'detections',
+    sync_errors: 'default',
+    system_health: 'default',
+    threat_intel: 'threat_intel',
+  },
+  notification_settings: {
+    detections: true,
+    sync_errors: true,
+    system_health: false,
+    threat_intel: true,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetTeamsConfig.mockResolvedValue(config);
+  mockUpdateTeamsConfig.mockResolvedValue(config);
+  mockTestTeamsConnection.mockResolvedValue({
+    ok: true,
+    channel: 'detections',
+    message: 'Test message sent successfully',
+  });
+});
+
+describe('TeamsIntegration', () => {
+  it('renders Teams configuration from the API', async () => {
+    renderWithProviders(<TeamsIntegration />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/detections channel mapping/i)).toHaveValue('detections');
+    });
+
+    expect(screen.getByRole('heading', { name: /microsoft teams integration/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/default channel webhook/i)).toHaveAttribute(
+      'placeholder',
+      'https://o*******1234',
+    );
+  });
+
+  it('saves updated Teams settings', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TeamsIntegration />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/system health channel mapping/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/system health channel webhook/i), 'https://example.test/system-health');
+    await user.selectOptions(screen.getByLabelText(/system health channel mapping/i), 'system_health');
+    await user.click(screen.getByRole('checkbox', { name: /enable system health/i }));
+    await user.click(screen.getByRole('button', { name: /save teams settings/i }));
+
+    await waitFor(() => {
+      expect(mockUpdateTeamsConfig).toHaveBeenCalledWith({
+        channel_webhooks: {
+          default: '',
+          detections: '',
+          sync_errors: '',
+          system_health: 'https://example.test/system-health',
+          threat_intel: '',
+        },
+        source_mappings: {
+          detections: 'detections',
+          sync_errors: 'default',
+          system_health: 'system_health',
+          threat_intel: 'threat_intel',
+        },
+        notification_settings: {
+          detections: true,
+          sync_errors: true,
+          system_health: true,
+          threat_intel: true,
+        },
+        clear_channels: [],
+      });
+    });
+  });
+
+  it('tests the Teams connection and shows status', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<TeamsIntegration />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /test message/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /test message/i }));
+
+    await waitFor(() => {
+      expect(mockTestTeamsConnection).toHaveBeenCalledWith('detections');
+    });
+
+    expect(screen.getByText('Test message sent successfully')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Integrations/TeamsIntegration.test.tsx
+++ b/frontend/src/pages/Integrations/TeamsIntegration.test.tsx
@@ -63,7 +63,9 @@ describe('TeamsIntegration', () => {
       expect(screen.getByLabelText(/detections channel mapping/i)).toHaveValue('detections');
     });
 
-    expect(screen.getByRole('heading', { name: /microsoft teams integration/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /microsoft teams integration/i }),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/default channel webhook/i)).toHaveAttribute(
       'placeholder',
       'https://o*******1234',
@@ -78,8 +80,14 @@ describe('TeamsIntegration', () => {
       expect(screen.getByLabelText(/system health channel mapping/i)).toBeInTheDocument();
     });
 
-    await user.type(screen.getByLabelText(/system health channel webhook/i), 'https://example.test/system-health');
-    await user.selectOptions(screen.getByLabelText(/system health channel mapping/i), 'system_health');
+    await user.type(
+      screen.getByLabelText(/system health channel webhook/i),
+      'https://example.test/system-health',
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/system health channel mapping/i),
+      'system_health',
+    );
     await user.click(screen.getByRole('checkbox', { name: /enable system health/i }));
     await user.click(screen.getByRole('button', { name: /save teams settings/i }));
 

--- a/frontend/src/pages/Integrations/TeamsIntegration.tsx
+++ b/frontend/src/pages/Integrations/TeamsIntegration.tsx
@@ -1,0 +1,256 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  getTeamsConfig,
+  testTeamsConnection,
+  updateTeamsConfig,
+  type TeamsChannelKey,
+  type TeamsConfigResponse,
+  type TeamsConfigUpdate,
+  type TeamsNotificationSource,
+} from '../../api/teams';
+import { Button } from '../../components/primitives/Button';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { useToast } from '../../hooks/useToast';
+import styles from './TeamsIntegration.module.css';
+
+const CHANNEL_LABELS: Record<TeamsChannelKey, string> = {
+  default: 'Default channel',
+  detections: 'Detections channel',
+  sync_errors: 'Sync errors channel',
+  system_health: 'System health channel',
+  threat_intel: 'Threat intel channel',
+};
+
+const SOURCE_LABELS: Record<TeamsNotificationSource, string> = {
+  detections: 'Detections',
+  sync_errors: 'Sync errors',
+  system_health: 'System health',
+  threat_intel: 'Threat intel',
+};
+
+const CHANNEL_KEYS = Object.keys(CHANNEL_LABELS) as TeamsChannelKey[];
+
+function toFormState(): TeamsConfigUpdate {
+  return {
+    channel_webhooks: {
+      default: '',
+      detections: '',
+      sync_errors: '',
+      system_health: '',
+      threat_intel: '',
+    },
+    source_mappings: {
+      detections: 'detections',
+      sync_errors: 'sync_errors',
+      system_health: 'system_health',
+      threat_intel: 'threat_intel',
+    },
+    notification_settings: {
+      detections: true,
+      sync_errors: true,
+      system_health: true,
+      threat_intel: false,
+    },
+    clear_channels: [],
+  };
+}
+
+function mergeConfig(config: TeamsConfigResponse): TeamsConfigUpdate {
+  return {
+    channel_webhooks: toFormState().channel_webhooks,
+    source_mappings: config.source_mappings,
+    notification_settings: config.notification_settings,
+    clear_channels: [],
+  };
+}
+
+export function TeamsIntegration() {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [draft, setDraft] = useState<TeamsConfigUpdate | null>(null);
+  const [testStatus, setTestStatus] = useState<{ state: 'success' | 'error'; message: string } | null>(null);
+
+  const { data, isLoading, isError, error } = useQuery({
+    queryKey: ['teams-config'],
+    queryFn: getTeamsConfig,
+  });
+
+  const form = draft ?? (data ? mergeConfig(data) : null);
+
+  const saveMutation = useMutation({
+    mutationFn: () => updateTeamsConfig(form as TeamsConfigUpdate),
+    onSuccess: (response) => {
+      queryClient.setQueryData(['teams-config'], response);
+      setDraft(null);
+      setTestStatus(null);
+      showToast('Teams configuration saved', 'success');
+    },
+    onError: () => {
+      showToast('Failed to save Teams configuration', 'error');
+    },
+  });
+
+  const testMutation = useMutation({
+    mutationFn: () => testTeamsConnection(form?.source_mappings.detections ?? 'default'),
+    onSuccess: (response) => {
+      setTestStatus({ state: 'success', message: response.message });
+      showToast('Teams test sent', 'success');
+    },
+    onError: () => {
+      setTestStatus({ state: 'error', message: 'Teams test failed. Check the configured webhook URLs.' });
+      showToast('Teams test failed', 'error');
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <Card>
+        <div className={styles.panel}>
+          <Spinner />
+          <span>Loading Teams integration…</span>
+        </div>
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return <ErrorBanner message={error instanceof Error ? error.message : 'Failed to load Teams integration'} />;
+  }
+
+  if (!data || !form) {
+    return null;
+  }
+
+  const configuredCount = Object.values(data.channel_webhook_configured).filter(Boolean).length;
+
+  return (
+    <Card>
+      <div className={styles.panel}>
+        <div className={styles.header}>
+          <div className={styles.titleGroup}>
+            <h2 className={styles.title}>Microsoft Teams integration</h2>
+            <p className={styles.description}>
+              Deliver OctoWatch alerts to Teams channels with Adaptive Cards and source-specific routing.
+            </p>
+          </div>
+          <div className={styles.statusRow}>
+            <span className={styles.badge} data-state={configuredCount > 0 ? 'ready' : 'missing'}>
+              {configuredCount} webhook{configuredCount === 1 ? '' : 's'} configured
+            </span>
+          </div>
+        </div>
+
+        <div className={styles.mappingSection}>
+          <CardHeader>Channel webhooks</CardHeader>
+          {CHANNEL_KEYS.map((channel) => (
+            <div key={channel} className={styles.mappingRow}>
+              <label className={styles.label} htmlFor={`teams-webhook-${channel}`}>
+                {CHANNEL_LABELS[channel]}
+              </label>
+              <div className={styles.inputGroup}>
+                <input
+                  id={`teams-webhook-${channel}`}
+                  className={styles.input}
+                  type="password"
+                  aria-label={`${CHANNEL_LABELS[channel]} webhook`}
+                  value={form.channel_webhooks[channel]}
+                  placeholder={data.channel_webhooks_masked[channel] ?? 'https://outlook.office.com/webhook/...'}
+                  onChange={(event) =>
+                    setDraft({
+                      ...form,
+                      channel_webhooks: {
+                        ...form.channel_webhooks,
+                        [channel]: event.target.value,
+                      },
+                      clear_channels: form.clear_channels.filter((value) => value !== channel),
+                    })
+                  }
+                />
+                {data.channel_webhook_configured[channel] && (
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={() =>
+                      setDraft({
+                        ...form,
+                        channel_webhooks: {
+                          ...form.channel_webhooks,
+                          [channel]: '',
+                        },
+                        clear_channels: Array.from(new Set([...form.clear_channels, channel])),
+                      })
+                    }
+                  >
+                    Clear
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.mappingSection}>
+          <CardHeader>Source routing</CardHeader>
+          {Object.entries(SOURCE_LABELS).map(([source, label]) => (
+            <div key={source} className={styles.mappingRow}>
+              <label className={styles.toggle}>
+                <input
+                  type="checkbox"
+                  checked={form.notification_settings[source as TeamsNotificationSource]}
+                  onChange={(event) =>
+                    setDraft({
+                      ...form,
+                      notification_settings: {
+                        ...form.notification_settings,
+                        [source]: event.target.checked,
+                      },
+                    })
+                  }
+                />
+                Enable {label}
+              </label>
+              <select
+                className={styles.input}
+                aria-label={`${label} channel mapping`}
+                value={form.source_mappings[source as TeamsNotificationSource]}
+                onChange={(event) =>
+                  setDraft({
+                    ...form,
+                    source_mappings: {
+                      ...form.source_mappings,
+                      [source]: event.target.value as TeamsChannelKey,
+                    },
+                  })
+                }
+              >
+                {CHANNEL_KEYS.map((channel) => (
+                  <option key={channel} value={channel}>
+                    {CHANNEL_LABELS[channel]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+
+        <div className={styles.actions}>
+          <Button variant="primary" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+            {saveMutation.isPending ? 'Saving…' : 'Save Teams settings'}
+          </Button>
+          <Button onClick={() => testMutation.mutate()} disabled={testMutation.isPending}>
+            {testMutation.isPending ? 'Testing…' : 'Test message'}
+          </Button>
+          {testStatus && (
+            <span className={styles.testStatus} data-state={testStatus.state}>
+              {testStatus.message}
+            </span>
+          )}
+          {saveMutation.isError && <span className={styles.error}>Unable to save Teams settings.</span>}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/frontend/src/pages/Integrations/TeamsIntegration.tsx
+++ b/frontend/src/pages/Integrations/TeamsIntegration.tsx
@@ -71,7 +71,10 @@ export function TeamsIntegration() {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
   const [draft, setDraft] = useState<TeamsConfigUpdate | null>(null);
-  const [testStatus, setTestStatus] = useState<{ state: 'success' | 'error'; message: string } | null>(null);
+  const [testStatus, setTestStatus] = useState<{
+    state: 'success' | 'error';
+    message: string;
+  } | null>(null);
 
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['teams-config'],
@@ -100,7 +103,10 @@ export function TeamsIntegration() {
       showToast('Teams test sent', 'success');
     },
     onError: () => {
-      setTestStatus({ state: 'error', message: 'Teams test failed. Check the configured webhook URLs.' });
+      setTestStatus({
+        state: 'error',
+        message: 'Teams test failed. Check the configured webhook URLs.',
+      });
       showToast('Teams test failed', 'error');
     },
   });
@@ -117,7 +123,11 @@ export function TeamsIntegration() {
   }
 
   if (isError) {
-    return <ErrorBanner message={error instanceof Error ? error.message : 'Failed to load Teams integration'} />;
+    return (
+      <ErrorBanner
+        message={error instanceof Error ? error.message : 'Failed to load Teams integration'}
+      />
+    );
   }
 
   if (!data || !form) {
@@ -133,7 +143,8 @@ export function TeamsIntegration() {
           <div className={styles.titleGroup}>
             <h2 className={styles.title}>Microsoft Teams integration</h2>
             <p className={styles.description}>
-              Deliver OctoWatch alerts to Teams channels with Adaptive Cards and source-specific routing.
+              Deliver OctoWatch alerts to Teams channels with Adaptive Cards and source-specific
+              routing.
             </p>
           </div>
           <div className={styles.statusRow}>
@@ -157,7 +168,10 @@ export function TeamsIntegration() {
                   type="password"
                   aria-label={`${CHANNEL_LABELS[channel]} webhook`}
                   value={form.channel_webhooks[channel]}
-                  placeholder={data.channel_webhooks_masked[channel] ?? 'https://outlook.office.com/webhook/...'}
+                  placeholder={
+                    data.channel_webhooks_masked[channel] ??
+                    'https://outlook.office.com/webhook/...'
+                  }
                   onChange={(event) =>
                     setDraft({
                       ...form,
@@ -237,7 +251,11 @@ export function TeamsIntegration() {
         </div>
 
         <div className={styles.actions}>
-          <Button variant="primary" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}>
+          <Button
+            variant="primary"
+            onClick={() => saveMutation.mutate()}
+            disabled={saveMutation.isPending}
+          >
             {saveMutation.isPending ? 'Saving…' : 'Save Teams settings'}
           </Button>
           <Button onClick={() => testMutation.mutate()} disabled={testMutation.isPending}>
@@ -248,7 +266,9 @@ export function TeamsIntegration() {
               {testStatus.message}
             </span>
           )}
-          {saveMutation.isError && <span className={styles.error}>Unable to save Teams settings.</span>}
+          {saveMutation.isError && (
+            <span className={styles.error}>Unable to save Teams settings.</span>
+          )}
         </div>
       </div>
     </Card>

--- a/frontend/src/pages/Settings/Settings.test.tsx
+++ b/frontend/src/pages/Settings/Settings.test.tsx
@@ -174,6 +174,9 @@ vi.mock('../../api/slack', () => ({
     ok: true,
     channel: '#security-alerts',
     message: 'Test message sent successfully',
+  }),
+}));
+
 vi.mock('../../api/pagerduty', () => ({
   getPagerDutyConfig: vi.fn().mockResolvedValue({
     routing_key_configured: true,

--- a/frontend/src/pages/Settings/Settings.test.tsx
+++ b/frontend/src/pages/Settings/Settings.test.tsx
@@ -174,6 +174,22 @@ vi.mock('../../api/slack', () => ({
     ok: true,
     channel: '#security-alerts',
     message: 'Test message sent successfully',
+vi.mock('../../api/pagerduty', () => ({
+  getPagerDutyConfig: vi.fn().mockResolvedValue({
+    routing_key_configured: true,
+    routing_key_masked: 'abcd********wxyz',
+    severity_mapping: { critical: 'critical', high: 'error', medium: 'warning', low: 'info', info: 'info' },
+    notification_settings: { detections: true, sync_errors: true, system_health: false, threat_intel: false },
+    auto_resolve: true,
+  }),
+}));
+
+vi.mock('../../api/teams', () => ({
+  getTeamsConfig: vi.fn().mockResolvedValue({
+    channel_webhook_configured: { default: true, detections: true, sync_errors: false, system_health: false, threat_intel: false },
+    channel_webhooks_masked: { default: 'https://o*******1234', detections: 'https://d*******5678', sync_errors: null, system_health: null, threat_intel: null },
+    source_mappings: { detections: 'detections', sync_errors: 'default', system_health: 'default', threat_intel: 'default' },
+    notification_settings: { detections: true, sync_errors: true, system_health: false, threat_intel: false },
   }),
 }));
 
@@ -536,9 +552,12 @@ describe('SettingsPage', () => {
     });
 
     expect(screen.getByText(/slack integration/i)).toBeInTheDocument();
+    expect(screen.getByText('Slack')).toBeInTheDocument();
+    expect(screen.getByText('Microsoft Teams')).toBeInTheDocument();
     expect(screen.getByText('Microsoft Sentinel')).toBeInTheDocument();
     expect(screen.getByText('Splunk')).toBeInTheDocument();
     expect(screen.getByText('PagerDuty')).toBeInTheDocument();
+    expect(screen.getByText('Microsoft Teams')).toBeInTheDocument();
   });
 
   it('renders Integrations tab via direct URL', async () => {

--- a/frontend/src/pages/Settings/Settings.test.tsx
+++ b/frontend/src/pages/Settings/Settings.test.tsx
@@ -178,18 +178,51 @@ vi.mock('../../api/pagerduty', () => ({
   getPagerDutyConfig: vi.fn().mockResolvedValue({
     routing_key_configured: true,
     routing_key_masked: 'abcd********wxyz',
-    severity_mapping: { critical: 'critical', high: 'error', medium: 'warning', low: 'info', info: 'info' },
-    notification_settings: { detections: true, sync_errors: true, system_health: false, threat_intel: false },
+    severity_mapping: {
+      critical: 'critical',
+      high: 'error',
+      medium: 'warning',
+      low: 'info',
+      info: 'info',
+    },
+    notification_settings: {
+      detections: true,
+      sync_errors: true,
+      system_health: false,
+      threat_intel: false,
+    },
     auto_resolve: true,
   }),
 }));
 
 vi.mock('../../api/teams', () => ({
   getTeamsConfig: vi.fn().mockResolvedValue({
-    channel_webhook_configured: { default: true, detections: true, sync_errors: false, system_health: false, threat_intel: false },
-    channel_webhooks_masked: { default: 'https://o*******1234', detections: 'https://d*******5678', sync_errors: null, system_health: null, threat_intel: null },
-    source_mappings: { detections: 'detections', sync_errors: 'default', system_health: 'default', threat_intel: 'default' },
-    notification_settings: { detections: true, sync_errors: true, system_health: false, threat_intel: false },
+    channel_webhook_configured: {
+      default: true,
+      detections: true,
+      sync_errors: false,
+      system_health: false,
+      threat_intel: false,
+    },
+    channel_webhooks_masked: {
+      default: 'https://o*******1234',
+      detections: 'https://d*******5678',
+      sync_errors: null,
+      system_health: null,
+      threat_intel: null,
+    },
+    source_mappings: {
+      detections: 'detections',
+      sync_errors: 'default',
+      system_health: 'default',
+      threat_intel: 'default',
+    },
+    notification_settings: {
+      detections: true,
+      sync_errors: true,
+      system_health: false,
+      threat_intel: false,
+    },
   }),
 }));
 

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -601,6 +601,17 @@ const INTEGRATION_INFO: {
   iconBg: string;
 }[] = [
   {
+    key: 'slack',
+    label: 'Slack',
+    description: 'Send real-time notifications and alerts to Slack channels.',
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+        <path d="M5.042 15.165a2.528 2.528 0 0 1-2.52 2.523A2.528 2.528 0 0 1 0 15.165a2.527 2.527 0 0 1 2.522-2.52h2.52v2.52zm1.271 0a2.527 2.527 0 0 1 2.521-2.52 2.527 2.527 0 0 1 2.521 2.52v6.313A2.528 2.528 0 0 1 8.834 24a2.528 2.528 0 0 1-2.521-2.522v-6.313z" />
+      </svg>
+    ),
+    iconBg: '#4A154B',
+  },
+  {
     key: 'jira',
     label: 'Jira',
     description: 'Automatically create Jira issues for security findings and track remediation.',

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -1377,12 +1377,16 @@ function IntegrationsPane() {
       }
       case 'pagerduty': {
         const configured = Boolean(pagerDutyConfig?.routing_key_configured);
-        const enabled = configured && Object.values(pagerDutyConfig?.notification_settings ?? {}).some(Boolean);
+        const enabled =
+          configured && Object.values(pagerDutyConfig?.notification_settings ?? {}).some(Boolean);
         return { configured, enabled };
       }
       case 'teams': {
-        const configured = Object.values(teamsConfig?.channel_webhook_configured ?? {}).some(Boolean);
-        const enabled = configured && Object.values(teamsConfig?.notification_settings ?? {}).some(Boolean);
+        const configured = Object.values(teamsConfig?.channel_webhook_configured ?? {}).some(
+          Boolean,
+        );
+        const enabled =
+          configured && Object.values(teamsConfig?.notification_settings ?? {}).some(Boolean);
         return { configured, enabled };
       }
       case 'syslog_cef': {

--- a/frontend/src/pages/Settings/index.tsx
+++ b/frontend/src/pages/Settings/index.tsx
@@ -23,6 +23,8 @@ import {
 import { getRetentionPolicies, updateRetentionPolicies } from '../../api/admin';
 import type { RetentionPolicyItem } from '../../api/admin';
 import { SyncPanel } from '../Integrations/SyncPanel';
+import { PagerDutyIntegration } from '../Integrations/PagerDutyIntegration';
+import { TeamsIntegration } from '../Integrations/TeamsIntegration';
 import { PageHeader } from '../../components/common/PageHeader';
 import { useToast } from '../../hooks/useToast';
 import { SyncRunHistory } from '../Integrations/SyncRunHistory';
@@ -38,6 +40,8 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { useFeatures } from '../../hooks/useFeatures';
 import { formatAbsolute } from '../../utils/dates';
+import { getPagerDutyConfig } from '../../api/pagerduty';
+import { getTeamsConfig } from '../../api/teams';
 import styles from './Settings.module.css';
 
 /* ------------------------------------------------------------------ */
@@ -536,6 +540,15 @@ function PagerDutyIcon() {
   );
 }
 
+function TeamsIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <rect x="4" y="5" width="16" height="14" rx="3" fill="#5b5fc7" />
+      <path d="M9 10h6M9 14h4" stroke="white" strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 function JiraIcon() {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -614,6 +627,13 @@ const INTEGRATION_INFO: {
     description: 'Trigger PagerDuty incidents for critical security detections.',
     icon: <PagerDutyIcon />,
     iconBg: '#06ac38',
+  },
+  {
+    key: 'teams',
+    label: 'Microsoft Teams',
+    description: 'Send adaptive card notifications to Teams channels through incoming webhooks.',
+    icon: <TeamsIcon />,
+    iconBg: '#5b5fc7',
   },
   {
     key: 'syslog_cef',
@@ -1319,6 +1339,16 @@ function IntegrationsPane() {
     queryFn: listSiemConfigs,
   });
 
+  const { data: pagerDutyConfig } = useQuery({
+    queryKey: ['pagerduty-config'],
+    queryFn: getPagerDutyConfig,
+  });
+
+  const { data: teamsConfig } = useQuery({
+    queryKey: ['teams-config'],
+    queryFn: getTeamsConfig,
+  });
+
   const notifConfigs = notificationConfigs ?? [];
   const ticketConfigs = ticketingConfigs ?? [];
   const siemCfgs = siemConfigs ?? [];
@@ -1346,8 +1376,14 @@ function IntegrationsPane() {
         return { configured: found.length > 0, enabled: found.some((c) => c.enabled) };
       }
       case 'pagerduty': {
-        const found = notifConfigs.filter((c) => c.channel_type === 'pagerduty');
-        return { configured: found.length > 0, enabled: found.some((c) => c.enabled) };
+        const configured = Boolean(pagerDutyConfig?.routing_key_configured);
+        const enabled = configured && Object.values(pagerDutyConfig?.notification_settings ?? {}).some(Boolean);
+        return { configured, enabled };
+      }
+      case 'teams': {
+        const configured = Object.values(teamsConfig?.channel_webhook_configured ?? {}).some(Boolean);
+        const enabled = configured && Object.values(teamsConfig?.notification_settings ?? {}).some(Boolean);
+        return { configured, enabled };
       }
       case 'syslog_cef': {
         const found = siemCfgs.filter((c) => c.export_type === 'syslog');
@@ -1441,18 +1477,34 @@ function IntegrationsPane() {
         <JiraConfigForm onClose={() => setConfigTarget(null)} />
       </Drawer>
 
-      {/* Webhook-based config modal (Sentinel, Splunk, PagerDuty) */}
+      {/* Webhook-based config modal (Sentinel, Splunk) */}
       <Drawer
-        open={configTarget !== null && ['sentinel', 'splunk', 'pagerduty'].includes(configTarget)}
+        open={configTarget !== null && ['sentinel', 'splunk'].includes(configTarget)}
         onClose={() => setConfigTarget(null)}
         title={getConfigModalTitle(configTarget ?? '')}
       >
-        {configTarget && ['sentinel', 'splunk', 'pagerduty'].includes(configTarget) && (
+        {configTarget && ['sentinel', 'splunk'].includes(configTarget) && (
           <WebhookConfigForm
             name={INTEGRATION_INFO.find((i) => i.key === configTarget)?.label ?? configTarget}
             onClose={() => setConfigTarget(null)}
           />
         )}
+      </Drawer>
+
+      <Drawer
+        open={configTarget === 'pagerduty'}
+        onClose={() => setConfigTarget(null)}
+        title="Configure PagerDuty"
+      >
+        <PagerDutyIntegration />
+      </Drawer>
+
+      <Drawer
+        open={configTarget === 'teams'}
+        onClose={() => setConfigTarget(null)}
+        title="Configure Microsoft Teams"
+      >
+        <TeamsIntegration />
       </Drawer>
 
       {/* Syslog/CEF config modal */}


### PR DESCRIPTION
Closes #58

PagerDuty and Microsoft Teams as notification delivery channels.

**PagerDuty:** Events API v2 incidents, auto-resolve on detection resolution, severity mapping
**Teams:** Adaptive Cards via incoming webhooks, channel mapping per notification source
**Frontend:** Config pages for both with test connection, enable/disable per source

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>