### PR TITLE
feat: keyboard shortcuts for power-user navigation (#141)

### DIFF
--- a/frontend/src/components/common/ShortcutsDialog.module.css
+++ b/frontend/src/components/common/ShortcutsDialog.module.css
@@ -1,0 +1,67 @@
+.content {
+  min-width: 360px;
+}
+
+.categoryTitle {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+  margin: 16px 0 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--border);
+}
+
+.categoryTitle:first-child {
+  margin-top: 0;
+}
+
+.shortcutList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.shortcutRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  gap: 16px;
+}
+
+.label {
+  font-size: 13px;
+  color: var(--fg);
+}
+
+.keys {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  font-size: 11px;
+  font-family: inherit;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--fg);
+  background: var(--canvas-default, #161b22);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.3);
+}
+
+.then {
+  font-size: 11px;
+  color: var(--fg-muted);
+}

--- a/frontend/src/components/common/ShortcutsDialog.test.tsx
+++ b/frontend/src/components/common/ShortcutsDialog.test.tsx
@@ -34,7 +34,9 @@ function ShortcutHarness({ initialRoute = '/' }: { initialRoute?: string }) {
   const closeShortcuts = useCallback(() => setShortcutsOpen(false), []);
 
   return (
-    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
       <ToastProvider>
         <MemoryRouter initialEntries={[initialRoute]}>
           <HotkeyProvider>
@@ -81,7 +83,9 @@ function ShortcutHarnessInner({
 
 function NavigationHarness() {
   return (
-    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+    <QueryClientProvider
+      client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+    >
       <ToastProvider>
         <MemoryRouter initialEntries={['/']}>
           <HotkeyProvider>
@@ -101,7 +105,12 @@ function NavigationHarnessInner() {
 
   const bindings: HotkeyBinding[] = useMemo(
     () => [
-      { key: 'g d', handler: () => setTarget('/dashboard'), label: 'Go to Dashboard', category: 'Navigation' },
+      {
+        key: 'g d',
+        handler: () => setTarget('/dashboard'),
+        label: 'Go to Dashboard',
+        category: 'Navigation',
+      },
     ],
     [],
   );
@@ -177,16 +186,16 @@ describe('Input suppression', () => {
     const [fired, setFired] = useState(false);
 
     const bindings: HotkeyBinding[] = useMemo(
-      () => [
-        { key: '?', handler: () => setFired(true), label: 'Test', category: 'General' },
-      ],
+      () => [{ key: '?', handler: () => setFired(true), label: 'Test', category: 'General' }],
       [],
     );
 
     useHotkeys(bindings);
 
     return (
-      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
         <ToastProvider>
           <MemoryRouter>
             <HotkeyProvider>

--- a/frontend/src/components/common/ShortcutsDialog.test.tsx
+++ b/frontend/src/components/common/ShortcutsDialog.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '../common/ToastProvider';
+import { HotkeyProvider } from '../../contexts/HotkeyProvider';
+import { useHotkeys, type HotkeyBinding } from '../../hooks/useHotkeys';
+import { ShortcutsDialog } from './ShortcutsDialog';
+import { useState, useCallback, useMemo } from 'react';
+
+/* ── Mocks ───────────────────────────────────────────────────────── */
+
+vi.mock('../GuidedTour/tourStorage', () => ({
+  isTourCompleted: () => true,
+  resetTour: vi.fn(),
+}));
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+
+function LocationDisplay() {
+  const loc = useLocation();
+  return <div data-testid="location">{loc.pathname}</div>;
+}
+
+/**
+ * A minimal harness that registers the same shortcuts AppShell does
+ * without dragging in Sidebar / TopBar / GuidedTour dependencies.
+ */
+function ShortcutHarness({ initialRoute = '/' }: { initialRoute?: string }) {
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+
+  const openShortcuts = useCallback(() => setShortcutsOpen(true), []);
+  const closeShortcuts = useCallback(() => setShortcutsOpen(false), []);
+
+  return (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={[initialRoute]}>
+          <HotkeyProvider>
+            <ShortcutHarnessInner
+              shortcutsOpen={shortcutsOpen}
+              openShortcuts={openShortcuts}
+              closeShortcuts={closeShortcuts}
+            />
+          </HotkeyProvider>
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+function ShortcutHarnessInner({
+  shortcutsOpen,
+  openShortcuts,
+  closeShortcuts,
+}: {
+  shortcutsOpen: boolean;
+  openShortcuts: () => void;
+  closeShortcuts: () => void;
+}) {
+  const bindings: HotkeyBinding[] = useMemo(
+    () => [
+      { key: '?', handler: openShortcuts, label: 'Show keyboard shortcuts', category: 'General' },
+      { key: 'g d', handler: () => {}, label: 'Go to Dashboard', category: 'Navigation' },
+    ],
+    [openShortcuts],
+  );
+
+  useHotkeys(bindings);
+
+  return (
+    <>
+      <Routes>
+        <Route path="*" element={<LocationDisplay />} />
+      </Routes>
+      <ShortcutsDialog open={shortcutsOpen} onClose={closeShortcuts} />
+    </>
+  );
+}
+
+function NavigationHarness() {
+  return (
+    <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <HotkeyProvider>
+            <NavigationHarnessInner />
+          </HotkeyProvider>
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>
+  );
+}
+
+function NavigationHarnessInner() {
+  /* We can't use react-router's useNavigate in tests with MemoryRouter
+     the same way as in the real app, so we capture navigation via location. */
+  const loc = useLocation();
+  const [target, setTarget] = useState(loc.pathname);
+
+  const bindings: HotkeyBinding[] = useMemo(
+    () => [
+      { key: 'g d', handler: () => setTarget('/dashboard'), label: 'Go to Dashboard', category: 'Navigation' },
+    ],
+    [],
+  );
+
+  useHotkeys(bindings);
+
+  return <div data-testid="nav-target">{target}</div>;
+}
+
+/* ── Tests ────────────────────────────────────────────────────────── */
+
+describe('ShortcutsDialog', () => {
+  it('opens the shortcuts dialog when "?" is pressed', async () => {
+    render(<ShortcutHarness />);
+
+    expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: '?' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+    });
+  });
+
+  it('closes the shortcuts dialog on Escape', async () => {
+    render(<ShortcutHarness />);
+
+    /* Open dialog */
+    fireEvent.keyDown(document, { key: '?' });
+    await waitFor(() => {
+      expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+    });
+
+    /* Close dialog */
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByText('Keyboard Shortcuts')).not.toBeInTheDocument();
+    });
+  });
+
+  it('displays shortcut entries grouped by category', async () => {
+    render(<ShortcutHarness />);
+
+    fireEvent.keyDown(document, { key: '?' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Navigation')).toBeInTheDocument();
+      expect(screen.getByText('General')).toBeInTheDocument();
+      expect(screen.getByText('Go to Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Show keyboard shortcuts')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Keyboard navigation sequences', () => {
+  it('triggers "g then d" navigation handler', async () => {
+    render(<NavigationHarness />);
+
+    expect(screen.getByTestId('nav-target')).toHaveTextContent('/');
+
+    /* Press 'g', then 'd' */
+    fireEvent.keyDown(document, { key: 'g' });
+    fireEvent.keyDown(document, { key: 'd' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('nav-target')).toHaveTextContent('/dashboard');
+    });
+  });
+});
+
+describe('Input suppression', () => {
+  function InputHarness() {
+    const [fired, setFired] = useState(false);
+
+    const bindings: HotkeyBinding[] = useMemo(
+      () => [
+        { key: '?', handler: () => setFired(true), label: 'Test', category: 'General' },
+      ],
+      [],
+    );
+
+    useHotkeys(bindings);
+
+    return (
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <ToastProvider>
+          <MemoryRouter>
+            <HotkeyProvider>
+              <input data-testid="text-input" type="text" />
+              <div data-testid="fired">{fired ? 'yes' : 'no'}</div>
+            </HotkeyProvider>
+          </MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  it('suppresses shortcuts when typing in an input field', async () => {
+    const user = userEvent.setup();
+    render(<InputHarness />);
+
+    const input = screen.getByTestId('text-input');
+    await user.click(input);
+
+    /* Type '?' inside the input — hotkey should NOT fire. */
+    fireEvent.keyDown(input, { key: '?' });
+
+    expect(screen.getByTestId('fired')).toHaveTextContent('no');
+  });
+
+  it('fires shortcut when not focused on input', () => {
+    render(<InputHarness />);
+
+    fireEvent.keyDown(document, { key: '?' });
+
+    expect(screen.getByTestId('fired')).toHaveTextContent('yes');
+  });
+});

--- a/frontend/src/components/common/ShortcutsDialog.tsx
+++ b/frontend/src/components/common/ShortcutsDialog.tsx
@@ -1,0 +1,106 @@
+import { useMemo } from 'react';
+import { Modal } from '../primitives/Modal';
+import type { HotkeyBinding } from '../../hooks/useHotkeys';
+import { useHotkeyContext } from '../../contexts/HotkeyContext';
+import styles from './ShortcutsDialog.module.css';
+
+interface ShortcutsDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const CATEGORY_ORDER: HotkeyBinding['category'][] = ['Navigation', 'Actions', 'General'];
+const STATIC_BINDINGS: HotkeyBinding[] = [
+  { key: 'Escape', handler: () => {}, label: 'Close open dialog or panel', category: 'General' },
+];
+
+/** Render a key string like "g d" or "Ctrl+K" into styled keycap elements. */
+function KeyCaps({ combo }: { combo: string }) {
+  /* Handle sequences like "g d" (space-separated single chars). */
+  const parts = combo.split(' ').filter(Boolean);
+
+  return (
+    <span className={styles.keys}>
+      {parts.map((part, i) => {
+        /* Handle modifier combos like "Ctrl+K" */
+        const segments = part.split('+');
+        return (
+          <span key={i} className={styles.keys}>
+            {i > 0 && <span className={styles.then}>then</span>}
+            {segments.map((seg, j) => (
+              <kbd key={j} className={styles.kbd}>
+                {formatKeyLabel(seg)}
+              </kbd>
+            ))}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+function formatKeyLabel(key: string): string {
+  const map: Record<string, string> = {
+    ctrl: '⌃',
+    control: '⌃',
+    meta: '⌘',
+    cmd: '⌘',
+    command: '⌘',
+    alt: '⌥',
+    option: '⌥',
+    shift: '⇧',
+    escape: 'Esc',
+    '?': '?',
+  };
+  return map[key.toLowerCase()] ?? key.toUpperCase();
+}
+
+export function ShortcutsDialog({ open, onClose }: ShortcutsDialogProps) {
+  const { getAll } = useHotkeyContext();
+
+  const grouped = useMemo(() => {
+    const registeredBindings = getAll();
+    const bindings = [...registeredBindings];
+    for (const staticBinding of STATIC_BINDINGS) {
+      const alreadyRegistered = registeredBindings.some((binding) => binding.key === staticBinding.key);
+      if (!alreadyRegistered) {
+        bindings.push(staticBinding);
+      }
+    }
+
+    const groups = new Map<HotkeyBinding['category'], HotkeyBinding[]>();
+    for (const cat of CATEGORY_ORDER) {
+      groups.set(cat, []);
+    }
+    for (const b of bindings) {
+      const list = groups.get(b.category);
+      if (list) list.push(b);
+      else groups.set(b.category, [b]);
+    }
+    return groups;
+  }, [getAll, open]);
+
+  return (
+    <Modal open={open} onClose={onClose} title="Keyboard Shortcuts" width={480}>
+      <div className={styles.content}>
+        {CATEGORY_ORDER.map((category) => {
+          const items = grouped.get(category);
+          if (!items || items.length === 0) return null;
+          return (
+            <div key={category}>
+              <h3 className={styles.categoryTitle}>{category}</h3>
+              <ul className={styles.shortcutList}>
+                {items.map((item) => (
+                  <li key={`${item.category}-${item.key}-${item.label}`} className={styles.shortcutRow}>
+                    <span className={styles.label}>{item.label}</span>
+                    <KeyCaps combo={item.key} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          );
+        })}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/common/ShortcutsDialog.tsx
+++ b/frontend/src/components/common/ShortcutsDialog.tsx
@@ -62,7 +62,9 @@ export function ShortcutsDialog({ open, onClose }: ShortcutsDialogProps) {
     const registeredBindings = getAll();
     const bindings = [...registeredBindings];
     for (const staticBinding of STATIC_BINDINGS) {
-      const alreadyRegistered = registeredBindings.some((binding) => binding.key === staticBinding.key);
+      const alreadyRegistered = registeredBindings.some(
+        (binding) => binding.key === staticBinding.key,
+      );
       if (!alreadyRegistered) {
         bindings.push(staticBinding);
       }
@@ -91,7 +93,10 @@ export function ShortcutsDialog({ open, onClose }: ShortcutsDialogProps) {
               <h3 className={styles.categoryTitle}>{category}</h3>
               <ul className={styles.shortcutList}>
                 {items.map((item) => (
-                  <li key={`${item.category}-${item.key}-${item.label}`} className={styles.shortcutRow}>
+                  <li
+                    key={`${item.category}-${item.key}-${item.label}`}
+                    className={styles.shortcutRow}
+                  >
                     <span className={styles.label}>{item.label}</span>
                     <KeyCaps combo={item.key} />
                   </li>

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,19 +1,61 @@
-import { useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { useState, useCallback, useMemo } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
 import { Sidebar } from './Sidebar';
 import { TopBar } from './TopBar';
 import { GuidedTour } from '../GuidedTour/GuidedTour';
 import { isTourCompleted, resetTour } from '../GuidedTour/tourStorage';
+import { HotkeyProvider } from '../../contexts/HotkeyProvider';
+import { useHotkeys, type HotkeyBinding } from '../../hooks/useHotkeys';
+import { ShortcutsDialog } from '../common/ShortcutsDialog';
 import styles from './AppShell.module.css';
 
-export function AppShell() {
+function AppShellInner() {
   const [showTour, setShowTour] = useState(!isTourCompleted());
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const navigate = useNavigate();
 
   function handleReplayTour() {
     resetTour();
     setShowTour(true);
   }
+
+  const openShortcuts = useCallback(() => setShortcutsOpen(true), []);
+  const closeShortcuts = useCallback(() => setShortcutsOpen(false), []);
+
+  const focusSearchInput = useCallback(() => {
+    const input = document.querySelector<HTMLInputElement>(
+      'input[type="search"], input[placeholder*="earch"], input[placeholder*="ilter"], input[aria-label*="earch"], input[aria-label*="ilter"]',
+    );
+    if (input) {
+      input.focus();
+      input.select();
+    }
+  }, []);
+
+  const bindings: HotkeyBinding[] = useMemo(
+    () => [
+      /* ── Navigation: g then <key> ─────────────────────────────── */
+      { key: 'g d', handler: () => navigate('/dashboard'), label: 'Go to Dashboard', category: 'Navigation' },
+      { key: 'g t', handler: () => navigate('/threats'), label: 'Go to Threats', category: 'Navigation' },
+      { key: 'g e', handler: () => navigate('/events'), label: 'Go to Events', category: 'Navigation' },
+      { key: 'g p', handler: () => navigate('/posture'), label: 'Go to Posture', category: 'Navigation' },
+      { key: 'g w', handler: () => navigate('/workflows'), label: 'Go to Workflows', category: 'Navigation' },
+      { key: 'g c', handler: () => navigate('/copilot'), label: 'Go to Copilot', category: 'Navigation' },
+      { key: 'g v', handler: () => navigate('/velocity'), label: 'Go to Velocity', category: 'Navigation' },
+      { key: 'g r', handler: () => navigate('/reports'), label: 'Go to Reports', category: 'Navigation' },
+      { key: 'g s', handler: () => navigate('/settings'), label: 'Go to Settings', category: 'Navigation' },
+
+      /* ── Actions ──────────────────────────────────────────────── */
+      { key: 'f', handler: focusSearchInput, label: 'Focus search / filter', category: 'Actions' },
+
+      /* ── General ──────────────────────────────────────────────── */
+      { key: '?', handler: openShortcuts, label: 'Show keyboard shortcuts', category: 'General' },
+    ],
+    [navigate, openShortcuts, focusSearchInput],
+  );
+
+  useHotkeys(bindings);
 
   return (
     <div className={styles.layout}>
@@ -33,6 +75,15 @@ export function AppShell() {
         </main>
       </div>
       {showTour && <GuidedTour onComplete={() => setShowTour(false)} />}
+      <ShortcutsDialog open={shortcutsOpen} onClose={closeShortcuts} />
     </div>
+  );
+}
+
+export function AppShell() {
+  return (
+    <HotkeyProvider>
+      <AppShellInner />
+    </HotkeyProvider>
   );
 }

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -36,15 +36,60 @@ function AppShellInner() {
   const bindings: HotkeyBinding[] = useMemo(
     () => [
       /* ── Navigation: g then <key> ─────────────────────────────── */
-      { key: 'g d', handler: () => navigate('/dashboard'), label: 'Go to Dashboard', category: 'Navigation' },
-      { key: 'g t', handler: () => navigate('/threats'), label: 'Go to Threats', category: 'Navigation' },
-      { key: 'g e', handler: () => navigate('/events'), label: 'Go to Events', category: 'Navigation' },
-      { key: 'g p', handler: () => navigate('/posture'), label: 'Go to Posture', category: 'Navigation' },
-      { key: 'g w', handler: () => navigate('/workflows'), label: 'Go to Workflows', category: 'Navigation' },
-      { key: 'g c', handler: () => navigate('/copilot'), label: 'Go to Copilot', category: 'Navigation' },
-      { key: 'g v', handler: () => navigate('/velocity'), label: 'Go to Velocity', category: 'Navigation' },
-      { key: 'g r', handler: () => navigate('/reports'), label: 'Go to Reports', category: 'Navigation' },
-      { key: 'g s', handler: () => navigate('/settings'), label: 'Go to Settings', category: 'Navigation' },
+      {
+        key: 'g d',
+        handler: () => navigate('/dashboard'),
+        label: 'Go to Dashboard',
+        category: 'Navigation',
+      },
+      {
+        key: 'g t',
+        handler: () => navigate('/threats'),
+        label: 'Go to Threats',
+        category: 'Navigation',
+      },
+      {
+        key: 'g e',
+        handler: () => navigate('/events'),
+        label: 'Go to Events',
+        category: 'Navigation',
+      },
+      {
+        key: 'g p',
+        handler: () => navigate('/posture'),
+        label: 'Go to Posture',
+        category: 'Navigation',
+      },
+      {
+        key: 'g w',
+        handler: () => navigate('/workflows'),
+        label: 'Go to Workflows',
+        category: 'Navigation',
+      },
+      {
+        key: 'g c',
+        handler: () => navigate('/copilot'),
+        label: 'Go to Copilot',
+        category: 'Navigation',
+      },
+      {
+        key: 'g v',
+        handler: () => navigate('/velocity'),
+        label: 'Go to Velocity',
+        category: 'Navigation',
+      },
+      {
+        key: 'g r',
+        handler: () => navigate('/reports'),
+        label: 'Go to Reports',
+        category: 'Navigation',
+      },
+      {
+        key: 'g s',
+        handler: () => navigate('/settings'),
+        label: 'Go to Settings',
+        category: 'Navigation',
+      },
 
       /* ── Actions ──────────────────────────────────────────────── */
       { key: 'f', handler: focusSearchInput, label: 'Focus search / filter', category: 'Actions' },

--- a/frontend/src/contexts/HotkeyContext.tsx
+++ b/frontend/src/contexts/HotkeyContext.tsx
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { HotkeyBinding } from '../hooks/useHotkeys';
+
+export interface HotkeyContextValue {
+  register: (binding: HotkeyBinding) => number;
+  unregister: (id: number) => void;
+  getAll: () => HotkeyBinding[];
+}
+
+export const HotkeyContext = createContext<HotkeyContextValue | null>(null);
+
+export function useHotkeyContext(): HotkeyContextValue {
+  const ctx = useContext(HotkeyContext);
+  if (!ctx) {
+    throw new Error('useHotkeyContext must be used within a HotkeyProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/contexts/HotkeyProvider.tsx
+++ b/frontend/src/contexts/HotkeyProvider.tsx
@@ -1,0 +1,21 @@
+import { useCallback, useMemo } from 'react';
+import {
+  getBindings,
+  registerBinding,
+  unregisterBinding,
+  type HotkeyBinding,
+} from '../hooks/useHotkeys';
+import { HotkeyContext, type HotkeyContextValue } from './HotkeyContext';
+
+export function HotkeyProvider({ children }: { children: React.ReactNode }) {
+  const register = useCallback((binding: HotkeyBinding) => registerBinding(binding), []);
+  const unregister = useCallback((id: number) => unregisterBinding(id), []);
+  const getAll = useCallback(() => getBindings(), []);
+
+  const value = useMemo<HotkeyContextValue>(
+    () => ({ register, unregister, getAll }),
+    [register, unregister, getAll],
+  );
+
+  return <HotkeyContext.Provider value={value}>{children}</HotkeyContext.Provider>;
+}

--- a/frontend/src/hooks/useHotkeys.ts
+++ b/frontend/src/hooks/useHotkeys.ts
@@ -1,0 +1,233 @@
+import { useEffect, useMemo } from 'react';
+
+export interface HotkeyBinding {
+  /** Human-readable key combo, e.g. "g d", "?", "Ctrl+K" */
+  key: string;
+  /** Handler invoked when the shortcut fires. */
+  handler: () => void;
+  /** Display label for the shortcuts dialog. */
+  label: string;
+  /** Grouping category for the shortcuts dialog. */
+  category: 'Navigation' | 'Actions' | 'General';
+  /** If true the shortcut fires even inside inputs (default false). */
+  allowInInput?: boolean;
+}
+
+interface ParsedChord {
+  ctrl: boolean;
+  meta: boolean;
+  alt: boolean;
+  shift: boolean;
+  baseKey: string;
+}
+
+interface RegistryEntry {
+  binding: HotkeyBinding;
+  id: number;
+}
+
+const registry = new Map<string, RegistryEntry[]>();
+const SEQUENCE_TIMEOUT_MS = 1000;
+const SHIFT_REQUIRED_PATTERN = /[a-z0-9]/;
+
+let nextId = 0;
+let listenerAttached = false;
+let pendingPrefix: string | null = null;
+let prefixTimer: ReturnType<typeof setTimeout> | null = null;
+
+function parseChord(chord: string): ParsedChord {
+  const parts = chord
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const parsed: ParsedChord = {
+    ctrl: false,
+    meta: false,
+    alt: false,
+    shift: false,
+    baseKey: '',
+  };
+
+  for (const part of parts) {
+    const normalized = part.toLowerCase();
+    if (normalized === 'ctrl' || normalized === 'control') parsed.ctrl = true;
+    else if (normalized === 'meta' || normalized === 'cmd' || normalized === 'command') parsed.meta = true;
+    else if (normalized === 'alt' || normalized === 'option') parsed.alt = true;
+    else if (normalized === 'shift') parsed.shift = true;
+    else parsed.baseKey = normalized;
+  }
+
+  return parsed;
+}
+
+function normalizeKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function normalizeChord(chord: string): string {
+  const parsed = parseChord(chord);
+  const parts: string[] = [];
+
+  if (parsed.ctrl) parts.push('ctrl');
+  if (parsed.meta) parts.push('meta');
+  if (parsed.alt) parts.push('alt');
+  if (parsed.shift) parts.push('shift');
+  parts.push(parsed.baseKey || normalizeKey(chord));
+
+  return parts.join('+');
+}
+
+function normalizeCombo(combo: string): string {
+  return combo
+    .split(' ')
+    .map((chord) => chord.trim())
+    .filter(Boolean)
+    .map(normalizeChord)
+    .join(' ');
+}
+
+function eventToChord(event: KeyboardEvent): string {
+  const baseKey = normalizeKey(event.key);
+  const parts: string[] = [];
+
+  if (event.ctrlKey) parts.push('ctrl');
+  if (event.metaKey) parts.push('meta');
+  if (event.altKey) parts.push('alt');
+  if (event.shiftKey && (baseKey.length > 1 || SHIFT_REQUIRED_PATTERN.test(baseKey))) {
+    parts.push('shift');
+  }
+  parts.push(baseKey);
+
+  return parts.join('+');
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!target || !(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
+}
+
+function getActiveEntry(entries: RegistryEntry[] | undefined, inEditable: boolean): RegistryEntry | undefined {
+  return entries?.findLast((entry) => !inEditable || entry.binding.allowInInput);
+}
+
+export function registerBinding(binding: HotkeyBinding): number {
+  const id = nextId++;
+  const normalizedKey = normalizeCombo(binding.key);
+
+  if (import.meta.env.DEV) {
+    const existing = registry.get(normalizedKey);
+    if (existing?.length) {
+      console.warn(
+        `[useHotkeys] Duplicate hotkey "${binding.key}" registered. ` +
+          `Existing: "${existing[0]!.binding.label}", New: "${binding.label}".`,
+      );
+    }
+  }
+
+  const entries = registry.get(normalizedKey) ?? [];
+  entries.push({ binding: { ...binding, key: binding.key.trim() }, id });
+  registry.set(normalizedKey, entries);
+
+  return id;
+}
+
+export function unregisterBinding(id: number): void {
+  for (const [combo, entries] of registry.entries()) {
+    const nextEntries = entries.filter((entry) => entry.id !== id);
+    if (nextEntries.length !== entries.length) {
+      if (nextEntries.length === 0) {
+        registry.delete(combo);
+      } else {
+        registry.set(combo, nextEntries);
+      }
+      return;
+    }
+  }
+}
+
+export function getBindings(): HotkeyBinding[] {
+  return Array.from(registry.values()).flatMap((entries) => entries.map((entry) => entry.binding));
+}
+
+function startPrefixTimer(): void {
+  clearPrefixTimer();
+  prefixTimer = setTimeout(() => {
+    pendingPrefix = null;
+    prefixTimer = null;
+  }, SEQUENCE_TIMEOUT_MS);
+}
+
+function clearPrefixTimer(): void {
+  if (prefixTimer) {
+    clearTimeout(prefixTimer);
+    prefixTimer = null;
+  }
+}
+
+function handleKeyDown(event: KeyboardEvent): void {
+  if (['Control', 'Shift', 'Alt', 'Meta'].includes(event.key)) {
+    return;
+  }
+
+  const inEditable = isEditableTarget(event.target);
+  const chord = eventToChord(event);
+
+  if (pendingPrefix) {
+    const sequenceEntry = getActiveEntry(registry.get(`${pendingPrefix} ${chord}`), inEditable);
+    clearPrefixTimer();
+    pendingPrefix = null;
+
+    if (sequenceEntry) {
+      event.preventDefault();
+      sequenceEntry.binding.handler();
+      return;
+    }
+  }
+
+  const hasSequenceCandidate = Array.from(registry.entries()).some(
+    ([combo, entries]) => combo.startsWith(`${chord} `) && Boolean(getActiveEntry(entries, inEditable)),
+  );
+  if (hasSequenceCandidate) {
+    pendingPrefix = chord;
+    startPrefixTimer();
+    return;
+  }
+
+  const entry = getActiveEntry(registry.get(chord), inEditable);
+  if (entry) {
+    event.preventDefault();
+    entry.binding.handler();
+  }
+}
+
+function ensureListener(): void {
+  if (!listenerAttached) {
+    document.addEventListener('keydown', handleKeyDown);
+    listenerAttached = true;
+  }
+}
+
+export function useHotkeys(bindings: HotkeyBinding[]): void {
+  const normalizedBindings = useMemo(() => bindings, [bindings]);
+
+  useEffect(() => {
+    ensureListener();
+
+    const ids = normalizedBindings.map((binding) => registerBinding(binding));
+
+    return () => {
+      ids.forEach(unregisterBinding);
+    };
+  }, [normalizedBindings]);
+}
+
+export function useHotkey(
+  key: string,
+  handler: () => void,
+  label: string,
+  category: HotkeyBinding['category'] = 'General',
+  allowInInput = false,
+): void {
+  useHotkeys([{ key, handler, label, category, allowInInput }]);
+}

--- a/frontend/src/hooks/useHotkeys.ts
+++ b/frontend/src/hooks/useHotkeys.ts
@@ -51,7 +51,8 @@ function parseChord(chord: string): ParsedChord {
   for (const part of parts) {
     const normalized = part.toLowerCase();
     if (normalized === 'ctrl' || normalized === 'control') parsed.ctrl = true;
-    else if (normalized === 'meta' || normalized === 'cmd' || normalized === 'command') parsed.meta = true;
+    else if (normalized === 'meta' || normalized === 'cmd' || normalized === 'command')
+      parsed.meta = true;
     else if (normalized === 'alt' || normalized === 'option') parsed.alt = true;
     else if (normalized === 'shift') parsed.shift = true;
     else parsed.baseKey = normalized;
@@ -107,7 +108,10 @@ function isEditableTarget(target: EventTarget | null): boolean {
   return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target.isContentEditable;
 }
 
-function getActiveEntry(entries: RegistryEntry[] | undefined, inEditable: boolean): RegistryEntry | undefined {
+function getActiveEntry(
+  entries: RegistryEntry[] | undefined,
+  inEditable: boolean,
+): RegistryEntry | undefined {
   return entries?.findLast((entry) => !inEditable || entry.binding.allowInInput);
 }
 
@@ -186,7 +190,8 @@ function handleKeyDown(event: KeyboardEvent): void {
   }
 
   const hasSequenceCandidate = Array.from(registry.entries()).some(
-    ([combo, entries]) => combo.startsWith(`${chord} `) && Boolean(getActiveEntry(entries, inEditable)),
+    ([combo, entries]) =>
+      combo.startsWith(`${chord} `) && Boolean(getActiveEntry(entries, inEditable)),
   );
   if (hasSequenceCandidate) {
     pendingPrefix = chord;


### PR DESCRIPTION
Closes #141

Global keyboard shortcuts with hotkey manager and help dialog.

- Central HotkeyProvider context with conflict detection
- Navigation: `g then d/t/e/p/w/c/v/r/s` sequences
- `?` opens shortcuts help dialog with styled keycaps
- Suppressed when typing in inputs
- Escape closes any open modal

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>