### PR TITLE
feat: responsive design for mobile & tablet (#142)

### DIFF
--- a/frontend/src/components/common/PageHeader.module.css
+++ b/frontend/src/components/common/PageHeader.module.css
@@ -52,3 +52,19 @@
   gap: 8px;
   flex-shrink: 0;
 }
+
+@media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .breadcrumbs {
+    display: none;
+  }
+
+  .actions {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/components/layout/AppShell.module.css
+++ b/frontend/src/components/layout/AppShell.module.css
@@ -55,3 +55,25 @@
     display: contents;
   }
 }
+
+@media (max-width: 1024px) {
+  .layout {
+    width: 100%;
+  }
+
+  .main,
+  .content {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .layout {
+    min-height: 100dvh;
+  }
+
+  .content {
+    overflow-x: hidden;
+  }
+}

--- a/frontend/src/components/layout/Sidebar.module.css
+++ b/frontend/src/components/layout/Sidebar.module.css
@@ -130,3 +130,20 @@
     opacity: 1;
   }
 }
+
+@media (max-width: 1024px) {
+  .sidebar {
+    width: min(320px, 84vw);
+    min-width: 0;
+    overscroll-behavior: contain;
+  }
+}
+
+@media (max-width: 768px) {
+  .logo {
+    position: sticky;
+    top: 0;
+    background: var(--canvas-subtle);
+    z-index: 1;
+  }
+}

--- a/frontend/src/components/layout/TopBar.module.css
+++ b/frontend/src/components/layout/TopBar.module.css
@@ -340,3 +340,73 @@
   background: var(--canvas-subtle);
   color: var(--fg);
 }
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 950;
+}
+
+.orgDropdownWrap {
+  min-width: 0;
+}
+
+.orgDropdownTrigger {
+  max-width: min(360px, 40vw);
+}
+
+@media (max-width: 1024px) {
+  .topbar {
+    padding-inline: 14px;
+  }
+
+  .orgDropdownTrigger {
+    max-width: min(320px, 32vw);
+  }
+
+  .right {
+    gap: 6px;
+  }
+}
+
+@media (max-width: 768px) {
+  .topbar {
+    height: auto;
+    min-height: 48px;
+    flex-wrap: wrap;
+    row-gap: 8px;
+    padding: 8px 12px;
+  }
+
+  .orgDropdownWrap,
+  .orgSingleLabel {
+    order: 2;
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
+  .orgDropdownTrigger {
+    width: 100%;
+    max-width: none;
+    justify-content: space-between;
+  }
+
+  .orgDropdownPanel {
+    left: 0;
+    right: auto;
+    width: min(100%, 360px);
+    min-width: 0;
+  }
+
+  .right {
+    margin-left: auto;
+  }
+
+  .menu {
+    min-width: 160px;
+  }
+
+  .menuRole {
+    display: none;
+  }
+}

--- a/frontend/src/pages/Copilot/Copilot.module.css
+++ b/frontend/src/pages/Copilot/Copilot.module.css
@@ -896,3 +896,64 @@
 .dataTable tr:last-child td {
   border-bottom: none;
 }
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 20px;
+  }
+
+  .metricStrip,
+  .tierGrid,
+  .editorGrid,
+  .govGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .grid2 {
+    grid-template-columns: 1fr;
+  }
+
+  .copilotTabs {
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .copilotTab {
+    flex: 0 0 auto;
+  }
+
+  .tableWrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tableWrap table,
+  .modalTable,
+  .dataTable,
+  .govTable {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 16px;
+  }
+
+  .metricStrip,
+  .tierGrid,
+  .editorGrid,
+  .govGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .ccrGrid,
+  .wasteAlert,
+  .recItem,
+  .anomalyHeader,
+  .govCardHeader,
+  .govFilters {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/CrossOrg/CrossOrg.module.css
+++ b/frontend/src/pages/CrossOrg/CrossOrg.module.css
@@ -416,3 +416,61 @@
   color: var(--fg-muted);
   font-size: 10px;
 }
+
+@media (max-width: 1024px) {
+  .splitMain {
+    padding: 20px;
+  }
+
+  .pageHeader,
+  .headerActions,
+  .filters,
+  .controlBar,
+  .controlRight,
+  .controlLeft,
+  .scoreMeta,
+  .panelMeta {
+    flex-wrap: wrap;
+  }
+
+  .tabs {
+    overflow-x: auto;
+  }
+
+  .splitPanel,
+  .splitPanelOpen {
+    width: 100%;
+  }
+
+  .scoreGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .splitLayout {
+    flex-direction: column;
+  }
+
+  .splitMain {
+    padding: 16px;
+  }
+
+  .filters,
+  .controlBar,
+  .pageHeader,
+  .panelKv {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filterSelect,
+  .panelLabel {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .scoreGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/pages/Dashboard/Dashboard.module.css
+++ b/frontend/src/pages/Dashboard/Dashboard.module.css
@@ -486,3 +486,81 @@
     grid-template-columns: repeat(2, 1fr);
   }
 }
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 20px;
+  }
+
+  .pills {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+  }
+
+  .pill {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .viewToggle {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .viewBtn {
+    flex: 1 1 calc(50% - 1px);
+    min-width: 140px;
+  }
+
+  .cardGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .gaugeGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+  }
+
+  .tableWrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tableWrap table,
+  .modalTable,
+  .dataTable {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 16px;
+  }
+
+  .pills,
+  .cardGrid,
+  .gaugeGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .pill {
+    justify-content: space-between;
+  }
+
+  .viewBtn {
+    flex-basis: 100%;
+  }
+
+  .legend,
+  .stackedLegend {
+    flex-wrap: wrap;
+  }
+
+  .alertRow,
+  .ingestionBanner,
+  .systemHealthBar {
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/Dashboard/ExecutiveView.module.css
+++ b/frontend/src/pages/Dashboard/ExecutiveView.module.css
@@ -330,3 +330,23 @@
     font-size: 18px;
   }
 }
+
+@media (max-width: 1024px) {
+  .grid3 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .scoreCard {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 768px) {
+  .periodToggle {
+    width: 100%;
+  }
+
+  .periodBtn {
+    flex: 1 1 0;
+  }
+}

--- a/frontend/src/pages/Dashboard/MetricsThatMatter.module.css
+++ b/frontend/src/pages/Dashboard/MetricsThatMatter.module.css
@@ -207,3 +207,13 @@
     grid-template-columns: 1fr;
   }
 }
+
+@media (max-width: 768px) {
+  .column {
+    padding: 14px;
+  }
+
+  .metricCard {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/pages/Events/Events.module.css
+++ b/frontend/src/pages/Events/Events.module.css
@@ -317,3 +317,59 @@
 .panelClose:hover {
   color: var(--fg);
 }
+
+@media (max-width: 1024px) {
+  .splitMain {
+    padding: 20px;
+  }
+
+  .tableHeader {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: 8px;
+  }
+
+  .tableActions {
+    flex-wrap: wrap;
+  }
+
+  .tableWrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tableWrap table {
+    min-width: 900px;
+  }
+
+  .splitPanel,
+  .splitPanelOpen {
+    width: 100%;
+    min-width: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .splitLayout {
+    flex-direction: column;
+  }
+
+  .splitMain {
+    padding: 16px;
+  }
+
+  .eventDetailRow,
+  .eventDataRow {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .eventDetailLabel,
+  .eventDataRow dt {
+    min-width: 0;
+  }
+
+  .pagination {
+    flex-wrap: wrap;
+  }
+}

--- a/frontend/src/pages/Health/Health.module.css
+++ b/frontend/src/pages/Health/Health.module.css
@@ -99,3 +99,36 @@
   color: var(--fg);
   margin-bottom: 4px;
 }
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 20px;
+  }
+
+  .metricStrip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .healthTabs {
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .healthTab {
+    flex: 0 0 auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 16px;
+  }
+
+  .metricStrip {
+    grid-template-columns: 1fr;
+  }
+
+  .placeholder {
+    padding: 24px 16px;
+  }
+}

--- a/frontend/src/pages/Posture/Posture.module.css
+++ b/frontend/src/pages/Posture/Posture.module.css
@@ -431,3 +431,64 @@
   min-width: 180px;
   max-height: 80px;
 }
+
+@media (max-width: 1024px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .content {
+    padding: 20px;
+    overflow-x: auto;
+  }
+
+  .filters,
+  .metricsSummary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .orgGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .repoTable {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 768px) {
+  .breadcrumb {
+    display: none;
+  }
+
+  .content {
+    padding: 16px;
+  }
+
+  .filters,
+  .orgGrid,
+  .metricsSummary,
+  .metaGrid,
+  .chartsRow {
+    grid-template-columns: 1fr;
+  }
+
+  .checkRow,
+  .orgCardHeader,
+  .orgMeta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .checkMeta {
+    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .repoTable {
+    min-width: 640px;
+  }
+}

--- a/frontend/src/pages/Rules/Rules.module.css
+++ b/frontend/src/pages/Rules/Rules.module.css
@@ -542,3 +542,66 @@
     opacity: 0.6;
   }
 }
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 20px;
+  }
+
+  .headerActions,
+  .backtestControls,
+  .analyticsTimeRange,
+  .bulkBar {
+    flex-wrap: wrap;
+  }
+
+  .tableWrap,
+  .versionTableWrap {
+    overflow-x: auto;
+  }
+
+  .table,
+  .versionTable {
+    min-width: 720px;
+  }
+
+  .formRowGrid,
+  .wizardTemplateGrid,
+  .analyticsMetrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 16px;
+  }
+
+  .pageHeader {
+    flex-direction: column;
+  }
+
+  .headerActions,
+  .bulkBar,
+  .backtestControls,
+  .wizardSummaryRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .formRowGrid,
+  .wizardTemplateGrid,
+  .analyticsMetrics {
+    grid-template-columns: 1fr;
+  }
+
+  .formActions,
+  .wizardNav {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .wizardStepLabels {
+    display: none;
+  }
+}

--- a/frontend/src/pages/Settings/Settings.module.css
+++ b/frontend/src/pages/Settings/Settings.module.css
@@ -746,3 +746,68 @@
   gap: 8px;
   padding-top: 1rem;
 }
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 20px;
+  }
+
+  .tableWrap,
+  .versionTableWrap {
+    overflow-x: auto;
+  }
+
+  .table,
+  .versionTable {
+    min-width: 720px;
+  }
+
+  .featureRow,
+  .categoryFormRow,
+  .configToggleRow,
+  .backtestControls,
+  .analyticsTimeRange,
+  .bulkBar {
+    flex-wrap: wrap;
+  }
+
+  .formActions,
+  .configActions,
+  .categoryFormActions {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 16px;
+  }
+
+  .featureRow,
+  .categoryFormRow,
+  .configRow,
+  .configToggleRow,
+  .wizardSummaryRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .configLabel,
+  .categoryFormControl,
+  .configValue {
+    width: 100%;
+  }
+
+  .categoryFormInput,
+  .categoryFormSelect {
+    width: 100%;
+  }
+
+  .formActions,
+  .configActions,
+  .categoryFormActions,
+  .wizardNav {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}

--- a/frontend/src/pages/Threats/Threats.module.css
+++ b/frontend/src/pages/Threats/Threats.module.css
@@ -878,3 +878,79 @@
 .chainsTab {
   padding: 20px 0;
 }
+
+@media (max-width: 1024px) {
+  .splitMain {
+    padding: 20px;
+  }
+
+  .filterRow > * {
+    flex: 1 1 180px;
+    min-width: 0;
+  }
+
+  .ilFilters {
+    overflow-x: auto;
+  }
+
+  .chainsMetrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .splitPanel,
+  .splitPanel.open {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .timelineOverlay {
+    width: 100vw;
+  }
+}
+
+@media (max-width: 768px) {
+  .splitLayout {
+    flex-direction: column;
+  }
+
+  .splitMain {
+    padding: 16px;
+  }
+
+  .topActions,
+  .panelActions,
+  .chainsFilter,
+  .assignDropdown,
+  .chainActions {
+    flex-wrap: wrap;
+  }
+
+  .filterBar {
+    padding: 10px;
+  }
+
+  .filterRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filterSelect,
+  .filterInput,
+  .filterDatetime {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .keyDetails,
+  .chainsMetrics {
+    grid-template-columns: 1fr;
+  }
+
+  .evidenceTable .evidenceRow,
+  .orgDetailRow,
+  .chainMetaRow,
+  .relatedEventRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/Velocity/Velocity.module.css
+++ b/frontend/src/pages/Velocity/Velocity.module.css
@@ -481,3 +481,57 @@
 .calloutDesc a:hover {
   text-decoration: underline;
 }
+
+@media (max-width: 1024px) {
+  .page {
+    padding: 20px;
+  }
+
+  .metricStrip,
+  .defsGrid,
+  .chartsGrid,
+  .modalMetrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .tabBar {
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .tab {
+    flex: 0 0 auto;
+  }
+
+  .tableWrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tableWrap table,
+  .doraTable,
+  .drillTable table {
+    min-width: 720px;
+  }
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: 16px;
+  }
+
+  .metricStrip,
+  .defsGrid,
+  .chartsGrid,
+  .modalMetrics {
+    grid-template-columns: 1fr;
+  }
+
+  .titleRow,
+  .doraGroup,
+  .contextCard,
+  .workflowCallout {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/frontend/src/pages/Workflows/Workflows.module.css
+++ b/frontend/src/pages/Workflows/Workflows.module.css
@@ -565,3 +565,82 @@
   color: var(--fg-muted);
   margin-top: 2px;
 }
+
+@media (max-width: 1024px) {
+  .splitMain {
+    padding: 20px;
+    overflow: auto;
+  }
+
+  .pageHeader,
+  .headerActions,
+  .filters,
+  .metricsControlGroup {
+    flex-wrap: wrap;
+  }
+
+  .tabs {
+    overflow-x: auto;
+  }
+
+  .findingsTable {
+    min-width: 760px;
+  }
+
+  .scoreGrid,
+  .modalMetrics,
+  .activitySummary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .modalPanel {
+    width: min(100vw, 720px);
+    max-height: 90dvh;
+  }
+}
+
+@media (max-width: 768px) {
+  .splitLayout {
+    flex-direction: column;
+  }
+
+  .splitMain {
+    padding: 16px;
+  }
+
+  .pageHeader,
+  .filters,
+  .panelKv,
+  .workflowCallout {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filterSelect,
+  .panelLabel {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .scoreGrid,
+  .modalMetrics,
+  .activitySummary {
+    grid-template-columns: 1fr;
+  }
+
+  .modalOverlay {
+    padding: 0;
+    align-items: stretch;
+  }
+
+  .modalPanel {
+    width: 100vw;
+    max-height: 100dvh;
+    border-radius: 0;
+  }
+
+  .modalHeader,
+  .modalBody {
+    padding-inline: 16px;
+  }
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -1,6 +1,7 @@
 @import './tokens.css';
 @import './reset.css';
 @import './a11y.css';
+@import './responsive.css';
 
 html,
 body {

--- a/frontend/src/styles/responsive.css
+++ b/frontend/src/styles/responsive.css
@@ -1,0 +1,37 @@
+/* Shared responsive utilities */
+:root {
+  --breakpoint-mobile: 768px;
+  --breakpoint-tablet: 1024px;
+  --page-padding-desktop: 24px;
+  --page-padding-tablet: 20px;
+  --page-padding-mobile: 16px;
+  --topbar-height: 48px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  max-width: 100%;
+}
+
+:where(table) {
+  min-width: 100%;
+}
+
+:where(input, select, textarea) {
+  max-width: 100%;
+}
+
+@media (max-width: 1024px) {
+  html {
+    -webkit-text-size-adjust: 100%;
+  }
+}


### PR DESCRIPTION
Closes #142

Mobile (≤768px) and tablet (769-1024px) responsive design across all pages.

- Shared responsive utilities CSS with breakpoint variables
- Stacked layouts, scrollable tables, collapsible filters on mobile
- Responsive grids for cards/dashboards (1→2→3+ columns)
- 13 CSS modules updated with media queries
- No JSX changes — pure CSS responsive fixes

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>