### PR TITLE
fix: Register supply-chain router (404s) and apply notifications migration (500s)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,6 +60,7 @@ from app.routers import (
     setup,
     slack,
     suggestions,
+    supply_chain,
     sync,
     teams,
     threat_intel,
@@ -716,6 +717,7 @@ def create_app() -> FastAPI:
     app.include_router(sync.router, prefix=API_PREFIX + "/admin")
     app.include_router(setup.router, prefix=API_PREFIX)
     app.include_router(suggestions.router, prefix=API_PREFIX)
+    app.include_router(supply_chain.router, prefix=API_PREFIX)
     app.include_router(teams.router, prefix=API_PREFIX)
     app.include_router(dev_activity.router, prefix=API_PREFIX)
     app.include_router(threat_intel.router, prefix=API_PREFIX)


### PR DESCRIPTION
## Problem
Two API errors on the live site:
- `/api/v1/supply-chain/*` returning **404** — router module existed but was never registered in `main.py`
- `/api/v1/notifications` returning **500** — migration 0054 (notifications table) was not applied to the DB

## Fix
1. Added `supply_chain` to the router imports and `include_router()` calls in `main.py`
2. Ran `alembic upgrade head` on the live DB (now at migration 0054)

## Testing
- Backend lint (ruff) passes via pre-commit hook
- Migration verified: DB now at version 0054