### PR TITLE
fix: Correct table name in supply-chain posture query (500 error)

### DIFF
--- a/backend/app/services/supply_chain_service.py
+++ b/backend/app/services/supply_chain_service.py
@@ -272,8 +272,7 @@ async def get_supply_chain_posture(
     # Dependency alerts (Dependabot-related events)
     dep_q = await session.execute(
         text(
-            "SELECT count(*) FROM audit_events "
-            f"WHERE action LIKE 'dependabot_alerts.%%' {org_filter}"
+            f"SELECT count(*) FROM events d WHERE action LIKE 'dependabot_alerts.%%' {org_filter}"
         ),
         params,
     )


### PR DESCRIPTION
The supply-chain posture endpoint was querying `audit_events` which doesn't exist. The correct table is `events`. Also added alias `d` so the org filter fragment (`AND d.org IN (...)`) resolves correctly.