### PR TITLE
Phase 6: Production Hardening — Celery workers, backup/restore, zero-downtime, HA

### DIFF
--- a/.playwright-mcp/page-2026-05-11T15-46-44-168Z.yml
+++ b/.playwright-mcp/page-2026-05-11T15-46-44-168Z.yml
@@ -1,0 +1,2 @@
+- generic [ref=e2]:
+  - generic "Notifications"

--- a/.playwright-mcp/page-2026-05-11T15-46-50-932Z.yml
+++ b/.playwright-mcp/page-2026-05-11T15-46-50-932Z.yml
@@ -1,0 +1,65 @@
+- generic [ref=e2]:
+  - generic [ref=e3]:
+    - link "Skip to content" [ref=e4] [cursor=pointer]:
+      - /url: "#start-of-content"
+    - banner [ref=e6]
+  - main [ref=e9]:
+    - generic [ref=e10]:
+      - generic [ref=e12]:
+        - img "Octowatch logo" [ref=e14]
+        - paragraph [ref=e15]:
+          - text: Sign in to
+          - strong [ref=e16]: GitHub
+          - text: to continue to
+          - strong [ref=e17]: Octowatch
+      - generic [ref=e18]:
+        - generic [ref=e19]:
+          - generic [ref=e20]:
+            - generic [ref=e21]: Username or email address
+            - textbox "Username or email address" [active] [ref=e22]
+          - generic [ref=e23]:
+            - generic [ref=e24]: Password
+            - textbox "Password" [ref=e25]
+            - link "Forgot password?" [ref=e26] [cursor=pointer]:
+              - /url: /password_reset
+          - button "Sign in" [ref=e28] [cursor=pointer]
+        - generic [ref=e29]:
+          - generic [ref=e31]: or
+          - button "Continue with Google" [ref=e33] [cursor=pointer]:
+            - generic [ref=e34]:
+              - generic:
+                - img:
+                  - img
+              - generic [ref=e35]: Continue with Google
+          - button "Continue with Apple" [ref=e37] [cursor=pointer]:
+            - generic [ref=e38]:
+              - generic:
+                - img:
+                  - img
+              - generic [ref=e39]: Continue with Apple
+      - generic [ref=e40]:
+        - paragraph [ref=e42]:
+          - text: New to GitHub?
+          - link "Create an account" [ref=e43] [cursor=pointer]:
+            - /url: /join?return_to=%2Flogin%2Foauth%2Fauthorize%3Fclient_id%3DOv23ctoyvthSLYdOGkmw%26redirect_uri%3Dhttps%253A%252F%252Foctowatch.jmassardo.azure.csa-github.com%252Fapi%252Fv1%252Fauth%252Fgithub%252Fcallback%26scope%3Dread%253Aorg%2Bread%253Auser%26state%3Dkg201Xr0Bo-ezBv0cgsZNptOfmtESqNz-FU6GZzn0bg&source=oauth
+        - paragraph [ref=e45]:
+          - button "Sign in with a passkey" [ref=e46] [cursor=pointer]:
+            - generic [ref=e48]: Sign in with a passkey
+  - contentinfo [ref=e49]:
+    - list [ref=e50]:
+      - listitem [ref=e51]:
+        - link "Terms" [ref=e52] [cursor=pointer]:
+          - /url: https://docs.github.com/site-policy/github-terms/github-terms-of-service
+      - listitem [ref=e53]:
+        - link "Privacy" [ref=e54] [cursor=pointer]:
+          - /url: https://docs.github.com/site-policy/privacy-policies/github-privacy-statement
+      - listitem [ref=e55]:
+        - link "Docs" [ref=e56] [cursor=pointer]:
+          - /url: https://docs.github.com
+      - listitem [ref=e57]:
+        - link "Contact GitHub Support" [ref=e58] [cursor=pointer]:
+          - /url: https://support.github.com
+      - listitem [ref=e59]:
+        - button "Manage cookies" [ref=e61] [cursor=pointer]
+      - listitem [ref=e62]:
+        - button "Do not share my personal information" [ref=e64] [cursor=pointer]

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -114,6 +114,18 @@ app.config_from_object(
                 "schedule": crontab(minute="*/30"),
                 "options": {"queue": "baseline"},
             },
+            # S3 audit log polling — every 5 minutes
+            "poll-s3-sources": {
+                "task": "app.workers.ingestion.s3_worker.poll_s3_sources",
+                "schedule": 300.0,
+                "options": {"queue": "ingestion"},
+            },
+            # Azure Blob audit log polling — every 5 minutes
+            "poll-azure-sources": {
+                "task": "app.workers.ingestion.azure_worker.poll_azure_sources",
+                "schedule": 300.0,
+                "options": {"queue": "ingestion"},
+            },
         },
     }
 )
@@ -136,6 +148,8 @@ app.conf.include = [
     "app.workers.retention_worker",
     "app.workers.copilot_metrics_worker",
     "app.workers.ingestion.base",
+    "app.workers.ingestion.s3_worker",
+    "app.workers.ingestion.azure_worker",
     "app.workers.ingest_webhook_worker",
     "app.workers.siem_export_worker",
     "app.workers.ingestion_health",

--- a/backend/app/workers/ingestion/azure_worker.py
+++ b/backend/app/workers/ingestion/azure_worker.py
@@ -1,0 +1,275 @@
+"""Celery worker: poll Azure Blob Storage containers for new audit log exports.
+
+Each active ``IngestionCursor`` with ``source_type='azure_blob'`` defines a
+container + prefix to poll.  The worker lists blobs newer than the cursor's
+``last_file``, downloads each JSON/NDJSON blob, and pushes events through the
+standard dedup → insert → detection pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import secrets
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from celery import Task
+
+from app.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+# Maximum blobs to process per poll cycle.
+_MAX_BLOBS_PER_POLL = 100
+
+# Maximum events to batch-insert per file.
+_BATCH_SIZE = 500
+
+
+@celery_app.task(
+    name="app.workers.ingestion.azure_worker.poll_azure_sources",
+    bind=True,
+    max_retries=3,
+)
+def poll_azure_sources(self: Task) -> dict[str, object]:
+    """Celery beat task: iterate active Azure Blob ingestion cursors and ingest new blobs."""
+    try:
+        result = asyncio.run(_poll_all_azure_sources())
+        return {"status": "ok", **result}
+    except Exception as exc:
+        logger.error("poll_azure_sources.failed", error=str(exc))
+        backoff = min(30 * (2**self.request.retries), 600)
+        jitter = secrets.randbelow(max(int(backoff * 0.1), 1))
+        raise self.retry(exc=exc, countdown=backoff + jitter) from exc
+
+
+async def _poll_all_azure_sources() -> dict[str, Any]:
+    """Poll every active Azure Blob ingestion cursor and ingest new blobs."""
+    import redis.asyncio as aioredis
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from app.config import settings
+    from app.workers.ingestion.base import AbstractIngestWorker
+
+    class AzureBlobIngestWorker(AbstractIngestWorker):
+        ingestion_source: str = "azure_blob"
+
+        async def run(self) -> None:
+            raise NotImplementedError
+
+    tmp_engine = create_async_engine(
+        settings.DATABASE_URL,
+        poolclass=NullPool,
+        echo=settings.LOG_LEVEL == "DEBUG",
+    )
+    tmp_session_factory = async_sessionmaker(
+        bind=tmp_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+        autocommit=False,
+    )
+    valkey = aioredis.from_url(settings.VALKEY_URL, decode_responses=False)
+
+    try:
+        async with tmp_session_factory() as db:
+            rows = await db.execute(
+                text(
+                    "SELECT id, source_name, source_region, source_prefix, last_file "
+                    "FROM ingestion_cursors "
+                    "WHERE source_type = 'azure_blob' AND status = 'active' "
+                    "FOR UPDATE SKIP LOCKED"
+                )
+            )
+            cursors = rows.fetchall()
+
+        total_blobs = 0
+        total_events = 0
+
+        for cursor in cursors:
+            cursor_id, container_url, _region, prefix, last_file = cursor
+            try:
+                blobs, events = await _poll_single_azure_source(
+                    cursor_id=cursor_id,
+                    container_url=container_url,
+                    prefix=prefix or "",
+                    last_file=last_file,
+                    session_factory=tmp_session_factory,
+                    valkey_client=valkey,
+                    worker_cls=AzureBlobIngestWorker,
+                )
+                total_blobs += blobs
+                total_events += events
+            except Exception:
+                logger.exception(
+                    "poll_azure_sources.source_failed",
+                    cursor_id=cursor_id,
+                    container_url=container_url,
+                )
+                async with tmp_session_factory() as db:
+                    await db.execute(
+                        text(
+                            "UPDATE ingestion_cursors "
+                            "SET error_count = error_count + 1, "
+                            "    error_message = :msg, "
+                            "    updated_at = NOW() "
+                            "WHERE id = :id"
+                        ),
+                        {"id": cursor_id, "msg": "Poll failed — see worker logs"},
+                    )
+                    await db.commit()
+
+        logger.info(
+            "poll_azure_sources.complete",
+            sources=len(cursors),
+            blobs=total_blobs,
+            events=total_events,
+        )
+        return {"sources": len(cursors), "blobs": total_blobs, "events": total_events}
+    finally:
+        await valkey.aclose()
+        await tmp_engine.dispose()
+
+
+async def _poll_single_azure_source(
+    *,
+    cursor_id: int,
+    container_url: str,
+    prefix: str,
+    last_file: str | None,
+    session_factory: Any,
+    valkey_client: Any,
+    worker_cls: type,
+) -> tuple[int, int]:
+    """List new blobs in a single Azure container and ingest them.
+
+    ``container_url`` is the full container URL including SAS token or
+    the storage account connection string.  The ``source_name`` field
+    on the IngestionCursor stores this value.
+
+    Returns (blobs_processed, events_inserted).
+    """
+    from azure.storage.blob import ContainerClient
+    from sqlalchemy import text
+
+    container_client = ContainerClient.from_container_url(container_url)
+
+    # List blobs with the given prefix
+    blob_list = []
+    count = 0
+    for blob in container_client.list_blobs(name_starts_with=prefix):
+        # Skip blobs at or before the cursor position (lexicographic)
+        if last_file and blob.name <= last_file:
+            continue
+        blob_list.append(blob)
+        count += 1
+        if count >= _MAX_BLOBS_PER_POLL:
+            break
+
+    if not blob_list:
+        return 0, 0
+
+    worker = worker_cls(valkey_client=valkey_client, db_session_factory=session_factory)
+
+    blobs_processed = 0
+    total_inserted = 0
+    latest_blob = last_file
+
+    for blob in blob_list:
+        blob_name = blob.name
+        if blob_name.endswith("/"):
+            continue
+
+        try:
+            events = await _download_and_parse_blob(container_client, blob_name)
+            if events:
+                for i in range(0, len(events), _BATCH_SIZE):
+                    batch = events[i : i + _BATCH_SIZE]
+                    inserted = await worker.ingest_batch(
+                        raw_events=batch,
+                        source_file_path=f"azure://{blob_name}",
+                    )
+                    total_inserted += inserted
+
+            blobs_processed += 1
+            latest_blob = blob_name
+
+            logger.info(
+                "poll_azure_sources.blob_processed",
+                container=container_url[:50],
+                blob=blob_name,
+                events=len(events),
+            )
+        except Exception:
+            logger.exception(
+                "poll_azure_sources.blob_failed",
+                blob=blob_name,
+            )
+
+    # Update cursor position
+    if latest_blob and latest_blob != last_file:
+        async with session_factory() as db:
+            await db.execute(
+                text(
+                    "UPDATE ingestion_cursors "
+                    "SET last_file = :last_file, "
+                    "    last_event_count = last_event_count + :events, "
+                    "    last_processed_at = :ts, "
+                    "    error_count = 0, "
+                    "    error_message = NULL, "
+                    "    updated_at = NOW() "
+                    "WHERE id = :id"
+                ),
+                {
+                    "id": cursor_id,
+                    "last_file": latest_blob,
+                    "events": total_inserted,
+                    "ts": datetime.now(UTC),
+                },
+            )
+            await db.commit()
+
+    return blobs_processed, total_inserted
+
+
+async def _download_and_parse_blob(
+    container_client: Any,
+    blob_name: str,
+) -> list[dict[str, Any]]:
+    """Download and parse a JSON or NDJSON blob from Azure Blob Storage.
+
+    Supports .json, .ndjson, .json.gz, and .ndjson.gz files.
+    Runs the blocking download in a thread to avoid blocking the event loop.
+    """
+    loop = asyncio.get_running_loop()
+
+    def _download() -> bytes:
+        blob_client = container_client.get_blob_client(blob_name)
+        return blob_client.download_blob().readall()
+
+    raw_bytes = await loop.run_in_executor(None, _download)
+
+    if blob_name.endswith(".gz"):
+        raw_bytes = gzip.decompress(raw_bytes)
+
+    text_content = raw_bytes.decode("utf-8")
+
+    events: list[dict[str, Any]] = []
+    if blob_name.endswith((".ndjson", ".ndjson.gz")):
+        for line in text_content.splitlines():
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    else:
+        parsed = json.loads(text_content)
+        if isinstance(parsed, list):
+            events = parsed
+        elif isinstance(parsed, dict):
+            events = [parsed]
+
+    return events

--- a/backend/app/workers/ingestion/s3_worker.py
+++ b/backend/app/workers/ingestion/s3_worker.py
@@ -1,0 +1,280 @@
+"""Celery worker: poll S3 buckets for new GitHub audit log exports and ingest them.
+
+Each active ``IngestionCursor`` with ``source_type='s3'`` defines a bucket +
+prefix to poll.  The worker lists objects newer than the cursor's
+``last_file``, downloads each JSON/NDJSON file, and pushes events through the
+standard dedup → insert → detection pipeline.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import gzip
+import json
+import secrets
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from celery import Task
+
+from app.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+# Maximum objects to process per poll cycle to bound memory and runtime.
+_MAX_OBJECTS_PER_POLL = 100
+
+# Maximum events to batch-insert per file before committing.
+_BATCH_SIZE = 500
+
+
+@celery_app.task(
+    name="app.workers.ingestion.s3_worker.poll_s3_sources",
+    bind=True,
+    max_retries=3,
+)
+def poll_s3_sources(self: Task) -> dict[str, object]:
+    """Celery beat task: iterate active S3 ingestion cursors and ingest new files."""
+    try:
+        result = asyncio.run(_poll_all_s3_sources())
+        return {"status": "ok", **result}
+    except Exception as exc:
+        logger.error("poll_s3_sources.failed", error=str(exc))
+        backoff = min(30 * (2**self.request.retries), 600)
+        jitter = secrets.randbelow(max(int(backoff * 0.1), 1))
+        raise self.retry(exc=exc, countdown=backoff + jitter) from exc
+
+
+async def _poll_all_s3_sources() -> dict[str, Any]:
+    """Poll every active S3 ingestion cursor and ingest new objects."""
+    import redis.asyncio as aioredis
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+    from sqlalchemy.pool import NullPool
+
+    from app.config import settings
+    from app.workers.ingestion.base import AbstractIngestWorker
+
+    class S3IngestWorker(AbstractIngestWorker):
+        ingestion_source: str = "s3"
+
+        async def run(self) -> None:
+            raise NotImplementedError
+
+    tmp_engine = create_async_engine(
+        settings.DATABASE_URL,
+        poolclass=NullPool,
+        echo=settings.LOG_LEVEL == "DEBUG",
+    )
+    tmp_session_factory = async_sessionmaker(
+        bind=tmp_engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+        autocommit=False,
+    )
+    valkey = aioredis.from_url(settings.VALKEY_URL, decode_responses=False)
+
+    try:
+        # Fetch active S3 cursors with row-level locking
+        async with tmp_session_factory() as db:
+            rows = await db.execute(
+                text(
+                    "SELECT id, source_name, source_region, source_prefix, last_file "
+                    "FROM ingestion_cursors "
+                    "WHERE source_type = 's3' AND status = 'active' "
+                    "FOR UPDATE SKIP LOCKED"
+                )
+            )
+            cursors = rows.fetchall()
+
+        total_files = 0
+        total_events = 0
+
+        for cursor in cursors:
+            cursor_id, bucket, region, prefix, last_file = cursor
+            try:
+                files, events = await _poll_single_s3_source(
+                    cursor_id=cursor_id,
+                    bucket=bucket,
+                    region=region or "us-east-1",
+                    prefix=prefix or "",
+                    last_file=last_file,
+                    session_factory=tmp_session_factory,
+                    valkey_client=valkey,
+                    worker_cls=S3IngestWorker,
+                )
+                total_files += files
+                total_events += events
+            except Exception:
+                logger.exception(
+                    "poll_s3_sources.source_failed",
+                    cursor_id=cursor_id,
+                    bucket=bucket,
+                )
+                async with tmp_session_factory() as db:
+                    await db.execute(
+                        text(
+                            "UPDATE ingestion_cursors "
+                            "SET error_count = error_count + 1, "
+                            "    error_message = :msg, "
+                            "    updated_at = NOW() "
+                            "WHERE id = :id"
+                        ),
+                        {"id": cursor_id, "msg": "Poll failed — see worker logs"},
+                    )
+                    await db.commit()
+
+        logger.info(
+            "poll_s3_sources.complete",
+            sources=len(cursors),
+            files=total_files,
+            events=total_events,
+        )
+        return {"sources": len(cursors), "files": total_files, "events": total_events}
+    finally:
+        await valkey.aclose()
+        await tmp_engine.dispose()
+
+
+async def _poll_single_s3_source(
+    *,
+    cursor_id: int,
+    bucket: str,
+    region: str,
+    prefix: str,
+    last_file: str | None,
+    session_factory: Any,
+    valkey_client: Any,
+    worker_cls: type,
+) -> tuple[int, int]:
+    """List new objects in a single S3 source and ingest them.
+
+    Returns (files_processed, events_inserted).
+    """
+    import boto3
+    from sqlalchemy import text
+
+    s3 = boto3.client("s3", region_name=region)
+
+    # List objects after the last processed file (lexicographic ordering)
+    list_kwargs: dict[str, Any] = {
+        "Bucket": bucket,
+        "Prefix": prefix,
+        "MaxKeys": _MAX_OBJECTS_PER_POLL,
+    }
+    if last_file:
+        list_kwargs["StartAfter"] = last_file
+
+    response = s3.list_objects_v2(**list_kwargs)
+    objects = response.get("Contents", [])
+
+    if not objects:
+        return 0, 0
+
+    worker = worker_cls(valkey_client=valkey_client, db_session_factory=session_factory)
+
+    files_processed = 0
+    total_inserted = 0
+    latest_file = last_file
+
+    for obj in objects:
+        key = obj["Key"]
+        # Skip directory markers
+        if key.endswith("/"):
+            continue
+
+        try:
+            events = await _download_and_parse_s3_object(s3, bucket, key)
+            if events:
+                # Process in batches
+                for i in range(0, len(events), _BATCH_SIZE):
+                    batch = events[i : i + _BATCH_SIZE]
+                    inserted = await worker.ingest_batch(
+                        raw_events=batch,
+                        source_file_path=f"s3://{bucket}/{key}",
+                    )
+                    total_inserted += inserted
+
+            files_processed += 1
+            latest_file = key
+
+            logger.info(
+                "poll_s3_sources.file_processed",
+                bucket=bucket,
+                key=key,
+                events=len(events),
+            )
+        except Exception:
+            logger.exception(
+                "poll_s3_sources.file_failed",
+                bucket=bucket,
+                key=key,
+            )
+            # Continue with next file rather than aborting the whole source
+
+    # Update cursor position
+    if latest_file and latest_file != last_file:
+        async with session_factory() as db:
+            await db.execute(
+                text(
+                    "UPDATE ingestion_cursors "
+                    "SET last_file = :last_file, "
+                    "    last_event_count = last_event_count + :events, "
+                    "    last_processed_at = :ts, "
+                    "    error_count = 0, "
+                    "    error_message = NULL, "
+                    "    updated_at = NOW() "
+                    "WHERE id = :id"
+                ),
+                {
+                    "id": cursor_id,
+                    "last_file": latest_file,
+                    "events": total_inserted,
+                    "ts": datetime.now(UTC),
+                },
+            )
+            await db.commit()
+
+    return files_processed, total_inserted
+
+
+async def _download_and_parse_s3_object(
+    s3_client: Any,
+    bucket: str,
+    key: str,
+) -> list[dict[str, Any]]:
+    """Download and parse a JSON or NDJSON file from S3.
+
+    Supports .json, .ndjson, .json.gz, and .ndjson.gz files.
+    Runs the blocking S3 download in a thread to avoid blocking the event loop.
+    """
+    loop = asyncio.get_running_loop()
+    response = await loop.run_in_executor(
+        None,
+        lambda: s3_client.get_object(Bucket=bucket, Key=key),
+    )
+    raw_bytes = response["Body"].read()
+
+    # Decompress if gzipped
+    if key.endswith(".gz"):
+        raw_bytes = gzip.decompress(raw_bytes)
+
+    text_content = raw_bytes.decode("utf-8")
+
+    # Parse as NDJSON (one JSON object per line) or single JSON array
+    events: list[dict[str, Any]] = []
+    if key.endswith((".ndjson", ".ndjson.gz")):
+        for line in text_content.splitlines():
+            line = line.strip()
+            if line:
+                events.append(json.loads(line))
+    else:
+        parsed = json.loads(text_content)
+        if isinstance(parsed, list):
+            events = parsed
+        elif isinstance(parsed, dict):
+            events = [parsed]
+
+    return events

--- a/backend/tests/test_ingestion_workers.py
+++ b/backend/tests/test_ingestion_workers.py
@@ -1,0 +1,280 @@
+"""Tests for S3 and Azure Blob ingestion workers."""
+
+from __future__ import annotations
+
+import gzip
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ── S3 worker tests ─────────────────────────────────────────────────────────
+
+
+class TestS3DownloadAndParse:
+    """Test the S3 file download and parsing logic."""
+
+    @pytest.mark.asyncio
+    async def test_parses_json_array(self):
+        from app.workers.ingestion.s3_worker import _download_and_parse_s3_object
+
+        events = [
+            {"action": "repos.create", "actor": "alice"},
+            {"action": "repos.delete", "actor": "bob"},
+        ]
+        body_mock = MagicMock()
+        body_mock.read.return_value = json.dumps(events).encode("utf-8")
+
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+
+        result = await _download_and_parse_s3_object(s3, "my-bucket", "logs/export.json")
+        assert len(result) == 2
+        assert result[0]["action"] == "repos.create"
+        assert result[1]["actor"] == "bob"
+
+    @pytest.mark.asyncio
+    async def test_parses_ndjson(self):
+        from app.workers.ingestion.s3_worker import _download_and_parse_s3_object
+
+        ndjson = '{"action": "a"}\n{"action": "b"}\n'
+        body_mock = MagicMock()
+        body_mock.read.return_value = ndjson.encode("utf-8")
+
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+
+        result = await _download_and_parse_s3_object(s3, "bucket", "logs/export.ndjson")
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_parses_gzipped_json(self):
+        from app.workers.ingestion.s3_worker import _download_and_parse_s3_object
+
+        events = [{"action": "repos.create"}]
+        compressed = gzip.compress(json.dumps(events).encode("utf-8"))
+        body_mock = MagicMock()
+        body_mock.read.return_value = compressed
+
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+
+        result = await _download_and_parse_s3_object(s3, "bucket", "logs/export.json.gz")
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_parses_single_object(self):
+        from app.workers.ingestion.s3_worker import _download_and_parse_s3_object
+
+        event = {"action": "repos.create", "actor": "alice"}
+        body_mock = MagicMock()
+        body_mock.read.return_value = json.dumps(event).encode("utf-8")
+
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+
+        result = await _download_and_parse_s3_object(s3, "bucket", "logs/single.json")
+        assert len(result) == 1
+        assert result[0]["action"] == "repos.create"
+
+    @pytest.mark.asyncio
+    async def test_parses_gzipped_ndjson(self):
+        from app.workers.ingestion.s3_worker import _download_and_parse_s3_object
+
+        ndjson = '{"action": "a"}\n{"action": "b"}\n'
+        compressed = gzip.compress(ndjson.encode("utf-8"))
+        body_mock = MagicMock()
+        body_mock.read.return_value = compressed
+
+        s3 = MagicMock()
+        s3.get_object.return_value = {"Body": body_mock}
+
+        result = await _download_and_parse_s3_object(s3, "bucket", "logs/export.ndjson.gz")
+        assert len(result) == 2
+
+
+class TestS3PollSingleSource:
+    """Test cursor-based S3 polling logic."""
+
+    @pytest.mark.asyncio
+    async def test_skips_directory_markers(self):
+        from app.workers.ingestion.s3_worker import _poll_single_s3_source
+
+        s3_mock = MagicMock()
+        s3_mock.list_objects_v2.return_value = {
+            "Contents": [{"Key": "logs/"}, {"Key": "logs/subdir/"}]
+        }
+
+        with patch("boto3.client", return_value=s3_mock):
+            worker_cls = MagicMock()
+            session_factory = AsyncMock()
+
+            files, events = await _poll_single_s3_source(
+                cursor_id=1,
+                bucket="test-bucket",
+                region="us-east-1",
+                prefix="logs/",
+                last_file=None,
+                session_factory=session_factory,
+                valkey_client=AsyncMock(),
+                worker_cls=worker_cls,
+            )
+
+        assert files == 0
+        assert events == 0
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_objects(self):
+        from app.workers.ingestion.s3_worker import _poll_single_s3_source
+
+        s3_mock = MagicMock()
+        s3_mock.list_objects_v2.return_value = {}
+
+        with patch("boto3.client", return_value=s3_mock):
+            files, events = await _poll_single_s3_source(
+                cursor_id=1,
+                bucket="test-bucket",
+                region="us-east-1",
+                prefix="logs/",
+                last_file=None,
+                session_factory=AsyncMock(),
+                valkey_client=AsyncMock(),
+                worker_cls=MagicMock(),
+            )
+
+        assert files == 0
+        assert events == 0
+
+
+# ── Azure worker tests ──────────────────────────────────────────────────────
+
+
+class TestAzureDownloadAndParse:
+    """Test the Azure Blob download and parsing logic."""
+
+    @pytest.mark.asyncio
+    async def test_parses_json_array(self):
+        from app.workers.ingestion.azure_worker import _download_and_parse_blob
+
+        events = [
+            {"action": "repos.create", "actor": "alice"},
+            {"action": "repos.delete", "actor": "bob"},
+        ]
+        blob_client = MagicMock()
+        download_stream = MagicMock()
+        download_stream.readall.return_value = json.dumps(events).encode("utf-8")
+        blob_client.download_blob.return_value = download_stream
+
+        container = MagicMock()
+        container.get_blob_client.return_value = blob_client
+
+        result = await _download_and_parse_blob(container, "logs/export.json")
+        assert len(result) == 2
+        assert result[0]["action"] == "repos.create"
+
+    @pytest.mark.asyncio
+    async def test_parses_ndjson(self):
+        from app.workers.ingestion.azure_worker import _download_and_parse_blob
+
+        ndjson = '{"action": "a"}\n{"action": "b"}\n'
+        blob_client = MagicMock()
+        download_stream = MagicMock()
+        download_stream.readall.return_value = ndjson.encode("utf-8")
+        blob_client.download_blob.return_value = download_stream
+
+        container = MagicMock()
+        container.get_blob_client.return_value = blob_client
+
+        result = await _download_and_parse_blob(container, "logs/export.ndjson")
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_parses_gzipped_json(self):
+        from app.workers.ingestion.azure_worker import _download_and_parse_blob
+
+        events = [{"action": "repos.create"}]
+        compressed = gzip.compress(json.dumps(events).encode("utf-8"))
+        blob_client = MagicMock()
+        download_stream = MagicMock()
+        download_stream.readall.return_value = compressed
+        blob_client.download_blob.return_value = download_stream
+
+        container = MagicMock()
+        container.get_blob_client.return_value = blob_client
+
+        result = await _download_and_parse_blob(container, "logs/export.json.gz")
+        assert len(result) == 1
+
+    @pytest.mark.asyncio
+    async def test_parses_single_object(self):
+        from app.workers.ingestion.azure_worker import _download_and_parse_blob
+
+        event = {"action": "repos.create", "actor": "alice"}
+        blob_client = MagicMock()
+        download_stream = MagicMock()
+        download_stream.readall.return_value = json.dumps(event).encode("utf-8")
+        blob_client.download_blob.return_value = download_stream
+
+        container = MagicMock()
+        container.get_blob_client.return_value = blob_client
+
+        result = await _download_and_parse_blob(container, "logs/single.json")
+        assert len(result) == 1
+
+
+class TestAzurePollSingleSource:
+    """Test cursor-based Azure Blob polling logic."""
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_no_blobs(self):
+        from app.workers.ingestion.azure_worker import _poll_single_azure_source
+
+        container_mock = MagicMock()
+        container_mock.list_blobs.return_value = iter([])
+
+        with patch(
+            "azure.storage.blob.ContainerClient.from_container_url",
+            return_value=container_mock,
+        ):
+            blobs, events = await _poll_single_azure_source(
+                cursor_id=1,
+                container_url="https://account.blob.core.windows.net/container?sas=token",
+                prefix="logs/",
+                last_file=None,
+                session_factory=AsyncMock(),
+                valkey_client=AsyncMock(),
+                worker_cls=MagicMock(),
+            )
+
+        assert blobs == 0
+        assert events == 0
+
+    @pytest.mark.asyncio
+    async def test_skips_blobs_before_cursor(self):
+        from app.workers.ingestion.azure_worker import _poll_single_azure_source
+
+        blob1 = MagicMock()
+        blob1.name = "logs/2024-01-01.json"
+        blob2 = MagicMock()
+        blob2.name = "logs/2024-01-02.json"
+
+        container_mock = MagicMock()
+        container_mock.list_blobs.return_value = iter([blob1, blob2])
+
+        with patch(
+            "azure.storage.blob.ContainerClient.from_container_url",
+            return_value=container_mock,
+        ):
+            # last_file = blob2's name, so both should be skipped
+            blobs, events = await _poll_single_azure_source(
+                cursor_id=1,
+                container_url="https://account.blob.core.windows.net/container",
+                prefix="logs/",
+                last_file="logs/2024-01-02.json",
+                session_factory=AsyncMock(),
+                valkey_client=AsyncMock(),
+                worker_cls=MagicMock(),
+            )
+
+        assert blobs == 0
+        assert events == 0

--- a/docs/runbooks/backup-restore.md
+++ b/docs/runbooks/backup-restore.md
@@ -1,0 +1,214 @@
+# Database Backup & Restore
+
+**Audience**: Platform operators, on-call engineers  
+**Components**: TimescaleDB (PostgreSQL 16), Helm CronJob, `scripts/backup.sh`, `scripts/restore.sh`
+
+---
+
+## Overview
+
+OctoWatch stores all audit log events, detections, and configuration in a
+TimescaleDB database.  This runbook covers automated and manual backup
+procedures, restore steps (including TimescaleDB-specific hooks), and
+post-restore verification.
+
+---
+
+## 1. Automated Backups (Helm CronJob)
+
+The Helm chart includes a `CronJob` that runs `pg_dump` on a configurable
+schedule and uploads the backup to S3-compatible storage.
+
+### Enable in values
+
+```yaml
+# values-azure.yaml (or your environment overlay)
+backup:
+  enabled: true
+  schedule: "0 2 * * *"           # Daily at 02:00 UTC
+  bucket: "octowatch-backups"     # S3 bucket name
+  retentionDays: 30               # Days to retain old backups
+  image: timescale/timescaledb:2.25.1-pg16
+```
+
+### How it works
+
+1. The CronJob runs at the configured schedule.
+2. `pg_dump` creates a compressed custom-format dump (`--format=custom --compress=9`).
+3. If the `aws` CLI is available in the image, the backup is uploaded to
+   `s3://<bucket>/octowatch/backups/<timestamp>.sql.gz`.
+4. Old backups beyond `retentionDays` are pruned from S3.
+5. The local temp file is deleted after upload.
+
+### Verify CronJob is running
+
+```bash
+kubectl -n octowatch get cronjob
+kubectl -n octowatch get jobs --sort-by=.metadata.creationTimestamp | tail -5
+```
+
+### Check backup job logs
+
+```bash
+kubectl -n octowatch logs job/octowatch-db-backup-<timestamp>
+```
+
+---
+
+## 2. Manual Backup
+
+Use `scripts/backup.sh` for ad-hoc backups from any machine with `pg_dump`
+and network access to the database.
+
+### Usage
+
+```bash
+# Local backup only
+DATABASE_URL="postgresql://app_rw:pass@db-host:5432/auditlogs" \
+  ./scripts/backup.sh
+
+# Backup + upload to S3
+DATABASE_URL="postgresql://app_rw:pass@db-host:5432/auditlogs" \
+  ./scripts/backup.sh s3://my-bucket/backups
+```
+
+### What the script does
+
+1. Validates `DATABASE_URL` and `pg_dump` are available.
+2. Runs `pg_dump` with flags: `--no-owner --no-acl --format=custom --compress=9`.
+3. Saves to `./backups/octowatch-backup-<timestamp>.dump`.
+4. Optionally uploads to the provided S3 path.
+
+### TimescaleDB compatibility
+
+The `--format=custom` flag produces a dump that is compatible with
+TimescaleDB's `timescaledb_pre_restore()` / `timescaledb_post_restore()`
+hooks.  No additional flags are needed — the dump includes hypertable
+definitions and chunk metadata.
+
+---
+
+## 3. Restore Procedure
+
+Use `scripts/restore.sh` to restore from a backup file or S3 path.
+
+### Prerequisites
+
+- **Stop all OctoWatch services** (API, workers, beat) before restoring.
+- Ensure `pg_restore` and `psql` are available.
+- The target database must exist (can be empty).
+
+### Usage
+
+```bash
+# From local file
+DATABASE_URL="postgresql://app_rw:pass@db-host:5432/auditlogs" \
+  ./scripts/restore.sh backups/octowatch-backup-20260501-020000.dump
+
+# From S3
+DATABASE_URL="postgresql://app_rw:pass@db-host:5432/auditlogs" \
+  ./scripts/restore.sh s3://octowatch-backups/octowatch/backups/20260501-020000.sql.gz
+```
+
+### Restore steps (performed by the script)
+
+| Step | Action | Notes |
+|------|--------|-------|
+| 1 | Download from S3 (if S3 path) | Uses `aws s3 cp` |
+| 2 | Ensure TimescaleDB extension exists | `CREATE EXTENSION IF NOT EXISTS timescaledb` |
+| 3 | Run `timescaledb_pre_restore()` | Prepares internal catalog for restore |
+| 4 | `pg_restore --clean --if-exists` | Drops and recreates all objects |
+| 5 | Run `timescaledb_post_restore()` | Rebuilds chunk indexes and catalog |
+| 6 | Verify hypertable integrity | Queries `timescaledb_information.hypertables` |
+| 7 | Check chunk health | Lists chunks with compression status |
+| 8 | Verify Alembic migrations | Runs `alembic check` and `alembic upgrade head` if needed |
+
+### Kubernetes restore
+
+If restoring to the AKS cluster database:
+
+```bash
+# 1. Scale down all deployments
+kubectl -n octowatch scale deploy --all --replicas=0
+
+# 2. Port-forward to the database
+kubectl -n octowatch port-forward svc/octowatch-timescaledb 5432:5432
+
+# 3. Run restore (in another terminal)
+DATABASE_URL="postgresql://app_rw:pass@localhost:5432/auditlogs" \
+  ./scripts/restore.sh backups/octowatch-backup-20260501-020000.dump
+
+# 4. Scale back up
+kubectl -n octowatch scale deploy --all --replicas=1
+# (HPA will scale API back to min replicas automatically)
+```
+
+---
+
+## 4. Post-Restore Verification Checklist
+
+After restoring, verify the following before re-enabling services:
+
+- [ ] **Alembic version matches code**: `alembic current` shows the expected head revision
+- [ ] **Hypertables intact**: `SELECT * FROM timescaledb_information.hypertables` returns expected tables
+- [ ] **Event count reasonable**: `SELECT COUNT(*) FROM events WHERE created_at > NOW() - INTERVAL '7 days'`
+- [ ] **Detections present**: `SELECT COUNT(*) FROM detections`
+- [ ] **Ingestion cursors valid**: `SELECT * FROM ingestion_cursors WHERE status = 'active'`
+- [ ] **Health endpoints**: After starting services, verify `/health` and `/ready` return 200
+- [ ] **Ingestion flowing**: Check worker logs for successful ingestion after restart
+
+---
+
+## 5. Backup Retention & Rotation
+
+### S3 lifecycle policy (recommended)
+
+Configure an S3 lifecycle rule as a safety net in case the CronJob pruning
+fails:
+
+```json
+{
+  "Rules": [{
+    "ID": "octowatch-backup-retention",
+    "Prefix": "octowatch/backups/",
+    "Status": "Enabled",
+    "Expiration": { "Days": 90 }
+  }]
+}
+```
+
+### Local backup cleanup
+
+Local backups in `./backups/` are not auto-pruned.  Add a cron job or
+periodically delete old files:
+
+```bash
+find ./backups/ -name "octowatch-backup-*.dump" -mtime +30 -delete
+```
+
+---
+
+## 6. Disaster Recovery Scenarios
+
+### Scenario: Complete database loss
+
+1. Provision a new TimescaleDB instance.
+2. Create the database and `timescaledb` extension.
+3. Run `scripts/restore.sh` with the latest backup.
+4. Verify with the checklist above.
+5. Restart all services.
+
+### Scenario: Corrupted table
+
+1. Identify the affected table.
+2. Take a fresh backup of the current state (even if corrupted).
+3. Restore from the last known good backup.
+4. Compare event counts to assess data loss window.
+5. Re-ingest missing data if the ingestion sources still have the original files.
+
+### Scenario: Failed migration
+
+1. Check `alembic current` to identify the stuck migration.
+2. If the migration is partially applied, run `alembic downgrade -1` to revert.
+3. Fix the migration script and re-run `alembic upgrade head`.
+4. If downgrade fails, restore from the pre-upgrade backup.

--- a/docs/runbooks/high-availability.md
+++ b/docs/runbooks/high-availability.md
@@ -1,0 +1,362 @@
+# High Availability Configuration Guide
+
+**Audience**: Platform operators, infrastructure engineers  
+**Components**: API, Celery workers, Celery Beat, TimescaleDB, Valkey, Ingress
+
+---
+
+## Overview
+
+This guide covers how to run OctoWatch in a highly available configuration
+where no single component failure causes data loss or extended downtime.
+
+### Architecture Summary
+
+```
+                    ┌──────────────┐
+                    │   Ingress    │
+                    │  (nginx LB)  │
+                    └──────┬───────┘
+                           │
+              ┌────────────┼────────────┐
+              ▼            ▼            ▼
+        ┌──────────┐ ┌──────────┐ ┌──────────┐
+        │  API (1) │ │  API (2) │ │  API (n) │
+        └────┬─────┘ └────┬─────┘ └────┬─────┘
+             │             │             │
+    ┌────────┴─────────────┴─────────────┴────────┐
+    │              Valkey (Broker)                  │
+    └────────┬─────────────┬─────────────┬────────┘
+             ▼             ▼             ▼
+      ┌────────────┐ ┌────────────┐ ┌────────────┐
+      │  Workers   │ │  Workers   │ │  Workers   │
+      │(ingestion) │ │(detection) │ │(baseline)  │
+      └──────┬─────┘ └──────┬─────┘ └──────┬─────┘
+             │               │               │
+             └───────────────┼───────────────┘
+                             ▼
+                    ┌──────────────┐
+                    │ TimescaleDB  │
+                    │  (Primary)   │
+                    └──────────────┘
+```
+
+---
+
+## 1. API High Availability
+
+### Horizontal Pod Autoscaler (HPA)
+
+The Helm chart includes an HPA for the API deployment:
+
+```yaml
+# helm/templates/hpa-api.yaml (already configured)
+apiVersion: autoscaling/v2
+spec:
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          averageUtilization: 70
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300  # Prevent flapping
+    scaleUp:
+      stabilizationWindowSeconds: 60
+```
+
+### PodDisruptionBudget (PDB)
+
+The Helm chart includes a PDB to ensure at least one API pod remains available
+during voluntary disruptions (node drains, upgrades):
+
+```yaml
+# helm/templates/pdb-api.yaml
+apiVersion: policy/v1
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api
+```
+
+### Rolling Update Strategy
+
+The API deployment uses a rolling update strategy that ensures zero downtime:
+
+```yaml
+# deployment-api.yaml
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1        # Start one new pod before stopping old
+    maxUnavailable: 0  # Never remove a pod until replacement is ready
+```
+
+### Session handling
+
+API pods are stateless — all session state is stored in Valkey.  Any pod can
+handle any request.  The Ingress load balancer distributes traffic
+round-robin.
+
+---
+
+## 2. Worker High Availability
+
+### Queue-based scaling with KEDA
+
+OctoWatch uses KEDA (Kubernetes Event-Driven Autoscaling) to scale worker
+deployments based on Valkey queue depth:
+
+```yaml
+# values-azure.yaml
+keda:
+  enabled: true
+
+workers:
+  ingestion:
+    replicas: 4    # Base replicas (KEDA scales above this)
+  detection:
+    replicas: 4
+  notification:
+    replicas: 2
+  baseline:
+    replicas: 2
+```
+
+KEDA ScaledObjects are defined in `helm/templates/keda-scaled-objects.yaml`
+and scale each worker deployment independently based on queue length.
+
+### Without KEDA
+
+If KEDA is not available, set static replica counts in values:
+
+```yaml
+keda:
+  enabled: false
+
+workers:
+  ingestion:
+    replicas: 4    # Fixed replica count
+  detection:
+    replicas: 4
+```
+
+### Worker reliability
+
+Celery is configured for at-least-once delivery:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `task_acks_late` | `True` | Tasks acknowledged only after completion |
+| `worker_prefetch_multiplier` | `1` | Workers fetch one task at a time |
+| `task_reject_on_worker_lost` | `True` | Tasks re-queued if worker dies |
+
+If a worker pod is killed (OOM, node failure), its in-progress task is
+automatically returned to the queue and picked up by another worker.
+
+---
+
+## 3. Celery Beat — Exactly-One Constraint
+
+Celery Beat (the task scheduler) **must run as exactly one instance**.
+Running multiple Beat instances will cause duplicate task submissions.
+
+### Current approach: single-replica Deployment
+
+```yaml
+# deployment-beat.yaml
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate  # Kill old before starting new — prevents overlap
+```
+
+### Failure recovery
+
+If the Beat pod fails:
+
+1. Kubernetes automatically restarts it (via the Deployment controller).
+2. Beat re-reads the schedule from `celery_app.py` on startup.
+3. Missed schedules fire immediately on the next beat tick.
+4. The `Recreate` strategy ensures no two Beat instances run simultaneously.
+
+### Monitoring Beat health
+
+```bash
+# Check Beat pod status
+kubectl -n octowatch get pods -l app.kubernetes.io/component=beat
+
+# Check Beat logs for schedule registration
+kubectl -n octowatch logs deploy/octowatch-beat --tail=20
+```
+
+### Advanced: leader election (optional)
+
+For environments requiring faster Beat failover, consider using a leader
+election sidecar:
+
+```yaml
+# Example: celery-beat with leader election via Kubernetes Lease
+containers:
+  - name: beat
+    command: ["celery", "-A", "app.celery_app", "beat", "--loglevel=info"]
+    # Only runs when this pod holds the Lease
+```
+
+This is not currently implemented in the Helm chart but can be added if
+sub-second Beat failover is required.
+
+---
+
+## 4. TimescaleDB High Availability
+
+### Current setup: standalone StatefulSet
+
+OctoWatch deploys TimescaleDB as a single-instance StatefulSet
+(`helm/templates/timescaledb.yaml`).  This provides data durability via PVC
+but not automatic failover.
+
+### Failover procedure (manual)
+
+If the TimescaleDB pod fails:
+
+1. **Kubernetes restarts it automatically** — the StatefulSet controller
+   ensures exactly one pod.  The PVC preserves data across restarts.
+2. **If the node fails** — Kubernetes reschedules the pod to another node.
+   The PVC must use a zone-redundant storage class (`managed-csi-zrs`) to
+   ensure the volume is accessible from any availability zone.
+3. **If the PVC is lost** — restore from backup (see
+   [backup-restore.md](backup-restore.md)).
+
+### Timeline
+
+| Failure type | Recovery time | Data loss |
+|-------------|---------------|-----------|
+| Pod crash | ~30 seconds | None (PVC intact) |
+| Node failure (ZRS PVC) | ~2-5 minutes | None |
+| Node failure (LRS PVC) | Manual restore | Since last backup |
+| PVC corruption | Manual restore | Since last backup |
+
+### Recommended: managed database
+
+For production environments requiring < 1 minute failover, use a managed
+database service:
+
+- **Azure**: Azure Database for PostgreSQL Flexible Server with Citus/TimescaleDB extension
+- **AWS**: Amazon RDS for PostgreSQL with TimescaleDB AMI
+
+Set `postgresql.enabled: false` in Helm values and provide the
+`DATABASE_URL` pointing to the managed instance.
+
+---
+
+## 5. Valkey (Redis) High Availability
+
+### Current setup: single instance
+
+OctoWatch uses Valkey as Celery's broker and result backend.
+
+### Failure impact
+
+If Valkey becomes unavailable:
+
+- **Workers** stop receiving tasks — work queues until Valkey recovers.
+- **API** continues serving read requests from the database.
+- **No data loss** — events are in the database; only task dispatch is delayed.
+
+### Recommended: Valkey Sentinel or Cluster
+
+For production HA:
+
+```yaml
+# values-azure.yaml
+valkey:
+  architecture: replication
+  sentinel:
+    enabled: true
+    replicas: 3
+```
+
+Update `VALKEY_URL` to use the Sentinel endpoint:
+
+```
+redis+sentinel://:password@sentinel-0:26379,sentinel-1:26379,sentinel-2:26379/mymaster/0
+```
+
+---
+
+## 6. Ingress & Load Balancing
+
+The nginx Ingress controller distributes traffic across all healthy API pods:
+
+- **Health checks**: The Ingress uses the API's `/ready` endpoint for
+  backend health checks.
+- **Rate limiting**: Separate Ingress resources apply per-path rate limits
+  (see `helm/templates/ingress.yaml`).
+- **TLS termination**: TLS is terminated at the Ingress level.
+
+### Multi-zone deployment
+
+Ensure API pods are spread across availability zones:
+
+```yaml
+# Add to API deployment (recommended)
+affinity:
+  podAntiAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          topologyKey: topology.kubernetes.io/zone
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: api
+```
+
+---
+
+## 7. Monitoring & Alerting for HA
+
+### Key metrics to monitor
+
+| Component | Metric | Alert threshold |
+|-----------|--------|-----------------|
+| API | Pod count < `minReplicas` | Immediate |
+| API | HTTP 5xx rate | > 1% for 5 minutes |
+| Workers | Queue depth growing | > 1000 for 15 minutes |
+| Beat | Pod not Running | > 2 minutes |
+| TimescaleDB | Pod not Ready | > 1 minute |
+| Valkey | Connection failures | Any |
+| Ingestion | No events ingested | > 30 minutes |
+
+### Health endpoints
+
+```bash
+# API health (includes DB and Valkey connectivity)
+curl https://<host>/health
+
+# API readiness (ready to serve traffic)
+curl https://<host>/ready
+```
+
+---
+
+## 8. HA Configuration Checklist
+
+- [ ] API `minReplicas` ≥ 2 in HPA
+- [ ] PodDisruptionBudget configured for API
+- [ ] Worker replicas ≥ 2 per queue (or KEDA enabled)
+- [ ] Beat deployment uses `Recreate` strategy
+- [ ] TimescaleDB PVC uses zone-redundant storage (`managed-csi-zrs`)
+- [ ] Automated backups enabled and tested
+- [ ] Pod anti-affinity configured for zone spread
+- [ ] Monitoring and alerting configured for all components
+- [ ] `terminationGracePeriodSeconds` set on worker pods (≥ 1800)

--- a/docs/runbooks/zero-downtime-upgrade.md
+++ b/docs/runbooks/zero-downtime-upgrade.md
@@ -1,0 +1,196 @@
+# Zero-Downtime Upgrade
+
+**Audience**: Platform operators, release engineers  
+**Components**: Helm chart, Alembic migrations, Celery workers
+
+---
+
+## Overview
+
+OctoWatch supports zero-downtime upgrades through:
+
+1. **Pre-upgrade migration job** — Alembic runs before new pods start.
+2. **Rolling deployments** — API pods roll one at a time (`maxSurge: 1`, `maxUnavailable: 0`).
+3. **Graceful worker shutdown** — Celery workers finish in-progress tasks before exiting.
+
+---
+
+## 1. Upgrade Procedure
+
+### Standard Helm upgrade
+
+```bash
+# 1. Review what will change
+helm diff upgrade octowatch ./helm \
+  -f helm/values.yaml \
+  -f helm/values-azure.yaml \
+  --namespace octowatch
+
+# 2. Run the upgrade
+helm upgrade octowatch ./helm \
+  -f helm/values.yaml \
+  -f helm/values-azure.yaml \
+  --namespace octowatch \
+  --wait \
+  --timeout 10m
+```
+
+### What happens during `helm upgrade`
+
+```
+helm upgrade
+  │
+  ├─ 1. Migration Job (post-sync hook, weight 5)
+  │     └─ Runs: alembic upgrade head
+  │     └─ Blocks until complete (backoffLimit: 3, deadline: 300s)
+  │     └─ Deleted after success (hook-delete-policy: before-hook-creation,hook-succeeded)
+  │
+  ├─ 2. API Deployment (rolling update)
+  │     └─ maxSurge: 1 — one new pod starts first
+  │     └─ maxUnavailable: 0 — no old pods terminate until new is Ready
+  │     └─ Readiness probe must pass before traffic shifts
+  │
+  ├─ 3. Worker Deployments (rolling update)
+  │     └─ Each worker deployment rolls independently
+  │     └─ Celery workers handle SIGTERM gracefully (see §3)
+  │
+  └─ 4. Beat Deployment (rolling update)
+        └─ Single replica — brief gap is acceptable for scheduler
+```
+
+---
+
+## 2. Migration Compatibility Guidelines
+
+To maintain zero-downtime, database migrations **must be backwards-compatible**
+with the currently running code version.  Follow these rules:
+
+### Safe operations (online, no locks)
+
+| Operation | Approach |
+|-----------|----------|
+| Add a nullable column | `ALTER TABLE ... ADD COLUMN ... NULL` — no table lock |
+| Add an index | `CREATE INDEX CONCURRENTLY` — does not block reads/writes |
+| Add a new table | Safe — existing code does not reference it |
+| Backfill data | Use batched updates with `LIMIT` to avoid long transactions |
+
+### Unsafe operations (require two-phase deploy)
+
+| Operation | Approach |
+|-----------|----------|
+| Remove a column | Phase 1: Stop reading the column in code. Phase 2: Drop column in next release |
+| Rename a column | Phase 1: Add new column + write to both. Phase 2: Drop old column |
+| Add NOT NULL constraint | Phase 1: Backfill nulls. Phase 2: Add constraint with `NOT VALID`, then `VALIDATE` |
+| Change column type | Phase 1: Add new column. Phase 2: Migrate data. Phase 3: Drop old column |
+
+### TimescaleDB-specific considerations
+
+- **Hypertable schema changes**: `ALTER TABLE` on hypertables may affect chunks.
+  Always test on a staging instance first.
+- **Compression policy changes**: Modify compression settings in a separate
+  migration from schema changes.
+- **Continuous aggregates**: Refresh policies must be updated if underlying
+  hypertable schema changes.
+
+---
+
+## 3. Celery Worker Graceful Shutdown
+
+OctoWatch's Celery configuration ensures no work is lost during upgrades:
+
+```python
+# celery_app.py
+"task_acks_late": True,           # Ack only after task completes
+"worker_prefetch_multiplier": 1,  # Fetch one task at a time
+"task_reject_on_worker_lost": True,  # Re-queue if worker dies
+```
+
+### How it works
+
+1. Kubernetes sends `SIGTERM` to the old worker pod.
+2. Celery receives `SIGTERM` and stops accepting new tasks.
+3. In-progress tasks continue until completion (up to `task_soft_time_limit` of 30 min).
+4. Once all tasks finish, the worker exits cleanly.
+5. Kubernetes waits up to `terminationGracePeriodSeconds` (default 30s) before `SIGKILL`.
+
+### Recommendation
+
+Set `terminationGracePeriodSeconds` on worker deployments to match the longest
+expected task duration:
+
+```yaml
+# In deployment-worker.yaml
+spec:
+  template:
+    spec:
+      terminationGracePeriodSeconds: 1800  # 30 minutes — matches task_soft_time_limit
+```
+
+If a worker is killed before its task completes, `task_reject_on_worker_lost`
+ensures the task is returned to the queue and picked up by another worker.
+
+---
+
+## 4. Rollback Procedure
+
+### Helm rollback
+
+```bash
+# List release history
+helm history octowatch --namespace octowatch
+
+# Rollback to previous revision
+helm rollback octowatch <revision> --namespace octowatch --wait
+```
+
+### Database rollback
+
+If the new migration is incompatible with the old code:
+
+```bash
+# 1. Identify the target revision
+kubectl exec -n octowatch deploy/octowatch-api -- alembic history | head -10
+
+# 2. Downgrade to the previous revision
+kubectl exec -n octowatch deploy/octowatch-api -- alembic downgrade -1
+
+# 3. Then rollback the Helm release
+helm rollback octowatch <revision> --namespace octowatch --wait
+```
+
+> **Important**: Only downgrade if the migration added columns/tables. If the
+> migration was destructive (dropped columns), restore from backup instead.
+
+---
+
+## 5. Pre-Upgrade Checklist
+
+Before running `helm upgrade`:
+
+- [ ] **Backup**: Verify the latest automated backup completed successfully
+- [ ] **Migration review**: Check new Alembic migrations for backwards compatibility
+- [ ] **Staging tested**: New version deployed and validated on staging
+- [ ] **Worker queues drained**: Check queue depth — large backlogs may cause long shutdown:
+  ```bash
+  kubectl exec -n octowatch deploy/octowatch-api -- \
+    python -c "from app.celery_app import celery_app; print(celery_app.control.inspect().active())"
+  ```
+- [ ] **Maintenance window** (optional): Enable maintenance mode for major upgrades
+
+---
+
+## 6. Post-Upgrade Verification
+
+After the upgrade completes:
+
+- [ ] **Health check**: `curl -s https://<host>/health | jq .`
+- [ ] **Readiness**: `curl -s https://<host>/ready | jq .`
+- [ ] **Migration version**: `kubectl exec -n octowatch deploy/octowatch-api -- alembic current`
+- [ ] **API version**: Check the `/api/v1/version` endpoint (if available)
+- [ ] **Worker status**: Verify all worker pods are Running:
+  ```bash
+  kubectl -n octowatch get pods -l app.kubernetes.io/component=worker
+  ```
+- [ ] **Beat schedule**: Check beat pod logs for scheduled task registration
+- [ ] **Ingestion flowing**: Monitor ingestion worker logs for new events
+- [ ] **No errors**: Check for elevated error rates in logs or monitoring


### PR DESCRIPTION
## Phase 6: Production Hardening

Completes the final roadmap phase with all 4 remaining issues.

### #29 — Implement missing Celery worker tasks
- Created `s3_worker.py` with `poll_s3_sources` Celery task — polls active S3 ingestion cursors, downloads JSON/NDJSON files, and ingests through the standard dedup pipeline
- Created `azure_worker.py` with `poll_azure_sources` task — same pattern for Azure Blob Storage containers
- Added beat schedule entries (5-minute intervals) and registered both modules in `conf.include`
- 13 unit tests covering file parsing (JSON, NDJSON, gzipped variants) and cursor-based polling logic

### #71 — Database backup & restore procedures
- Created `docs/runbooks/backup-restore.md` covering:
  - Automated CronJob backups (already in Helm chart)
  - Manual backup/restore scripts (`scripts/backup.sh`, `scripts/restore.sh`)
  - TimescaleDB-specific restore hooks and hypertable verification
  - Post-restore verification checklist
  - Disaster recovery scenarios

### #73 — Zero-downtime upgrade path
- Created `docs/runbooks/zero-downtime-upgrade.md` covering:
  - `helm upgrade` flow with migration job → rolling API → worker rollout
  - Migration compatibility guidelines (safe vs unsafe DDL operations)
  - Celery graceful shutdown mechanics (`task_acks_late`, `task_reject_on_worker_lost`)
  - Rollback procedure (Helm + Alembic)
  - Pre/post-upgrade checklists

### #74 — High availability configuration guide
- Created `docs/runbooks/high-availability.md` covering:
  - API: HPA (2-10 replicas), PDB (already in chart), rolling updates
  - Workers: KEDA queue-based scaling, at-least-once delivery
  - Beat: exactly-one constraint, failure recovery
  - TimescaleDB: failover timelines, ZRS storage, managed DB recommendations
  - Valkey: Sentinel/Cluster HA options
  - Monitoring and alerting guidance

Closes #29, closes #71, closes #73, closes #74