### PR TITLE
fix: allow all DB-defined roles in role assignment schema

### DIFF
--- a/backend/app/schemas/integration.py
+++ b/backend/app/schemas/integration.py
@@ -161,7 +161,7 @@ class RoleAssignmentCreate(BaseModel):
     github_team_id: int | None = None
     github_team_slug: str | None = Field(None, max_length=255)
     saml_subject: str | None = Field(None, max_length=500)
-    role_name: str = Field(..., pattern=r"^(analyst|report_admin|rule_author|sys_admin)$")
+    role_name: str = Field(..., min_length=1, max_length=100)
     scope_type: str = Field(..., pattern=r"^(global|org|repo)$")
     scope_value: str | None = Field(None, max_length=512)
     expires_at: datetime | None = None

--- a/frontend/src/pages/Users/index.tsx
+++ b/frontend/src/pages/Users/index.tsx
@@ -958,7 +958,7 @@ export function UsersPage() {
     queryFn: getActiveSessions,
   });
 
-  const roles = roleDefs?.map((r) => r.name) ?? ['viewer', 'analyst', 'admin'];
+  const roles = roleDefs?.map((r) => r.name) ?? ['viewer', 'security_analyst', 'super_admin'];
 
   const createMutation = useMutation({
     mutationFn: createRoleAssignment,


### PR DESCRIPTION
## Bug

Adding a user via the admin UI fails with "Failed to create role assignment" every time.

## Root Cause

**Backend**: `RoleAssignmentCreate.role_name` had a hardcoded regex: `^(analyst|report_admin|rule_author|sys_admin)$`

None of these match the actual seeded roles in the DB:
- `super_admin`, `security_analyst`, `security_engineer`, `compliance_officer`, `engineering_leader`, `copilot_admin`, `viewer`

Every POST to `/admin/assignments` was rejected with a 422 before the DB lookup could even run.

**Frontend**: The fallback role list (`['viewer', 'analyst', 'admin']`) also didn't match.

## Fix

- **Backend**: Replace the stale regex with `min_length=1, max_length=100`. The role name is already validated against the DB at the router level (`admin.py:111-117`).
- **Frontend**: Update the fallback to `['viewer', 'security_analyst', 'super_admin']` to match actual DB roles.