### PR TITLE
feat: pre-seed 5 default threat intelligence feeds (#253)

### DIFF
--- a/backend/alembic/versions/0056_seed_default_threat_intel_feeds.py
+++ b/backend/alembic/versions/0056_seed_default_threat_intel_feeds.py
@@ -1,0 +1,118 @@
+"""Seed default threat intelligence feeds.
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-06-01 00:00:00.000000+00:00
+
+Adds an ``is_default`` boolean column to ``threat_intel_feeds`` and inserts
+five curated, open-source threat intelligence feeds so new installations
+see value on first load.  The migration is idempotent — feeds are matched
+by URL using ``ON CONFLICT`` so re-running is safe for existing installs.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0056"
+down_revision = "0055"
+branch_labels = None
+depends_on = None
+
+# (name, url, feed_type, refresh_interval_minutes, description)
+_DEFAULT_FEEDS = [
+    (
+        "Abuse.ch URLhaus",
+        "https://urlhaus.abuse.ch/downloads/csv_recent/",
+        "domain",
+        360,
+        "Malicious URLs used for malware distribution, updated frequently by abuse.ch.",
+    ),
+    (
+        "Abuse.ch Feodo Tracker",
+        "https://feodotracker.abuse.ch/downloads/ipblocklist_recommended.txt",
+        "ip",
+        360,
+        "Botnet command-and-control server IPs tracked by Feodo Tracker.",
+    ),
+    (
+        "AlienVault OTX",
+        "https://otx.alienvault.com/api/v1/pulses/subscribed",
+        "domain",
+        1440,
+        "Community-sourced indicators from AlienVault Open Threat Exchange.",
+    ),
+    (
+        "CISA Known Exploited Vulnerabilities",
+        "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+        "domain",
+        1440,
+        "Actively exploited CVEs catalogued by CISA — critical for patch prioritisation.",
+    ),
+    (
+        "PhishTank",
+        "https://data.phishtank.com/data/online-valid.csv",
+        "domain",
+        720,
+        "Verified phishing URLs submitted and validated by the PhishTank community.",
+    ),
+]
+
+
+def upgrade() -> None:
+    """Add is_default column and seed default threat intel feeds."""
+    # 1. Add the is_default column (FALSE for any pre-existing rows).
+    op.add_column(
+        "threat_intel_feeds",
+        sa.Column(
+            "is_default",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("FALSE"),
+        ),
+    )
+
+    # 2. Add a unique constraint on url to support idempotent upserts.
+    op.create_unique_constraint(
+        "uq_threat_intel_feeds_url",
+        "threat_intel_feeds",
+        ["url"],
+    )
+
+    # 3. Seed the five default feeds.
+    conn = op.get_bind()
+    for name, url, feed_type, refresh_minutes, _description in _DEFAULT_FEEDS:
+        conn.execute(
+            sa.text(
+                "INSERT INTO threat_intel_feeds"
+                "    (name, url, feed_type, refresh_interval_minutes,"
+                "     enabled, is_default, created_by)"
+                " VALUES"
+                "    (:name, :url, :feed_type, :refresh_minutes,"
+                "     TRUE, TRUE, 'system')"
+                " ON CONFLICT (url) DO UPDATE SET"
+                "    name = EXCLUDED.name,"
+                "    feed_type = EXCLUDED.feed_type,"
+                "    refresh_interval_minutes = EXCLUDED.refresh_interval_minutes,"
+                "    is_default = TRUE,"
+                "    updated_at = NOW()"
+            ),
+            {
+                "name": name,
+                "url": url,
+                "feed_type": feed_type,
+                "refresh_minutes": refresh_minutes,
+            },
+        )
+
+
+def downgrade() -> None:
+    """Remove seeded default feeds, drop unique constraint, and remove is_default column."""
+    conn = op.get_bind()
+    urls = [url for _, url, *_ in _DEFAULT_FEEDS]
+    conn.execute(
+        sa.text("DELETE FROM threat_intel_feeds WHERE url = ANY(:urls) AND is_default = TRUE"),
+        {"urls": urls},
+    )
+    op.drop_constraint("uq_threat_intel_feeds_url", "threat_intel_feeds", type_="unique")
+    op.drop_column("threat_intel_feeds", "is_default")

--- a/backend/app/models/threat_intel.py
+++ b/backend/app/models/threat_intel.py
@@ -87,3 +87,4 @@ class ThreatIntelFeed(Base):
         nullable=False,
         server_default=text("NOW()"),
     )
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("FALSE"))

--- a/backend/app/schemas/threat_intel.py
+++ b/backend/app/schemas/threat_intel.py
@@ -95,6 +95,7 @@ class FeedResponse(BaseModel):
     created_by: str
     created_at: datetime
     updated_at: datetime
+    is_default: bool = False
 
 
 class FeedListResponse(BaseModel):

--- a/backend/app/services/threat_intel_service.py
+++ b/backend/app/services/threat_intel_service.py
@@ -297,7 +297,7 @@ async def get_feeds(
         text("""
             SELECT id, name, url, feed_type, enabled, refresh_interval_minutes,
                    last_fetched_at, last_fetch_status, last_indicator_count,
-                   created_by, created_at, updated_at
+                   created_by, created_at, updated_at, is_default
             FROM threat_intel_feeds
             ORDER BY created_at DESC
         """)
@@ -323,7 +323,7 @@ async def create_feed(
                 (:name, :url, :feed_type, :refresh_interval_minutes, :created_by)
             RETURNING id, name, url, feed_type, enabled, refresh_interval_minutes,
                       last_fetched_at, last_fetch_status, last_indicator_count,
-                      created_by, created_at, updated_at
+                      created_by, created_at, updated_at, is_default
         """),
         {
             "name": name,
@@ -424,7 +424,7 @@ async def update_feed(
             WHERE id = :id
             RETURNING id, name, url, feed_type, enabled, refresh_interval_minutes,
                       last_fetched_at, last_fetch_status, last_indicator_count,
-                      created_by, created_at, updated_at
+                      created_by, created_at, updated_at, is_default
         """),
         params,
     )

--- a/backend/tests/test_seed_threat_intel_feeds.py
+++ b/backend/tests/test_seed_threat_intel_feeds.py
@@ -1,0 +1,132 @@
+"""Tests for the 0056 seed-default-threat-intel-feeds migration."""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+_MIGRATION_PATH = (
+    Path(__file__).parent.parent
+    / "alembic"
+    / "versions"
+    / "0056_seed_default_threat_intel_feeds.py"
+)
+
+
+def _load_migration() -> types.ModuleType:
+    """Import the migration module whose name starts with a digit."""
+    spec = importlib.util.spec_from_file_location("migration_0056", str(_MIGRATION_PATH))
+    assert spec is not None
+    assert spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestMigrationFileStructure:
+    """Validate the Alembic migration file is well-formed."""
+
+    def test_migration_file_exists(self) -> None:
+        assert _MIGRATION_PATH.exists(), f"Migration not found at {_MIGRATION_PATH}"
+
+    def test_revision_chain(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert 'revision = "0056"' in content
+        assert 'down_revision = "0055"' in content
+
+    def test_upgrade_adds_is_default_column(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert "is_default" in content
+        assert "add_column" in content
+
+    def test_upgrade_creates_unique_constraint_on_url(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert "uq_threat_intel_feeds_url" in content
+        assert "create_unique_constraint" in content
+
+    def test_upgrade_inserts_five_feeds(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert "urlhaus.abuse.ch" in content
+        assert "feodotracker.abuse.ch" in content
+        assert "otx.alienvault.com" in content
+        assert "cisa.gov" in content
+        assert "phishtank.com" in content
+
+    def test_upgrade_is_idempotent(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert "ON CONFLICT" in content
+
+    def test_downgrade_removes_feeds_and_column(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert "DELETE FROM threat_intel_feeds" in content
+        assert "drop_column" in content
+        assert "drop_constraint" in content
+
+    def test_feeds_are_marked_as_default(self) -> None:
+        content = _MIGRATION_PATH.read_text()
+        assert "is_default = TRUE" in content or "is_default, created_by" in content
+
+
+class TestDefaultFeedData:
+    """Validate the seed data constants are correct."""
+
+    def test_feed_count(self) -> None:
+        mod = _load_migration()
+        assert len(mod._DEFAULT_FEEDS) == 5
+
+    def test_feed_tuple_structure(self) -> None:
+        mod = _load_migration()
+        for feed in mod._DEFAULT_FEEDS:
+            name, url, feed_type, refresh_minutes, description = feed
+            assert isinstance(name, str) and len(name) > 0
+            assert url.startswith("https://")
+            assert feed_type in ("domain", "ip")
+            assert isinstance(refresh_minutes, int) and refresh_minutes > 0
+            assert isinstance(description, str) and len(description) > 0
+
+    def test_feed_urls_are_unique(self) -> None:
+        mod = _load_migration()
+        urls = [url for _, url, *_ in mod._DEFAULT_FEEDS]
+        assert len(urls) == len(set(urls)), "Feed URLs must be unique"
+
+    def test_feed_names_are_unique(self) -> None:
+        mod = _load_migration()
+        names = [name for name, *_ in mod._DEFAULT_FEEDS]
+        assert len(names) == len(set(names)), "Feed names must be unique"
+
+    def test_all_feeds_enabled_by_default(self) -> None:
+        """The INSERT statement sets enabled = TRUE for all default feeds."""
+        content = _MIGRATION_PATH.read_text()
+        assert "TRUE, TRUE, 'system'" in content
+
+
+class TestThreatIntelFeedModel:
+    """Verify the ORM model has the is_default column."""
+
+    def test_model_has_is_default_field(self) -> None:
+        from app.models.threat_intel import ThreatIntelFeed
+
+        assert hasattr(ThreatIntelFeed, "is_default")
+
+    def test_is_default_column_type(self) -> None:
+        from app.models.threat_intel import ThreatIntelFeed
+
+        col = ThreatIntelFeed.__table__.columns["is_default"]
+        assert not col.nullable
+        assert str(col.server_default.arg) == "FALSE"
+
+
+class TestFeedResponseSchema:
+    """Verify the Pydantic schema exposes is_default."""
+
+    def test_schema_has_is_default(self) -> None:
+        from app.schemas.threat_intel import FeedResponse
+
+        assert "is_default" in FeedResponse.model_fields
+
+    def test_schema_is_default_defaults_to_false(self) -> None:
+        from app.schemas.threat_intel import FeedResponse
+
+        field = FeedResponse.model_fields["is_default"]
+        assert field.default is False


### PR DESCRIPTION
## Summary

Seeds 5 curated threat intelligence feeds via Alembic migration so new users see value on the Threat Intel page immediately.

### Default Feeds
| Feed | Type | Refresh |
|------|------|---------|
| Abuse.ch URLhaus | domain | 6h |
| Abuse.ch Feodo Tracker | ip | 6h |
| AlienVault OTX | domain | 24h |
| CISA KEV | domain | 24h |
| PhishTank | domain | 12h |

### Changes
- New migration `0056_seed_default_threat_intel_feeds.py` — adds `is_default` column + seeds 5 feeds
- Updated ORM model, Pydantic schema, and service queries to include `is_default`
- 17 new tests for migration structure, idempotency, and data validation
- Migration is idempotent (`ON CONFLICT DO UPDATE`) — safe for existing installations

### Validation
- ✅ 2,741 backend tests passing (17 new)
- ✅ Ruff lint + format clean
- ✅ mypy clean

Closes #253