### PR TITLE
feat: auto-populate workflow security data via background sync (#256)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -102,10 +102,10 @@ app.config_from_object(
                 "schedule": crontab(hour=6, minute=0),
                 "options": {"queue": "github_sync"},
             },
-            # Workflow security scan — daily at 04:00 UTC
+            # Workflow security scan — every 6 hours
             "scan-workflow-security": {
                 "task": "app.workers.workflow_scan_worker.scan_all_workflows",
-                "schedule": crontab(hour=4, minute=0),
+                "schedule": crontab(minute=0, hour="*/6"),
                 "options": {"queue": "baseline"},
             },
             # Threat intel feed refresh — every 30 minutes

--- a/backend/app/routers/workflow_scanner.py
+++ b/backend/app/routers/workflow_scanner.py
@@ -64,6 +64,18 @@ class FindingsListResponse(BaseModel):
     total: int
 
 
+class ScanStatusResponse(BaseModel):
+    """Status of the automated workflow security scanner."""
+
+    last_scan_at: datetime | None = None
+    last_scan_status: str | None = None
+    total_scans: int = 0
+    total_findings: int = 0
+    repos_scanned: int = 0
+    next_scheduled_scan: str = "Runs every 6 hours and on new audit-log events"
+    is_automated: bool = True
+
+
 class ScanResultResponse(BaseModel):
     """Result of a manual workflow scan."""
 
@@ -140,6 +152,47 @@ async def list_findings(
             for f in findings
         ],
         total=total,
+    )
+
+
+@router.get("/scan-status", response_model=ScanStatusResponse)
+async def get_scan_status(
+    current_user: AuthenticatedUser = Depends(require_permission("workflow_security", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> ScanStatusResponse:
+    """Return the current status of the automated workflow scanner.
+
+    Reports the most recent scan time, total scan count, total findings, and
+    the number of distinct repositories with findings.  No GitHub API calls are
+    made — all data comes from the database.
+    """
+    # Latest activity record
+    latest_stmt = (
+        select(WorkflowScanActivity).order_by(WorkflowScanActivity.started_at.desc()).limit(1)
+    )
+    latest = (await db.execute(latest_stmt)).scalar_one_or_none()
+
+    # Total scans
+    total_scans = (
+        await db.execute(select(func.count()).select_from(WorkflowScanActivity))
+    ).scalar() or 0
+
+    # Total open findings
+    total_findings = (
+        await db.execute(select(func.count()).select_from(WorkflowFinding))
+    ).scalar() or 0
+
+    # Distinct repos with findings
+    repos_scanned = (
+        await db.execute(select(func.count(func.distinct(WorkflowFinding.repo))))
+    ).scalar() or 0
+
+    return ScanStatusResponse(
+        last_scan_at=latest.started_at if latest else None,
+        last_scan_status=latest.status if latest else None,
+        total_scans=total_scans,
+        total_findings=total_findings,
+        repos_scanned=repos_scanned,
     )
 
 

--- a/backend/tests/test_workflow_scan_activity.py
+++ b/backend/tests/test_workflow_scan_activity.py
@@ -164,6 +164,54 @@ class TestAnalyzeFunctions:
         assert findings == []
 
 
+class TestScanStatusEndpoint:
+    """Test the /scan-status endpoint response schema."""
+
+    def test_scan_status_response_schema(self) -> None:
+        """ScanStatusResponse should accept valid data."""
+        from app.routers.workflow_scanner import ScanStatusResponse
+
+        resp = ScanStatusResponse(
+            last_scan_at=datetime.now(UTC),
+            last_scan_status="completed",
+            total_scans=42,
+            total_findings=5,
+            repos_scanned=3,
+            next_scheduled_scan="Runs every 6 hours and on new audit-log events",
+            is_automated=True,
+        )
+        assert resp.total_scans == 42
+        assert resp.total_findings == 5
+        assert resp.repos_scanned == 3
+        assert resp.is_automated is True
+
+    def test_scan_status_response_defaults(self) -> None:
+        """ScanStatusResponse should have sensible defaults."""
+        from app.routers.workflow_scanner import ScanStatusResponse
+
+        resp = ScanStatusResponse()
+        assert resp.last_scan_at is None
+        assert resp.last_scan_status is None
+        assert resp.total_scans == 0
+        assert resp.total_findings == 0
+        assert resp.repos_scanned == 0
+        assert resp.is_automated is True
+
+    def test_scan_status_response_without_last_scan(self) -> None:
+        """ScanStatusResponse should work when no scan has run yet."""
+        from app.routers.workflow_scanner import ScanStatusResponse
+
+        resp = ScanStatusResponse(
+            last_scan_at=None,
+            last_scan_status=None,
+            total_scans=0,
+            total_findings=0,
+            repos_scanned=0,
+        )
+        assert resp.last_scan_at is None
+        assert resp.last_scan_status is None
+
+
 class TestActivityEndpoint:
     """Test the /activity endpoint response schemas."""
 
@@ -224,3 +272,21 @@ class TestDetectionWorkerChain:
             scan_workflow_events_task.name
             == "app.workers.workflow_scan_worker.scan_workflow_events"
         )
+
+
+class TestCeleryBeatSchedule:
+    """Test that workflow scanning is scheduled at the correct frequency."""
+
+    def test_scan_scheduled_every_six_hours(self) -> None:
+        """Workflow security scan should run every 6 hours."""
+        from app.celery_app import celery_app
+
+        schedule = celery_app.conf.beat_schedule
+        assert "scan-workflow-security" in schedule
+
+        scan_config = schedule["scan-workflow-security"]
+        assert scan_config["task"] == "app.workers.workflow_scan_worker.scan_all_workflows"
+        # Verify the schedule is every 6 hours (hour="*/6", minute=0)
+        cron = scan_config["schedule"]
+        assert {0, 6, 12, 18} == set(cron.hour)
+        assert {0} == set(cron.minute)

--- a/frontend/src/api/workflowScanner.ts
+++ b/frontend/src/api/workflowScanner.ts
@@ -50,6 +50,16 @@ export interface ScanActivityListResponse {
   total: number;
 }
 
+export interface ScanStatus {
+  last_scan_at: string | null;
+  last_scan_status: string | null;
+  total_scans: number;
+  total_findings: number;
+  repos_scanned: number;
+  next_scheduled_scan: string;
+  is_automated: boolean;
+}
+
 export function listWorkflowFindings(params?: {
   org?: string;
   repo?: string;
@@ -73,8 +83,8 @@ export function scanWorkflow(body: { content: string; path?: string }) {
   return api.post<{ findings: WorkflowFinding[] }>('/workflows/scan', body);
 }
 
-export function triggerRepoScan() {
-  return api.post<{ task_id: string; status: string }>('/workflows/scan-repos', {});
+export function getScanStatus() {
+  return api.get<ScanStatus>('/workflows/scan-status');
 }
 
 export function listScanActivity(params?: { page?: number; page_size?: number }) {

--- a/frontend/src/pages/Workflows/Workflows.test.tsx
+++ b/frontend/src/pages/Workflows/Workflows.test.tsx
@@ -8,12 +8,12 @@ import { WorkflowsPage } from './index';
 
 const mockListFindings = vi.fn();
 const mockGetScores = vi.fn();
-const mockTriggerRepoScan = vi.fn();
+const mockGetScanStatus = vi.fn();
 
 vi.mock('../../api/workflowScanner', () => ({
   listWorkflowFindings: (...args: unknown[]) => mockListFindings(...args),
   getRepoSecurityScores: (...args: unknown[]) => mockGetScores(...args),
-  triggerRepoScan: (...args: unknown[]) => mockTriggerRepoScan(...args),
+  getScanStatus: (...args: unknown[]) => mockGetScanStatus(...args),
 }));
 
 vi.mock('../../api/workflowMetrics', () => ({
@@ -79,14 +79,26 @@ const SCORES_RESPONSE = [
   },
 ];
 
+const SCAN_STATUS_RESPONSE = {
+  last_scan_at: '2024-06-07T04:00:00Z',
+  last_scan_status: 'completed',
+  total_scans: 42,
+  total_findings: 5,
+  repos_scanned: 3,
+  next_scheduled_scan: 'Runs every 6 hours and on new audit-log events',
+  is_automated: true,
+};
+
 /* ── Tests ─────────────────────────────────────────────────────────── */
 
 describe('WorkflowsPage — Findings Tab', () => {
   beforeEach(() => {
     mockListFindings.mockClear();
     mockGetScores.mockClear();
+    mockGetScanStatus.mockClear();
     mockListFindings.mockResolvedValue(FINDINGS_RESPONSE);
     mockGetScores.mockResolvedValue(SCORES_RESPONSE);
+    mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
   });
 
   it('renders page title', async () => {
@@ -133,8 +145,10 @@ describe('WorkflowsPage — Scores Tab', () => {
   beforeEach(() => {
     mockListFindings.mockClear();
     mockGetScores.mockClear();
+    mockGetScanStatus.mockClear();
     mockListFindings.mockResolvedValue(FINDINGS_RESPONSE);
     mockGetScores.mockResolvedValue(SCORES_RESPONSE);
+    mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
   });
 
   it('switches to scores tab and shows repo scores', async () => {
@@ -167,11 +181,49 @@ describe('WorkflowsPage — Error Handling', () => {
   beforeEach(() => {
     mockListFindings.mockClear();
     mockGetScores.mockClear();
+    mockGetScanStatus.mockClear();
+    mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
   });
 
   it('shows error banner on findings failure', async () => {
     mockListFindings.mockRejectedValue(new Error('Network error'));
     renderWithProviders(<WorkflowsPage />);
     expect(await screen.findByText('Failed to load findings')).toBeInTheDocument();
+  });
+});
+
+describe('WorkflowsPage — Scan Status', () => {
+  beforeEach(() => {
+    mockListFindings.mockClear();
+    mockGetScores.mockClear();
+    mockGetScanStatus.mockClear();
+    mockListFindings.mockResolvedValue(FINDINGS_RESPONSE);
+    mockGetScores.mockResolvedValue(SCORES_RESPONSE);
+  });
+
+  it('displays scan status with last scan time', async () => {
+    mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
+    renderWithProviders(<WorkflowsPage />);
+    expect(await screen.findByText(/3 repos/)).toBeInTheDocument();
+    expect(await screen.findByText(/5 findings/)).toBeInTheDocument();
+  });
+
+  it('shows awaiting message when no scans have run', async () => {
+    mockGetScanStatus.mockResolvedValue({
+      ...SCAN_STATUS_RESPONSE,
+      last_scan_at: null,
+      last_scan_status: null,
+    });
+    renderWithProviders(<WorkflowsPage />);
+    expect(
+      await screen.findByText('Awaiting first scan — data will appear automatically'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders guidance box with automated scanning description', async () => {
+    mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
+    renderWithProviders(<WorkflowsPage />);
+    expect(await screen.findByText(/Fully automated/)).toBeInTheDocument();
+    expect(await screen.findByText(/every 6 hours/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Workflows/index.tsx
+++ b/frontend/src/pages/Workflows/index.tsx
@@ -1,16 +1,15 @@
 import { useState } from 'react';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import {
   listWorkflowFindings,
   getRepoSecurityScores,
-  triggerRepoScan,
+  getScanStatus,
 } from '../../api/workflowScanner';
 import type { WorkflowFinding, RepoSecurityScore } from '../../api/workflowScanner';
 import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { PageHeader } from '../../components/common/PageHeader';
-import { Button } from '../../components/primitives/Button';
 import { Label } from '../../components/primitives/Label';
 import { formatRelativeShort } from '../../utils/dates';
 import { ScannerActivityTab } from './ScannerActivityTab';
@@ -52,20 +51,15 @@ function ScoreCard({ score }: { score: RepoSecurityScore }) {
 }
 
 export function WorkflowsPage() {
-  const queryClient = useQueryClient();
   const [tab, setTab] = useState<Tab>('findings');
   const [sevFilter, setSevFilter] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [selectedFinding, setSelectedFinding] = useState<WorkflowFinding | null>(null);
 
-  const scanMutation = useMutation({
-    mutationFn: triggerRepoScan,
-    onSuccess: () => {
-      // Poll for new data after a delay
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['workflow-scanner'] });
-      }, 5000);
-    },
+  const { data: scanStatus } = useQuery({
+    queryKey: ['workflow-scanner', 'scan-status'],
+    queryFn: () => getScanStatus(),
+    refetchInterval: 60_000,
   });
 
   const {
@@ -82,6 +76,7 @@ export function WorkflowsPage() {
         page_size: 50,
       }),
     enabled: tab === 'findings',
+    refetchInterval: 5 * 60_000,
   });
 
   const {
@@ -93,6 +88,7 @@ export function WorkflowsPage() {
     queryKey: ['workflow-scanner', 'scores'],
     queryFn: () => getRepoSecurityScores(),
     enabled: tab === 'scores',
+    refetchInterval: 5 * 60_000,
   });
 
   return (
@@ -102,23 +98,18 @@ export function WorkflowsPage() {
           <div>
             <PageHeader
               title="Workflow Security Scanner"
-              description="Event-driven workflow security scanning — findings appear automatically as audit log events are ingested"
+              description="Automated workflow security scanning — findings are continuously populated from audit log events and periodic background scans"
               showHelp
             />
           </div>
           <div className={styles.headerActions}>
-            <Button
-              size="sm"
-              variant="primary"
-              onClick={() => scanMutation.mutate()}
-              disabled={scanMutation.isPending}
-            >
-              {scanMutation.isPending ? 'Analyzing…' : 'Analyze Events'}
-            </Button>
-            {scanMutation.isSuccess && (
-              <span className={styles.scanStatus}>Analysis queued — results appear shortly</span>
+            {scanStatus && (
+              <span className={styles.scanStatus}>
+                {scanStatus.last_scan_at
+                  ? `Last scan: ${formatRelativeShort(scanStatus.last_scan_at)} · ${scanStatus.repos_scanned} repos · ${scanStatus.total_findings} findings`
+                  : 'Awaiting first scan — data will appear automatically'}
+              </span>
             )}
-            {scanMutation.isError && <span className={styles.scanError}>Analysis failed</span>}
           </div>
         </div>
 
@@ -133,8 +124,9 @@ export function WorkflowsPage() {
           <div className={styles.guidanceTitle}>How scanning works</div>
           <ul className={styles.guidanceList}>
             <li>
-              <strong>Event-driven</strong> — Workflow audit log events are automatically scanned as
-              they arrive through the HEC ingestion pipeline. No manual action needed.
+              <strong>Fully automated</strong> — Workflow audit log events are scanned as they
+              arrive through the HEC ingestion pipeline, plus a full background scan runs every 6
+              hours.
             </li>
             <li>
               <strong>Findings</strong> — Security issues detected in workflow configurations:
@@ -147,11 +139,11 @@ export function WorkflowsPage() {
             </li>
             <li>
               <strong>Scanner Activity</strong> — View scan history, trigger sources (event-driven
-              vs manual), checks performed, and provenance.
+              vs scheduled), checks performed, and provenance.
             </li>
             <li>
-              Click <strong>Analyze Events</strong> to trigger a batch scan of existing events —
-              this is in addition to the automatic event-driven scanning.
+              <strong>New repos</strong> — Automatically detected as workflow events flow in. No
+              configuration needed.
             </li>
           </ul>
         </div>
@@ -216,9 +208,9 @@ export function WorkflowsPage() {
                 <div className={styles.emptyIcon}>🔍</div>
                 <div className={styles.emptyTitle}>No workflow findings yet</div>
                 <div className={styles.emptyDesc}>
-                  Click <strong>Analyze Events</strong> above to scan workflow audit log events. The
-                  analyzer checks for self-hosted runners, excessive secrets, PR-triggered
-                  workflows, public repo risks, and PAT-triggered automation.
+                  Findings will appear automatically as workflow audit log events are ingested and
+                  analyzed. A background scan also runs every 6 hours to ensure comprehensive
+                  coverage. No action is required.
                 </div>
               </div>
             )}
@@ -282,7 +274,8 @@ export function WorkflowsPage() {
                 <div className={styles.emptyIcon}>📊</div>
                 <div className={styles.emptyTitle}>No repository scores available</div>
                 <div className={styles.emptyDesc}>
-                  Run a scan first to generate security scores for your repositories.
+                  Security scores are computed automatically from findings. Once workflow audit log
+                  events are ingested, scores will appear here for each repository.
                 </div>
               </div>
             )}


### PR DESCRIPTION
## Summary

Removes manual intervention from the Workflow Security page. Data is now collected automatically via a 6-hour Celery beat schedule.

### Changes
- **Backend**: New `/workflows/scan-status` endpoint serving pre-computed data from DB
- **Backend**: Increased scan frequency from daily to every 6 hours in Celery beat
- **Frontend**: Removed manual 'Analyze Events' button, added scan status display with auto-refresh
- **Frontend**: Updated empty state and guidance to explain automatic population

### Tests
- 4 new backend tests (scan status endpoint + Celery schedule)
- 3 new frontend tests (scan status display)

### Validation
- ✅ 2,728 backend tests + 1,630 frontend tests passing
- ✅ All linting clean

Closes #256