### PR TITLE
feat: GitHub Packages monitoring — security posture & operations (#164)

### DIFF
--- a/backend/alembic/versions/0058_add_packages_monitoring.py
+++ b/backend/alembic/versions/0058_add_packages_monitoring.py
@@ -1,0 +1,124 @@
+"""Add packages and package_alerts tables for GitHub Packages monitoring.
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-06-15
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create packages and package_alerts tables."""
+    op.create_table(
+        "packages",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, primary_key=True),
+        sa.Column("org", sa.Text(), nullable=False),
+        sa.Column("repo", sa.Text(), nullable=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("package_type", sa.Text(), nullable=False),
+        sa.Column(
+            "visibility",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'private'"),
+        ),
+        sa.Column("owner", sa.Text(), nullable=True),
+        sa.Column(
+            "versions_count",
+            sa.BigInteger(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("latest_version", sa.Text(), nullable=True),
+        sa.Column("last_published_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "is_stale",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "published_outside_actions",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column(
+            "published_by_external",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.create_index("idx_packages_org", "packages", ["org"])
+    op.create_index("idx_packages_visibility", "packages", ["visibility"])
+    op.create_index("idx_packages_type", "packages", ["package_type"])
+    op.create_index("idx_packages_org_name", "packages", ["org", "name"], unique=True)
+
+    op.create_table(
+        "package_alerts",
+        sa.Column("id", sa.BigInteger(), autoincrement=True, primary_key=True),
+        sa.Column(
+            "package_id",
+            sa.BigInteger(),
+            sa.ForeignKey("packages.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("alert_type", sa.Text(), nullable=False),
+        sa.Column("severity", sa.Text(), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column(
+            "detected_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'open'"),
+        ),
+    )
+    op.create_index("idx_package_alerts_package_id", "package_alerts", ["package_id"])
+    op.create_index("idx_package_alerts_status", "package_alerts", ["status"])
+    op.create_index("idx_package_alerts_severity", "package_alerts", ["severity"])
+    op.create_index("idx_package_alerts_type", "package_alerts", ["alert_type"])
+
+
+def downgrade() -> None:
+    """Drop package_alerts and packages tables."""
+    op.drop_index("idx_package_alerts_type", table_name="package_alerts")
+    op.drop_index("idx_package_alerts_severity", table_name="package_alerts")
+    op.drop_index("idx_package_alerts_status", table_name="package_alerts")
+    op.drop_index("idx_package_alerts_package_id", table_name="package_alerts")
+    op.drop_table("package_alerts")
+
+    op.drop_index("idx_packages_org_name", table_name="packages")
+    op.drop_index("idx_packages_type", table_name="packages")
+    op.drop_index("idx_packages_visibility", table_name="packages")
+    op.drop_index("idx_packages_org", table_name="packages")
+    op.drop_table("packages")

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -48,6 +48,7 @@ app.config_from_object(
             "app.workers.ingestion_health.*": {"queue": "baseline"},
             "app.workers.github_ip_allowlist_worker.*": {"queue": "baseline"},
             "app.workers.workflow_scan_worker.*": {"queue": "baseline"},
+            "app.workers.package_sync_worker.*": {"queue": "github_sync"},
         },
         # ─── Soft / hard time limits ─────────────────────────────────────────
         "task_soft_time_limit": 1800,  # 30 minutes
@@ -108,6 +109,12 @@ app.config_from_object(
                 "schedule": crontab(minute=0, hour="*/6"),
                 "options": {"queue": "baseline"},
             },
+            # Package monitoring sync — every 6 hours
+            "sync-packages": {
+                "task": "app.workers.package_sync_worker.sync_packages",
+                "schedule": crontab(minute=30, hour="*/6"),
+                "options": {"queue": "github_sync"},
+            },
             # Threat intel feed refresh — every 30 minutes
             "refresh-threat-intel-feeds": {
                 "task": "app.workers.threat_intel_worker.refresh_threat_intel_feeds",
@@ -155,6 +162,7 @@ app.conf.include = [
     "app.workers.ingestion_health",
     "app.workers.threat_intel_worker",
     "app.workers.workflow_scan_worker",
+    "app.workers.package_sync_worker",
 ]
 
 # Conditionally add GitHub sync heartbeat to beat schedule

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -51,6 +51,7 @@ from app.routers import (
     maintenance,
     notifications,
     org_config,
+    packages,
     pagerduty,
     playbooks,
     posture,
@@ -721,6 +722,7 @@ def create_app() -> FastAPI:
     app.include_router(setup.router, prefix=API_PREFIX)
     app.include_router(suggestions.router, prefix=API_PREFIX)
     app.include_router(supply_chain.router, prefix=API_PREFIX)
+    app.include_router(packages.router, prefix=API_PREFIX)
     app.include_router(teams.router, prefix=API_PREFIX)
     app.include_router(dev_activity.router, prefix=API_PREFIX)
     app.include_router(threat_intel.router, prefix=API_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -51,6 +51,7 @@ from app.models.integration import (
 )
 from app.models.notification import Notification, NotificationPreference
 from app.models.org_config import OrgConfig
+from app.models.package import Package, PackageAlert
 from app.models.playbook import PlaybookExecution, PlaybookTemplate
 from app.models.query_template import QueryTemplate
 from app.models.report_schedule import ReportSchedule
@@ -103,6 +104,8 @@ __all__ = [
     "OrgCodeScanningAlertSummary",
     "OrgConfig",
     "OrgDependabotAlertSummary",
+    "Package",
+    "PackageAlert",
     "OrgMember",
     "OrgOutsideCollaborator",
     "OrgSecretScanningAlertSummary",

--- a/backend/app/models/package.py
+++ b/backend/app/models/package.py
@@ -1,0 +1,75 @@
+"""SQLAlchemy ORM models for GitHub Packages monitoring."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, Boolean, DateTime, ForeignKey, Index, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.audit_event import Base
+
+
+class Package(Base):
+    """A GitHub Package tracked for security and operations monitoring."""
+
+    __tablename__ = "packages"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    org: Mapped[str] = mapped_column(Text, nullable=False)
+    repo: Mapped[str | None] = mapped_column(Text)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    package_type: Mapped[str] = mapped_column(Text, nullable=False)
+    visibility: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'private'"))
+    owner: Mapped[str | None] = mapped_column(Text)
+    versions_count: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, server_default=text("0")
+    )
+    latest_version: Mapped[str | None] = mapped_column(Text)
+    last_published_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    is_stale: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    published_outside_actions: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+    published_by_external: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("false")
+    )
+
+    __table_args__ = (
+        Index("idx_packages_org", "org"),
+        Index("idx_packages_visibility", "visibility"),
+        Index("idx_packages_type", "package_type"),
+        Index("idx_packages_org_name", "org", "name", unique=True),
+    )
+
+
+class PackageAlert(Base):
+    """A security alert generated from package monitoring analysis."""
+
+    __tablename__ = "package_alerts"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    package_id: Mapped[int] = mapped_column(
+        BigInteger, ForeignKey("packages.id", ondelete="CASCADE"), nullable=False
+    )
+    alert_type: Mapped[str] = mapped_column(Text, nullable=False)
+    severity: Mapped[str] = mapped_column(Text, nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    detected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'open'"))
+
+    __table_args__ = (
+        Index("idx_package_alerts_package_id", "package_id"),
+        Index("idx_package_alerts_status", "status"),
+        Index("idx_package_alerts_severity", "severity"),
+        Index("idx_package_alerts_type", "alert_type"),
+    )

--- a/backend/app/routers/packages.py
+++ b/backend/app/routers/packages.py
@@ -1,0 +1,274 @@
+"""GitHub Packages monitoring router: security posture and operations visibility.
+
+Endpoints expose package inventory, security alerts, summary dashboards,
+and stale container image detection. All endpoints enforce RBAC via
+``require_permission`` and scope results to the caller's orgs.
+"""
+
+from __future__ import annotations
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import AuthenticatedUser, get_db, require_permission
+from app.services import package_monitoring_service as svc
+from app.services import rbac_service
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/packages", tags=["packages"])
+
+
+# ── RBAC helper ──────────────────────────────────────────────────────────────
+
+
+async def _resolve_orgs(
+    db: AsyncSession,
+    current_user: AuthenticatedUser,
+) -> list[str]:
+    """Resolve RBAC-scoped orgs and raise 403 when the list is empty."""
+    scoped_orgs = await rbac_service.get_scoped_orgs(db, current_user)
+    if not scoped_orgs and current_user.scope_type != "global":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No org access",
+        )
+    return scoped_orgs
+
+
+# ── Response schemas ─────────────────────────────────────────────────────────
+
+
+class PackageSummaryResponse(BaseModel):
+    """Dashboard summary of packages monitoring."""
+
+    total_packages: int
+    public_packages: int
+    private_packages: int
+    by_type: dict[str, int] = Field(default_factory=dict)
+    newly_public: int = 0
+    stale_images: int = 0
+    open_alerts: int = 0
+
+
+class PackageAlertResponse(BaseModel):
+    """A single package security alert."""
+
+    id: int
+    package_id: int
+    package_name: str
+    package_org: str
+    alert_type: str
+    severity: str
+    message: str
+    detected_at: str
+    resolved_at: str | None
+    status: str
+
+
+class PackageAlertListResponse(BaseModel):
+    """Paginated list of package alerts."""
+
+    alerts: list[PackageAlertResponse]
+    total: int
+
+
+class PackageInventoryItemResponse(BaseModel):
+    """A single package in the inventory."""
+
+    id: int
+    org: str
+    repo: str | None
+    name: str
+    package_type: str
+    visibility: str
+    owner: str | None
+    versions_count: int
+    latest_version: str | None
+    last_published_at: str | None
+    is_stale: bool
+    published_outside_actions: bool
+    published_by_external: bool
+
+
+class PackageInventoryResponse(BaseModel):
+    """Paginated package inventory."""
+
+    items: list[PackageInventoryItemResponse]
+    total: int
+    page: int
+    page_size: int
+
+
+class StaleImageResponse(BaseModel):
+    """A stale container image."""
+
+    id: int
+    org: str
+    repo: str | None
+    name: str
+    last_published_at: str | None
+    days_since_rebuild: int
+    owner: str | None
+
+
+class StaleImageListResponse(BaseModel):
+    """List of stale container images."""
+
+    images: list[StaleImageResponse]
+    total: int
+    threshold_days: int
+
+
+# ── Endpoints ────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/summary",
+    response_model=PackageSummaryResponse,
+    summary="Package monitoring summary",
+    description="Dashboard summary: totals, public/private breakdown, alerts.",
+)
+async def get_summary(
+    current_user: AuthenticatedUser = Depends(require_permission("detections", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> PackageSummaryResponse:
+    """Return the aggregate package monitoring summary."""
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    summary = await svc.get_packages_summary(db, scoped_orgs)
+    return PackageSummaryResponse(
+        total_packages=summary.total_packages,
+        public_packages=summary.public_packages,
+        private_packages=summary.private_packages,
+        by_type=summary.by_type,
+        newly_public=summary.newly_public,
+        stale_images=summary.stale_images,
+        open_alerts=summary.open_alerts,
+    )
+
+
+@router.get(
+    "/alerts",
+    response_model=PackageAlertListResponse,
+    summary="Package security alerts",
+    description="Filtered, paginated security alerts from package monitoring.",
+)
+async def get_alerts(
+    alert_status: str | None = Query(None, alias="status", description="open or resolved"),
+    severity: str | None = Query(None, description="high, medium, or low"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    current_user: AuthenticatedUser = Depends(require_permission("detections", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> PackageAlertListResponse:
+    """Return filtered, paginated package security alerts."""
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    result = await svc.get_package_alerts(
+        db,
+        scoped_orgs,
+        alert_status=alert_status,
+        severity=severity,
+        page=page,
+        page_size=page_size,
+    )
+    return PackageAlertListResponse(
+        alerts=[
+            PackageAlertResponse(
+                id=a.id,
+                package_id=a.package_id,
+                package_name=a.package_name,
+                package_org=a.package_org,
+                alert_type=a.alert_type,
+                severity=a.severity,
+                message=a.message,
+                detected_at=a.detected_at,
+                resolved_at=a.resolved_at,
+                status=a.status,
+            )
+            for a in result.alerts
+        ],
+        total=result.total,
+    )
+
+
+@router.get(
+    "/inventory",
+    response_model=PackageInventoryResponse,
+    summary="Package inventory",
+    description="Paginated inventory of all packages with optional type/visibility filters.",
+)
+async def get_inventory(
+    package_type: str | None = Query(None, alias="type", description="npm, maven, docker, etc."),
+    visibility: str | None = Query(None, description="public or private"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    current_user: AuthenticatedUser = Depends(require_permission("detections", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> PackageInventoryResponse:
+    """Return the full paginated package inventory."""
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    result = await svc.get_package_inventory(
+        db,
+        scoped_orgs,
+        package_type=package_type,
+        visibility=visibility,
+        page=page,
+        page_size=page_size,
+    )
+    return PackageInventoryResponse(
+        items=[
+            PackageInventoryItemResponse(
+                id=item.id,
+                org=item.org,
+                repo=item.repo,
+                name=item.name,
+                package_type=item.package_type,
+                visibility=item.visibility,
+                owner=item.owner,
+                versions_count=item.versions_count,
+                latest_version=item.latest_version,
+                last_published_at=item.last_published_at,
+                is_stale=item.is_stale,
+                published_outside_actions=item.published_outside_actions,
+                published_by_external=item.published_by_external,
+            )
+            for item in result.items
+        ],
+        total=result.total,
+        page=result.page,
+        page_size=result.page_size,
+    )
+
+
+@router.get(
+    "/stale-images",
+    response_model=StaleImageListResponse,
+    summary="Stale container images",
+    description="Container images not rebuilt within the configured threshold.",
+)
+async def get_stale_images(
+    days: int = Query(90, ge=1, le=365, description="Days threshold for staleness"),
+    current_user: AuthenticatedUser = Depends(require_permission("detections", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> StaleImageListResponse:
+    """Return container images not rebuilt within the threshold."""
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    result = await svc.get_stale_images(db, scoped_orgs, days_threshold=days)
+    return StaleImageListResponse(
+        images=[
+            StaleImageResponse(
+                id=img.id,
+                org=img.org,
+                repo=img.repo,
+                name=img.name,
+                last_published_at=img.last_published_at,
+                days_since_rebuild=img.days_since_rebuild,
+                owner=img.owner,
+            )
+            for img in result.images
+        ],
+        total=result.total,
+        threshold_days=result.threshold_days,
+    )

--- a/backend/app/services/package_monitoring_service.py
+++ b/backend/app/services/package_monitoring_service.py
@@ -1,0 +1,391 @@
+"""Package monitoring service.
+
+Provides summary, alerts, inventory, and stale image queries for GitHub
+Packages security and operations monitoring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger(__name__)
+
+
+# ── Data classes ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class PackageSummary:
+    """Dashboard-level summary of package monitoring."""
+
+    total_packages: int
+    public_packages: int
+    private_packages: int
+    by_type: dict[str, int] = field(default_factory=dict)
+    newly_public: int = 0
+    stale_images: int = 0
+    open_alerts: int = 0
+
+
+@dataclass
+class PackageAlertRecord:
+    """A single package security alert."""
+
+    id: int
+    package_id: int
+    package_name: str
+    package_org: str
+    alert_type: str
+    severity: str
+    message: str
+    detected_at: str
+    resolved_at: str | None
+    status: str
+
+
+@dataclass
+class PackageAlertList:
+    """Paginated list of package alerts."""
+
+    alerts: list[PackageAlertRecord] = field(default_factory=list)
+    total: int = 0
+
+
+@dataclass
+class PackageInventoryItem:
+    """A single package in the inventory view."""
+
+    id: int
+    org: str
+    repo: str | None
+    name: str
+    package_type: str
+    visibility: str
+    owner: str | None
+    versions_count: int
+    latest_version: str | None
+    last_published_at: str | None
+    is_stale: bool
+    published_outside_actions: bool
+    published_by_external: bool
+
+
+@dataclass
+class PackageInventory:
+    """Paginated package inventory."""
+
+    items: list[PackageInventoryItem] = field(default_factory=list)
+    total: int = 0
+    page: int = 1
+    page_size: int = 50
+
+
+@dataclass
+class StaleImageRecord:
+    """A stale container image."""
+
+    id: int
+    org: str
+    repo: str | None
+    name: str
+    last_published_at: str | None
+    days_since_rebuild: int
+    owner: str | None
+
+
+@dataclass
+class StaleImageList:
+    """List of stale container images."""
+
+    images: list[StaleImageRecord] = field(default_factory=list)
+    total: int = 0
+    threshold_days: int = 90
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _org_filter(
+    scoped_orgs: list[str],
+    *,
+    table_alias: str = "p",
+) -> tuple[str, dict[str, Any]]:
+    """Build an org-scoping SQL fragment and parameter dict."""
+    if not scoped_orgs:
+        return "", {}
+    placeholders = ", ".join(f":org_{i}" for i in range(len(scoped_orgs)))
+    params = {f"org_{i}": org for i, org in enumerate(scoped_orgs)}
+    return f"AND {table_alias}.org IN ({placeholders})", params
+
+
+# ── Service functions ────────────────────────────────────────────────────────
+
+
+async def get_packages_summary(
+    session: AsyncSession,
+    scoped_orgs: list[str],
+) -> PackageSummary:
+    """Return dashboard-level summary of packages for scoped orgs."""
+    org_filter, params = _org_filter(scoped_orgs)
+
+    # Total packages
+    total_q = await session.execute(
+        text(f"SELECT count(*) FROM packages p WHERE 1=1 {org_filter}"),
+        params,
+    )
+    total = total_q.scalar() or 0
+
+    # Public vs private
+    vis_q = await session.execute(
+        text(
+            f"SELECT visibility, count(*) as cnt FROM packages p "
+            f"WHERE 1=1 {org_filter} GROUP BY visibility"
+        ),
+        params,
+    )
+    vis_counts: dict[str, int] = {row.visibility: row.cnt for row in vis_q.fetchall()}
+    public_count = vis_counts.get("public", 0)
+    private_count = vis_counts.get("private", 0)
+
+    # By type
+    type_q = await session.execute(
+        text(
+            f"SELECT package_type, count(*) as cnt FROM packages p "
+            f"WHERE 1=1 {org_filter} GROUP BY package_type"
+        ),
+        params,
+    )
+    by_type: dict[str, int] = {row.package_type: row.cnt for row in type_q.fetchall()}
+
+    # Newly public (changed to public in last 7 days based on alerts)
+    newly_q = await session.execute(
+        text(
+            "SELECT count(*) FROM package_alerts a "
+            "JOIN packages p ON a.package_id = p.id "
+            f"WHERE a.alert_type = 'public_exposure' AND a.status = 'open' "
+            f"AND a.detected_at >= NOW() - INTERVAL '7 days' {org_filter}"
+        ),
+        params,
+    )
+    newly_public = newly_q.scalar() or 0
+
+    # Stale images count
+    stale_q = await session.execute(
+        text(
+            f"SELECT count(*) FROM packages p "
+            f"WHERE p.is_stale = true AND p.package_type = 'container' {org_filter}"
+        ),
+        params,
+    )
+    stale_count = stale_q.scalar() or 0
+
+    # Open alerts count
+    alerts_q = await session.execute(
+        text(
+            "SELECT count(*) FROM package_alerts a "
+            f"JOIN packages p ON a.package_id = p.id WHERE a.status = 'open' {org_filter}"
+        ),
+        params,
+    )
+    open_alerts = alerts_q.scalar() or 0
+
+    return PackageSummary(
+        total_packages=total,
+        public_packages=public_count,
+        private_packages=private_count,
+        by_type=by_type,
+        newly_public=newly_public,
+        stale_images=stale_count,
+        open_alerts=open_alerts,
+    )
+
+
+async def get_package_alerts(
+    session: AsyncSession,
+    scoped_orgs: list[str],
+    *,
+    alert_status: str | None = None,
+    severity: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> PackageAlertList:
+    """Return filtered, paginated package security alerts."""
+    org_filter, params = _org_filter(scoped_orgs)
+
+    where_clauses = f"WHERE 1=1 {org_filter}"
+    if alert_status:
+        where_clauses += " AND a.status = :alert_status"
+        params["alert_status"] = alert_status
+    if severity:
+        where_clauses += " AND a.severity = :severity"
+        params["severity"] = severity
+
+    # Count
+    count_q = await session.execute(
+        text(
+            f"SELECT count(*) FROM package_alerts a "
+            f"JOIN packages p ON a.package_id = p.id {where_clauses}"
+        ),
+        params,
+    )
+    total = count_q.scalar() or 0
+
+    # Fetch page
+    offset = (page - 1) * page_size
+    params["limit"] = page_size
+    params["offset"] = offset
+
+    rows_q = await session.execute(
+        text(
+            f"SELECT a.id, a.package_id, p.name as package_name, p.org as package_org, "
+            f"a.alert_type, a.severity, a.message, a.detected_at, a.resolved_at, a.status "
+            f"FROM package_alerts a "
+            f"JOIN packages p ON a.package_id = p.id {where_clauses} "
+            f"ORDER BY a.detected_at DESC LIMIT :limit OFFSET :offset"
+        ),
+        params,
+    )
+    rows = rows_q.fetchall()
+
+    alerts = [
+        PackageAlertRecord(
+            id=row.id,
+            package_id=row.package_id,
+            package_name=row.package_name,
+            package_org=row.package_org,
+            alert_type=row.alert_type,
+            severity=row.severity,
+            message=row.message,
+            detected_at=row.detected_at.isoformat() if row.detected_at else "",
+            resolved_at=row.resolved_at.isoformat() if row.resolved_at else None,
+            status=row.status,
+        )
+        for row in rows
+    ]
+
+    return PackageAlertList(alerts=alerts, total=total)
+
+
+async def get_package_inventory(
+    session: AsyncSession,
+    scoped_orgs: list[str],
+    *,
+    package_type: str | None = None,
+    visibility: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> PackageInventory:
+    """Return paginated inventory of packages with optional filters."""
+    org_filter, params = _org_filter(scoped_orgs)
+
+    where_clauses = f"WHERE 1=1 {org_filter}"
+    if package_type:
+        where_clauses += " AND p.package_type = :package_type"
+        params["package_type"] = package_type
+    if visibility:
+        where_clauses += " AND p.visibility = :visibility"
+        params["visibility"] = visibility
+
+    # Count
+    count_q = await session.execute(
+        text(f"SELECT count(*) FROM packages p {where_clauses}"),
+        params,
+    )
+    total = count_q.scalar() or 0
+
+    # Fetch page
+    offset = (page - 1) * page_size
+    params["limit"] = page_size
+    params["offset"] = offset
+
+    rows_q = await session.execute(
+        text(
+            f"SELECT p.id, p.org, p.repo, p.name, p.package_type, p.visibility, "
+            f"p.owner, p.versions_count, p.latest_version, p.last_published_at, "
+            f"p.is_stale, p.published_outside_actions, p.published_by_external "
+            f"FROM packages p {where_clauses} "
+            f"ORDER BY p.updated_at DESC LIMIT :limit OFFSET :offset"
+        ),
+        params,
+    )
+    rows = rows_q.fetchall()
+
+    items = [
+        PackageInventoryItem(
+            id=row.id,
+            org=row.org,
+            repo=row.repo,
+            name=row.name,
+            package_type=row.package_type,
+            visibility=row.visibility,
+            owner=row.owner,
+            versions_count=row.versions_count,
+            latest_version=row.latest_version,
+            last_published_at=row.last_published_at.isoformat() if row.last_published_at else None,
+            is_stale=row.is_stale,
+            published_outside_actions=row.published_outside_actions,
+            published_by_external=row.published_by_external,
+        )
+        for row in rows
+    ]
+
+    return PackageInventory(items=items, total=total, page=page, page_size=page_size)
+
+
+async def get_stale_images(
+    session: AsyncSession,
+    scoped_orgs: list[str],
+    *,
+    days_threshold: int = 90,
+) -> StaleImageList:
+    """Return container images not rebuilt within the threshold days."""
+    org_filter, params = _org_filter(scoped_orgs)
+    params["threshold_days"] = days_threshold
+
+    count_q = await session.execute(
+        text(
+            f"SELECT count(*) FROM packages p "
+            f"WHERE p.package_type = 'container' "
+            f"AND (p.last_published_at IS NULL OR "
+            f"    p.last_published_at < NOW() - INTERVAL '1 day' * :threshold_days) "
+            f"{org_filter}"
+        ),
+        params,
+    )
+    total = count_q.scalar() or 0
+
+    rows_q = await session.execute(
+        text(
+            f"SELECT p.id, p.org, p.repo, p.name, p.last_published_at, p.owner, "
+            f"COALESCE(EXTRACT(EPOCH FROM (NOW() - p.last_published_at)) / 86400, 9999)::int "
+            f"  as days_since "
+            f"FROM packages p "
+            f"WHERE p.package_type = 'container' "
+            f"AND (p.last_published_at IS NULL OR "
+            f"    p.last_published_at < NOW() - INTERVAL '1 day' * :threshold_days) "
+            f"{org_filter} "
+            f"ORDER BY days_since DESC"
+        ),
+        params,
+    )
+    rows = rows_q.fetchall()
+
+    images = [
+        StaleImageRecord(
+            id=row.id,
+            org=row.org,
+            repo=row.repo,
+            name=row.name,
+            last_published_at=row.last_published_at.isoformat() if row.last_published_at else None,
+            days_since_rebuild=row.days_since,
+            owner=row.owner,
+        )
+        for row in rows
+    ]
+
+    return StaleImageList(images=images, total=total, threshold_days=days_threshold)

--- a/backend/app/workers/package_sync_worker.py
+++ b/backend/app/workers/package_sync_worker.py
@@ -1,0 +1,506 @@
+"""Background worker for GitHub Packages monitoring sync.
+
+Queue: github_sync
+
+Periodically syncs package data from the GitHub API (REST) for all
+configured orgs, stores results in the ``packages`` table, computes
+staleness flags, and generates security alerts when risk conditions are met.
+
+Runs every 6 hours via Celery beat.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+
+import structlog
+from celery import Task
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.celery_app import celery_app
+
+logger = structlog.get_logger(__name__)
+
+
+def _make_session_factory() -> async_sessionmaker[AsyncSession]:
+    from app.config import settings
+
+    engine = create_async_engine(settings.DATABASE_URL, poolclass=NullPool)
+    return async_sessionmaker(
+        bind=engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+        autoflush=False,
+        autocommit=False,
+    )
+
+
+# ── Alert generation helpers ─────────────────────────────────────────────────
+
+_STALE_THRESHOLD_DAYS = 90
+
+_EXPECTED_REGISTRY_TYPES = frozenset(
+    {
+        "npm",
+        "maven",
+        "docker",
+        "container",
+        "nuget",
+        "rubygems",
+    }
+)
+
+
+async def _generate_alerts(session: AsyncSession) -> int:
+    """Scan the packages table and create alerts for risk conditions.
+
+    Returns the number of new alerts created.
+    """
+    created = 0
+
+    # 1. Public exposure alerts — packages with visibility=public that have no open alert
+    public_q = await session.execute(
+        text(
+            "SELECT p.id, p.org, p.name FROM packages p "
+            "WHERE p.visibility = 'public' "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM package_alerts a "
+            "  WHERE a.package_id = p.id AND a.alert_type = 'public_exposure' "
+            "  AND a.status = 'open'"
+            ")"
+        )
+    )
+    for row in public_q.fetchall():
+        await session.execute(
+            text(
+                "INSERT INTO package_alerts (package_id, alert_type, severity, message) "
+                "VALUES (:pkg_id, 'public_exposure', 'medium', :msg)"
+            ),
+            {
+                "pkg_id": row.id,
+                "msg": f"Package '{row.name}' in org '{row.org}' has public visibility",
+            },
+        )
+        created += 1
+
+    # 2. Stale image alerts
+    stale_q = await session.execute(
+        text(
+            "SELECT p.id, p.org, p.name FROM packages p "
+            "WHERE p.is_stale = true AND p.package_type = 'container' "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM package_alerts a "
+            "  WHERE a.package_id = p.id AND a.alert_type = 'stale_image' "
+            "  AND a.status = 'open'"
+            ")"
+        )
+    )
+    for row in stale_q.fetchall():
+        await session.execute(
+            text(
+                "INSERT INTO package_alerts (package_id, alert_type, severity, message) "
+                "VALUES (:pkg_id, 'stale_image', 'medium', :msg)"
+            ),
+            {
+                "pkg_id": row.id,
+                "msg": (
+                    f"Container image '{row.name}' in org '{row.org}' "
+                    f"has not been rebuilt in over {_STALE_THRESHOLD_DAYS} days"
+                ),
+            },
+        )
+        created += 1
+
+    # 3. External publisher alerts
+    ext_q = await session.execute(
+        text(
+            "SELECT p.id, p.org, p.name FROM packages p "
+            "WHERE p.published_by_external = true "
+            "AND NOT EXISTS ("
+            "  SELECT 1 FROM package_alerts a "
+            "  WHERE a.package_id = p.id AND a.alert_type = 'external_publisher' "
+            "  AND a.status = 'open'"
+            ")"
+        )
+    )
+    for row in ext_q.fetchall():
+        await session.execute(
+            text(
+                "INSERT INTO package_alerts (package_id, alert_type, severity, message) "
+                "VALUES (:pkg_id, 'external_publisher', 'high', :msg)"
+            ),
+            {
+                "pkg_id": row.id,
+                "msg": (
+                    f"Package '{row.name}' in org '{row.org}' "
+                    f"was published by a non-org-member (external collaborator)"
+                ),
+            },
+        )
+        created += 1
+
+    # 4. Unexpected registry type alerts
+    unreg_q = await session.execute(
+        text(
+            "SELECT p.id, p.org, p.name, p.package_type FROM packages p "
+            "WHERE NOT EXISTS ("
+            "  SELECT 1 FROM package_alerts a "
+            "  WHERE a.package_id = p.id AND a.alert_type = 'unexpected_registry' "
+            "  AND a.status = 'open'"
+            ")"
+        )
+    )
+    for row in unreg_q.fetchall():
+        if row.package_type not in _EXPECTED_REGISTRY_TYPES:
+            await session.execute(
+                text(
+                    "INSERT INTO package_alerts "
+                    "(package_id, alert_type, severity, message) "
+                    "VALUES (:pkg_id, 'unexpected_registry', 'medium', :msg)"
+                ),
+                {
+                    "pkg_id": row.id,
+                    "msg": (
+                        f"Package '{row.name}' in org '{row.org}' uses "
+                        f"unexpected registry type '{row.package_type}'"
+                    ),
+                },
+            )
+            created += 1
+
+    # 5. Auto-resolve alerts where the condition is no longer true
+    await session.execute(
+        text(
+            "UPDATE package_alerts SET status = 'resolved', resolved_at = NOW() "
+            "WHERE alert_type = 'public_exposure' AND status = 'open' "
+            "AND package_id IN ("
+            "  SELECT id FROM packages WHERE visibility != 'public'"
+            ")"
+        )
+    )
+    await session.execute(
+        text(
+            "UPDATE package_alerts SET status = 'resolved', resolved_at = NOW() "
+            "WHERE alert_type = 'stale_image' AND status = 'open' "
+            "AND package_id IN ("
+            "  SELECT id FROM packages WHERE is_stale = false"
+            ")"
+        )
+    )
+
+    return created
+
+
+async def _update_staleness_flags(session: AsyncSession) -> int:
+    """Mark container images as stale if not rebuilt within threshold days.
+
+    Returns the number of packages updated.
+    """
+    result = await session.execute(
+        text(
+            "UPDATE packages SET is_stale = true, updated_at = NOW() "
+            "WHERE package_type = 'container' "
+            "AND is_stale = false "
+            "AND (last_published_at IS NULL "
+            "     OR last_published_at < NOW() - INTERVAL '1 day' * :threshold)"
+        ),
+        {"threshold": _STALE_THRESHOLD_DAYS},
+    )
+    stale_count = result.rowcount or 0
+
+    # Un-stale packages that were recently rebuilt
+    result2 = await session.execute(
+        text(
+            "UPDATE packages SET is_stale = false, updated_at = NOW() "
+            "WHERE package_type = 'container' "
+            "AND is_stale = true "
+            "AND last_published_at IS NOT NULL "
+            "AND last_published_at >= NOW() - INTERVAL '1 day' * :threshold"
+        ),
+        {"threshold": _STALE_THRESHOLD_DAYS},
+    )
+    unstale_count = result2.rowcount or 0
+
+    return stale_count + unstale_count
+
+
+async def _sync_packages_for_org(session: AsyncSession, org: str) -> int:
+    """Sync packages for a single org from GitHub API.
+
+    Uses the REST API: GET /orgs/{org}/packages for each package type.
+    Returns the number of packages upserted.
+
+    Note: Requires a valid GitHub token configured in the app. If no GitHub
+    App config is found, the sync is skipped gracefully.
+    """
+    try:
+        from app.services.github_token_service import GitHubAppTokenManager
+    except ImportError:
+        logger.warning("package_sync.github_token_service_unavailable")
+        return 0
+
+    # Look up GitHub App installation for this org
+    install_q = await session.execute(
+        text(
+            "SELECT i.installation_id, c.app_id, c.private_key "
+            "FROM github_app_installations i "
+            "JOIN github_app_configs c ON i.app_config_id = c.id "
+            "WHERE i.target_type = 'Organization' AND i.account_login = :org "
+            "ORDER BY i.installed_at DESC LIMIT 1"
+        ),
+        {"org": org},
+    )
+    install_row = install_q.fetchone()
+    if not install_row:
+        logger.info("package_sync.no_installation", org=org)
+        return 0
+
+    try:
+        token_manager = GitHubAppTokenManager(
+            app_id=install_row.app_id,
+            private_key_pem=install_row.private_key,
+        )
+        token = await token_manager.get_installation_token(
+            install_row.installation_id,
+        )
+    except Exception as exc:
+        logger.warning("package_sync.token_error", org=org, error=str(exc))
+        return 0
+
+    import httpx
+
+    upserted = 0
+    package_types = ["npm", "maven", "docker", "container", "nuget", "rubygems"]
+
+    async with httpx.AsyncClient(
+        base_url="https://api.github.com",
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        timeout=30.0,
+    ) as client:
+        for pkg_type in package_types:
+            page = 1
+            while True:
+                resp = await client.get(
+                    f"/orgs/{org}/packages",
+                    params={"package_type": pkg_type, "per_page": 100, "page": page},
+                )
+                if resp.status_code == 404:
+                    break
+                if resp.status_code == 403:
+                    logger.warning(
+                        "package_sync.forbidden",
+                        org=org,
+                        package_type=pkg_type,
+                    )
+                    break
+                resp.raise_for_status()
+                packages = resp.json()
+                if not packages:
+                    break
+
+                for pkg in packages:
+                    pkg_name = pkg.get("name", "")
+                    visibility = pkg.get("visibility", "private")
+                    owner_login = pkg.get("owner", {}).get("login", "")
+                    repo_name = (
+                        pkg.get("repository", {}).get("full_name")
+                        if pkg.get("repository")
+                        else None
+                    )
+
+                    # Fetch version count
+                    versions_count = 0
+                    latest_version = None
+                    last_published = None
+                    try:
+                        ver_resp = await client.get(
+                            f"/orgs/{org}/packages/{pkg_type}/{pkg_name}/versions",
+                            params={"per_page": 1},
+                        )
+                        if ver_resp.status_code == 200:
+                            versions = ver_resp.json()
+                            if versions:
+                                latest_version = versions[0].get("name")
+                                last_published = versions[0].get("updated_at")
+
+                        # Get total version count from the link header or a separate call
+                        count_resp = await client.get(
+                            f"/orgs/{org}/packages/{pkg_type}/{pkg_name}/versions",
+                            params={"per_page": 1, "page": 1},
+                        )
+                        if count_resp.status_code == 200:
+                            # Parse link header for total
+                            link = count_resp.headers.get("link", "")
+                            if 'rel="last"' in link:
+                                import re
+
+                                match = re.search(r"page=(\d+)>; rel=\"last\"", link)
+                                if match:
+                                    versions_count = int(match.group(1))
+                            else:
+                                versions_count = len(count_resp.json())
+                    except Exception as ver_exc:
+                        logger.debug(
+                            "package_sync.version_fetch_error",
+                            org=org,
+                            package=pkg_name,
+                            error=str(ver_exc),
+                        )
+
+                    # Check if published outside GitHub Actions
+                    published_outside = False
+                    # Check last version metadata for source
+                    try:
+                        if latest_version:
+                            meta_resp = await client.get(
+                                f"/orgs/{org}/packages/{pkg_type}/{pkg_name}/versions",
+                                params={"per_page": 1},
+                            )
+                            if meta_resp.status_code == 200:
+                                meta = meta_resp.json()
+                                if meta:
+                                    metadata = meta[0].get("metadata", {})
+                                    container_meta = metadata.get("container", {})
+                                    # If no workflow ref in metadata, manual push
+                                    is_container = pkg_type in (
+                                        "docker",
+                                        "container",
+                                    )
+                                    no_pkg_type = not container_meta.get("package_type")
+                                    if is_container and no_pkg_type:
+                                        published_outside = True
+                    except Exception as meta_exc:
+                        logger.debug(
+                            "package_sync.metadata_check_error",
+                            package=pkg_name,
+                            error=str(meta_exc),
+                        )
+
+                    # Check if publisher is external collaborator
+                    published_by_ext = False
+                    if owner_login and owner_login != org:
+                        member_q = await session.execute(
+                            text("SELECT 1 FROM org_members WHERE org = :org AND login = :login"),
+                            {"org": org, "login": owner_login},
+                        )
+                        if not member_q.fetchone():
+                            published_by_ext = True
+
+                    # Upsert the package
+                    now = datetime.now(UTC)
+                    await session.execute(
+                        text(
+                            "INSERT INTO packages "
+                            "(org, repo, name, package_type, visibility, owner, "
+                            " versions_count, latest_version, last_published_at, "
+                            " published_outside_actions, published_by_external, updated_at) "
+                            "VALUES (:org, :repo, :name, :pkg_type, :vis, :owner, "
+                            " :ver_count, :latest_ver, :last_pub, "
+                            " :pub_outside, :pub_ext, :now) "
+                            "ON CONFLICT (org, name) DO UPDATE SET "
+                            " repo = EXCLUDED.repo, "
+                            " package_type = EXCLUDED.package_type, "
+                            " visibility = EXCLUDED.visibility, "
+                            " owner = EXCLUDED.owner, "
+                            " versions_count = EXCLUDED.versions_count, "
+                            " latest_version = EXCLUDED.latest_version, "
+                            " last_published_at = EXCLUDED.last_published_at, "
+                            " published_outside_actions = EXCLUDED.published_outside_actions, "
+                            " published_by_external = EXCLUDED.published_by_external, "
+                            " updated_at = EXCLUDED.updated_at"
+                        ),
+                        {
+                            "org": org,
+                            "repo": repo_name,
+                            "name": pkg_name,
+                            "pkg_type": pkg_type,
+                            "vis": visibility,
+                            "owner": owner_login or None,
+                            "ver_count": versions_count,
+                            "latest_ver": latest_version,
+                            "last_pub": last_published,
+                            "pub_outside": published_outside,
+                            "pub_ext": published_by_ext,
+                            "now": now,
+                        },
+                    )
+                    upserted += 1
+
+                page += 1
+                if len(packages) < 100:
+                    break
+
+    return upserted
+
+
+async def _run_sync() -> None:
+    """Run the full packages sync: fetch from GitHub, update flags, generate alerts."""
+    session_factory = _make_session_factory()
+    async with session_factory() as session:
+        # Get all configured orgs
+        orgs_q = await session.execute(
+            text(
+                "SELECT DISTINCT account_login "
+                "FROM github_app_installations "
+                "WHERE target_type = 'Organization'"
+            )
+        )
+        orgs = [row.account_login for row in orgs_q.fetchall()]
+
+        if not orgs:
+            logger.info("package_sync.no_orgs_configured")
+            return
+
+        total_upserted = 0
+        for org in orgs:
+            try:
+                count = await _sync_packages_for_org(session, org)
+                total_upserted += count
+                logger.info("package_sync.org_complete", org=org, packages=count)
+            except Exception as exc:
+                logger.error("package_sync.org_failed", org=org, error=str(exc))
+
+        # Update staleness flags
+        stale_updated = await _update_staleness_flags(session)
+        logger.info("package_sync.staleness_updated", count=stale_updated)
+
+        # Generate alerts
+        alerts_created = await _generate_alerts(session)
+        logger.info("package_sync.alerts_created", count=alerts_created)
+
+        await session.commit()
+        logger.info(
+            "package_sync.complete",
+            orgs=len(orgs),
+            packages_upserted=total_upserted,
+            alerts_created=alerts_created,
+        )
+
+
+# ── Celery task ──────────────────────────────────────────────────────────────
+
+
+@celery_app.task(
+    name="app.workers.package_sync_worker.sync_packages",
+    bind=True,
+    max_retries=2,
+    default_retry_delay=300,
+)
+def sync_packages(self: Task) -> dict[str, str]:
+    """Celery task: sync GitHub Packages data and generate alerts.
+
+    Runs every 6 hours via Celery beat schedule.
+    """
+    try:
+        asyncio.run(_run_sync())
+        return {"status": "ok"}
+    except Exception as exc:
+        logger.error("package_sync.task_failed", error=str(exc))
+        raise self.retry(exc=exc) from exc

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -169,6 +169,9 @@ ignore = [
 # supply_chain_service uses SQLAlchemy text() with bound parameters (:param syntax),
 # not raw string interpolation of user data. S608 is a false positive here.
 "app/services/supply_chain_service.py" = ["S608"]
+# package_monitoring_service uses SQLAlchemy text() with bound parameters (:param syntax),
+# not raw string interpolation of user data. S608 is a false positive here.
+"app/services/package_monitoring_service.py" = ["S608"]
 # fix_ann001.py is a one-off development helper script
 "fix_ann001.py" = ["T20"]
 

--- a/backend/tests/test_packages.py
+++ b/backend/tests/test_packages.py
@@ -1,0 +1,505 @@
+"""Tests for the packages monitoring service and router."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import jwt as pyjwt
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.deps import get_db, get_valkey
+from app.routers import packages as packages_module
+from app.services.package_monitoring_service import (
+    PackageAlertList,
+    PackageAlertRecord,
+    PackageInventory,
+    PackageInventoryItem,
+    PackageSummary,
+    StaleImageList,
+    StaleImageRecord,
+    _org_filter,
+)
+
+SECRET = "testsecretkey_for_unit_tests_only_32ch"
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_jwt(sub: str = "testuser", jti: str = "pkg-jti") -> str:
+    now = datetime.now(UTC)
+    payload = {
+        "sub": sub,
+        "github_id": 12345,
+        "jti": jti,
+        "exp": now + timedelta(hours=1),
+        "iat": now,
+    }
+    return pyjwt.encode(payload, SECRET, algorithm="HS256")
+
+
+def _make_session(roles: list[str] | None = None) -> str:
+    return json.dumps(
+        {
+            "github_login": "testuser",
+            "github_id": 12345,
+            "roles": roles or ["analyst"],
+            "scoped_orgs": ["my-org"],
+            "scoped_repos": [],
+            "scope_type": "scoped",
+            "session_expires_at": "2099-01-01T00:00:00+00:00",
+        }
+    )
+
+
+def _make_mock_db() -> AsyncMock:
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.fetchall.return_value = []
+    mock_result.scalar.return_value = 0
+
+    mock_db = AsyncMock()
+    mock_db.execute.return_value = mock_result
+    return mock_db
+
+
+def _build_packages_app(
+    valkey_session: str | None = None,
+) -> tuple[FastAPI, AsyncMock, AsyncMock]:
+    """Create a FastAPI app with the packages router for testing."""
+    app = FastAPI()
+    app.include_router(packages_module.router, prefix="/api/v1")
+
+    mock_db = _make_mock_db()
+    mock_valkey = AsyncMock()
+    mock_valkey.get = AsyncMock(return_value=valkey_session)
+
+    async def override_db():  # type: ignore[return-value]
+        yield mock_db
+
+    async def override_valkey():  # type: ignore[return-value]
+        yield mock_valkey
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_valkey] = override_valkey
+
+    return app, mock_db, mock_valkey
+
+
+# ── org_filter helper tests ─────────────────────────────────────────────────
+
+
+class TestOrgFilter:
+    """Tests for _org_filter helper."""
+
+    def test_empty_orgs_returns_empty(self) -> None:
+        sql, params = _org_filter([])
+        assert sql == ""
+        assert params == {}
+
+    def test_single_org(self) -> None:
+        sql, params = _org_filter(["my-org"])
+        assert "IN" in sql
+        assert params == {"org_0": "my-org"}
+
+    def test_multiple_orgs(self) -> None:
+        sql, params = _org_filter(["org1", "org2", "org3"])
+        assert ":org_0" in sql
+        assert ":org_1" in sql
+        assert ":org_2" in sql
+        assert params["org_0"] == "org1"
+        assert params["org_1"] == "org2"
+        assert params["org_2"] == "org3"
+
+    def test_custom_alias(self) -> None:
+        sql, _ = _org_filter(["my-org"], table_alias="pkg")
+        assert "pkg.org" in sql
+
+
+# ── Service function tests ───────────────────────────────────────────────────
+
+
+class TestGetPackagesSummary:
+    """Tests for get_packages_summary."""
+
+    @pytest.mark.asyncio
+    async def test_returns_summary_with_empty_db(self) -> None:
+        from app.services.package_monitoring_service import get_packages_summary
+
+        mock_db = _make_mock_db()
+        result = await get_packages_summary(mock_db, ["my-org"])
+
+        assert isinstance(result, PackageSummary)
+        assert result.total_packages == 0
+        assert result.public_packages == 0
+        assert result.private_packages == 0
+        assert result.by_type == {}
+
+    @pytest.mark.asyncio
+    async def test_returns_summary_with_global_scope(self) -> None:
+        from app.services.package_monitoring_service import get_packages_summary
+
+        mock_db = _make_mock_db()
+        result = await get_packages_summary(mock_db, [])
+
+        assert isinstance(result, PackageSummary)
+        assert result.total_packages == 0
+
+
+class TestGetPackageAlerts:
+    """Tests for get_package_alerts."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_alert_list(self) -> None:
+        from app.services.package_monitoring_service import get_package_alerts
+
+        mock_db = _make_mock_db()
+        result = await get_package_alerts(mock_db, ["my-org"])
+
+        assert isinstance(result, PackageAlertList)
+        assert result.total == 0
+        assert result.alerts == []
+
+    @pytest.mark.asyncio
+    async def test_accepts_status_filter(self) -> None:
+        from app.services.package_monitoring_service import get_package_alerts
+
+        mock_db = _make_mock_db()
+        result = await get_package_alerts(mock_db, ["my-org"], alert_status="open")
+
+        assert isinstance(result, PackageAlertList)
+
+    @pytest.mark.asyncio
+    async def test_accepts_severity_filter(self) -> None:
+        from app.services.package_monitoring_service import get_package_alerts
+
+        mock_db = _make_mock_db()
+        result = await get_package_alerts(mock_db, ["my-org"], severity="high")
+
+        assert isinstance(result, PackageAlertList)
+
+
+class TestGetPackageInventory:
+    """Tests for get_package_inventory."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_inventory(self) -> None:
+        from app.services.package_monitoring_service import get_package_inventory
+
+        mock_db = _make_mock_db()
+        result = await get_package_inventory(mock_db, ["my-org"])
+
+        assert isinstance(result, PackageInventory)
+        assert result.total == 0
+        assert result.items == []
+        assert result.page == 1
+        assert result.page_size == 50
+
+    @pytest.mark.asyncio
+    async def test_accepts_type_filter(self) -> None:
+        from app.services.package_monitoring_service import get_package_inventory
+
+        mock_db = _make_mock_db()
+        result = await get_package_inventory(mock_db, ["my-org"], package_type="npm")
+        assert isinstance(result, PackageInventory)
+
+    @pytest.mark.asyncio
+    async def test_accepts_visibility_filter(self) -> None:
+        from app.services.package_monitoring_service import get_package_inventory
+
+        mock_db = _make_mock_db()
+        result = await get_package_inventory(mock_db, ["my-org"], visibility="public")
+        assert isinstance(result, PackageInventory)
+
+    @pytest.mark.asyncio
+    async def test_pagination(self) -> None:
+        from app.services.package_monitoring_service import get_package_inventory
+
+        mock_db = _make_mock_db()
+        result = await get_package_inventory(mock_db, ["my-org"], page=2, page_size=10)
+        assert result.page == 2
+        assert result.page_size == 10
+
+
+class TestGetStaleImages:
+    """Tests for get_stale_images."""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_stale_list(self) -> None:
+        from app.services.package_monitoring_service import get_stale_images
+
+        mock_db = _make_mock_db()
+        result = await get_stale_images(mock_db, ["my-org"])
+
+        assert isinstance(result, StaleImageList)
+        assert result.total == 0
+        assert result.images == []
+        assert result.threshold_days == 90
+
+    @pytest.mark.asyncio
+    async def test_custom_threshold(self) -> None:
+        from app.services.package_monitoring_service import get_stale_images
+
+        mock_db = _make_mock_db()
+        result = await get_stale_images(mock_db, ["my-org"], days_threshold=30)
+
+        assert result.threshold_days == 30
+
+
+# ── Router endpoint tests ───────────────────────────────────────────────────
+
+
+class TestPackagesRouter:
+    """Tests for the packages router endpoints."""
+
+    def test_summary_requires_auth(self) -> None:
+        app, _, _ = _build_packages_app(valkey_session=None)
+        client = TestClient(app)
+        resp = client.get("/api/v1/packages/summary")
+        assert resp.status_code == 401
+
+    def test_summary_returns_200(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/summary",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "total_packages" in data
+        assert "public_packages" in data
+        assert "private_packages" in data
+
+    def test_alerts_requires_auth(self) -> None:
+        app, _, _ = _build_packages_app(valkey_session=None)
+        client = TestClient(app)
+        resp = client.get("/api/v1/packages/alerts")
+        assert resp.status_code == 401
+
+    def test_alerts_returns_200(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/alerts",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "alerts" in data
+        assert "total" in data
+
+    def test_alerts_with_filters(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/alerts?status=open&severity=high",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+
+    def test_inventory_requires_auth(self) -> None:
+        app, _, _ = _build_packages_app(valkey_session=None)
+        client = TestClient(app)
+        resp = client.get("/api/v1/packages/inventory")
+        assert resp.status_code == 401
+
+    def test_inventory_returns_200(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/inventory",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "items" in data
+        assert "total" in data
+        assert "page" in data
+
+    def test_inventory_with_filters(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/inventory?type=npm&visibility=public&page=2&page_size=10",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+
+    def test_stale_images_requires_auth(self) -> None:
+        app, _, _ = _build_packages_app(valkey_session=None)
+        client = TestClient(app)
+        resp = client.get("/api/v1/packages/stale-images")
+        assert resp.status_code == 401
+
+    def test_stale_images_returns_200(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/stale-images",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "images" in data
+        assert "total" in data
+        assert "threshold_days" in data
+
+    def test_stale_images_custom_threshold(self) -> None:
+        session_data = _make_session()
+        app, mock_db, _ = _build_packages_app(valkey_session=session_data)
+        client = TestClient(app)
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/packages/stale-images?days=30",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+
+
+# ── Data class tests ─────────────────────────────────────────────────────────
+
+
+class TestDataClasses:
+    """Tests for service data classes."""
+
+    def test_package_summary_defaults(self) -> None:
+        summary = PackageSummary(
+            total_packages=10,
+            public_packages=3,
+            private_packages=7,
+        )
+        assert summary.by_type == {}
+        assert summary.newly_public == 0
+        assert summary.stale_images == 0
+        assert summary.open_alerts == 0
+
+    def test_package_alert_record(self) -> None:
+        alert = PackageAlertRecord(
+            id=1,
+            package_id=10,
+            package_name="my-pkg",
+            package_org="my-org",
+            alert_type="public_exposure",
+            severity="high",
+            message="Package is public",
+            detected_at="2024-01-01T00:00:00Z",
+            resolved_at=None,
+            status="open",
+        )
+        assert alert.id == 1
+        assert alert.alert_type == "public_exposure"
+
+    def test_package_inventory_item(self) -> None:
+        item = PackageInventoryItem(
+            id=1,
+            org="my-org",
+            repo="my-org/repo",
+            name="my-pkg",
+            package_type="npm",
+            visibility="private",
+            owner="user1",
+            versions_count=5,
+            latest_version="1.2.3",
+            last_published_at="2024-01-01T00:00:00Z",
+            is_stale=False,
+            published_outside_actions=False,
+            published_by_external=False,
+        )
+        assert item.name == "my-pkg"
+        assert item.versions_count == 5
+
+    def test_stale_image_record(self) -> None:
+        image = StaleImageRecord(
+            id=1,
+            org="my-org",
+            repo="my-org/myapp",
+            name="myapp",
+            last_published_at="2023-06-01T00:00:00Z",
+            days_since_rebuild=180,
+            owner="user1",
+        )
+        assert image.days_since_rebuild == 180
+
+    def test_package_alert_list_defaults(self) -> None:
+        alert_list = PackageAlertList()
+        assert alert_list.alerts == []
+        assert alert_list.total == 0
+
+    def test_package_inventory_defaults(self) -> None:
+        inv = PackageInventory()
+        assert inv.items == []
+        assert inv.total == 0
+        assert inv.page == 1
+        assert inv.page_size == 50
+
+    def test_stale_image_list_defaults(self) -> None:
+        stale = StaleImageList()
+        assert stale.images == []
+        assert stale.total == 0
+        assert stale.threshold_days == 90
+
+
+# ── Worker helper tests ──────────────────────────────────────────────────────
+
+
+class TestPackageSyncWorker:
+    """Tests for package sync worker helper functions."""
+
+    def test_expected_registry_types(self) -> None:
+        from app.workers.package_sync_worker import _EXPECTED_REGISTRY_TYPES
+
+        assert "npm" in _EXPECTED_REGISTRY_TYPES
+        assert "maven" in _EXPECTED_REGISTRY_TYPES
+        assert "docker" in _EXPECTED_REGISTRY_TYPES
+        assert "container" in _EXPECTED_REGISTRY_TYPES
+        assert "nuget" in _EXPECTED_REGISTRY_TYPES
+        assert "rubygems" in _EXPECTED_REGISTRY_TYPES
+
+    def test_stale_threshold_days(self) -> None:
+        from app.workers.package_sync_worker import _STALE_THRESHOLD_DAYS
+
+        assert _STALE_THRESHOLD_DAYS == 90
+
+    @pytest.mark.asyncio
+    async def test_update_staleness_flags(self) -> None:
+        from app.workers.package_sync_worker import _update_staleness_flags
+
+        mock_result = MagicMock()
+        mock_result.rowcount = 3
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        count = await _update_staleness_flags(mock_db)
+        assert count == 6  # 3 stale + 3 unstale (both return rowcount=3)
+
+    @pytest.mark.asyncio
+    async def test_generate_alerts_with_empty_db(self) -> None:
+        from app.workers.package_sync_worker import _generate_alerts
+
+        mock_result = MagicMock()
+        mock_result.fetchall.return_value = []
+        mock_result.rowcount = 0
+
+        mock_db = AsyncMock()
+        mock_db.execute.return_value = mock_result
+
+        count = await _generate_alerts(mock_db)
+        assert count == 0

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -27,6 +27,7 @@ import { WorkflowHealthPage } from './pages/WorkflowHealth';
 import { AdvancedSecurityPage } from './pages/AdvancedSecurity';
 import { PlaybooksPage } from './pages/Playbooks';
 import { SupplyChainPage } from './pages/SupplyChain';
+import { PackagesPage } from './pages/Packages';
 import { ThreatIntelPage } from './pages/ThreatIntel';
 import { SyncStatusPage } from './pages/SyncStatus';
 import { NotificationsPage } from './pages/Notifications';
@@ -68,6 +69,7 @@ export const router = createBrowserRouter([
       { path: '/workflows/health', element: <WorkflowHealthPage /> },
       { path: '/advanced-security', element: <AdvancedSecurityPage /> },
       { path: '/supply-chain', element: <SupplyChainPage /> },
+      { path: '/packages', element: <PackagesPage /> },
       { path: '/playbooks', element: <PlaybooksPage /> },
       { path: '/velocity', element: <VelocityPage /> },
       { path: '/devactivity', element: <DevActivityPage /> },

--- a/frontend/src/api/packages.ts
+++ b/frontend/src/api/packages.ts
@@ -1,0 +1,111 @@
+import { api } from './client';
+
+/* ── Response types ─────────────────────────────────────────────────────── */
+
+export interface PackageSummary {
+  total_packages: number;
+  public_packages: number;
+  private_packages: number;
+  by_type: Record<string, number>;
+  newly_public: number;
+  stale_images: number;
+  open_alerts: number;
+}
+
+export interface PackageAlert {
+  id: number;
+  package_id: number;
+  package_name: string;
+  package_org: string;
+  alert_type: string;
+  severity: string;
+  message: string;
+  detected_at: string;
+  resolved_at: string | null;
+  status: string;
+}
+
+export interface PackageAlertList {
+  alerts: PackageAlert[];
+  total: number;
+}
+
+export interface PackageInventoryItem {
+  id: number;
+  org: string;
+  repo: string | null;
+  name: string;
+  package_type: string;
+  visibility: string;
+  owner: string | null;
+  versions_count: number;
+  latest_version: string | null;
+  last_published_at: string | null;
+  is_stale: boolean;
+  published_outside_actions: boolean;
+  published_by_external: boolean;
+}
+
+export interface PackageInventory {
+  items: PackageInventoryItem[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+export interface StaleImage {
+  id: number;
+  org: string;
+  repo: string | null;
+  name: string;
+  last_published_at: string | null;
+  days_since_rebuild: number;
+  owner: string | null;
+}
+
+export interface StaleImageList {
+  images: StaleImage[];
+  total: number;
+  threshold_days: number;
+}
+
+/* ── API functions ──────────────────────────────────────────────────────── */
+
+export function getPackageSummary(): Promise<PackageSummary> {
+  return api.get<PackageSummary>('/packages/summary');
+}
+
+export function getPackageAlerts(params?: {
+  status?: string;
+  severity?: string;
+  page?: number;
+  page_size?: number;
+}): Promise<PackageAlertList> {
+  const searchParams = new URLSearchParams();
+  if (params?.status) searchParams.set('status', params.status);
+  if (params?.severity) searchParams.set('severity', params.severity);
+  if (params?.page) searchParams.set('page', String(params.page));
+  if (params?.page_size) searchParams.set('page_size', String(params.page_size));
+  const qs = searchParams.toString();
+  return api.get<PackageAlertList>(`/packages/alerts${qs ? `?${qs}` : ''}`);
+}
+
+export function getPackageInventory(params?: {
+  type?: string;
+  visibility?: string;
+  page?: number;
+  page_size?: number;
+}): Promise<PackageInventory> {
+  const searchParams = new URLSearchParams();
+  if (params?.type) searchParams.set('type', params.type);
+  if (params?.visibility) searchParams.set('visibility', params.visibility);
+  if (params?.page) searchParams.set('page', String(params.page));
+  if (params?.page_size) searchParams.set('page_size', String(params.page_size));
+  const qs = searchParams.toString();
+  return api.get<PackageInventory>(`/packages/inventory${qs ? `?${qs}` : ''}`);
+}
+
+export function getStaleImages(days?: number): Promise<StaleImageList> {
+  const qs = days ? `?days=${days}` : '';
+  return api.get<StaleImageList>(`/packages/stale-images${qs}`);
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -376,6 +376,19 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
             Supply Chain
           </NavItem>
         )}
+        {hasPermission('detections', 'view') && (
+          <NavItem
+            to="/packages"
+            onClick={onMobileClose}
+            icon={
+              <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M8.878.392a1.75 1.75 0 00-1.756 0l-5.25 3.045A1.75 1.75 0 001 4.951v6.098c0 .624.332 1.2.872 1.514l5.25 3.045a1.75 1.75 0 001.756 0l5.25-3.045A1.75 1.75 0 0015 11.049V4.951a1.75 1.75 0 00-.872-1.514zM2.5 5.677l5-2.9a.25.25 0 01.25 0l5 2.9V11.05a.25.25 0 01-.125.216l-5 2.9a.25.25 0 01-.25 0l-5-2.9a.25.25 0 01-.125-.216z" />
+              </svg>
+            }
+          >
+            Packages
+          </NavItem>
+        )}
       </div>
 
       <div className={styles.navSection}>

--- a/frontend/src/pages/Packages/Packages.module.css
+++ b/frontend/src/pages/Packages/Packages.module.css
@@ -1,0 +1,193 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.metricGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.sectionTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 4px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.sectionSub {
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-bottom: 10px;
+}
+
+.centered {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+}
+
+.tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 16px;
+}
+
+.tab {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg-muted);
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.tab:hover {
+  color: var(--fg);
+}
+
+.tabActive {
+  color: var(--fg);
+  border-bottom-color: var(--accent);
+}
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.table th,
+.table td {
+  padding: 8px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.table th {
+  font-weight: 600;
+  color: var(--fg-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.table tr:hover td {
+  background: var(--canvas-subtle);
+}
+
+.badge {
+  display: inline-block;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 10px;
+  text-transform: capitalize;
+}
+
+.critical {
+  background: var(--danger-subtle, #2d0d10);
+  color: var(--danger-fg, #f85149);
+}
+
+.high {
+  background: var(--attention-subtle, #2d1d00);
+  color: var(--attention-fg, #d29922);
+}
+
+.medium {
+  background: var(--accent-subtle, #0d1d2d);
+  color: var(--accent-fg, #58a6ff);
+}
+
+.low {
+  background: var(--success-subtle, #0d2d1d);
+  color: var(--success-fg, #3fb950);
+}
+
+.none {
+  background: var(--neutral-subtle, #1d1d1d);
+  color: var(--fg-muted);
+}
+
+.publicBadge {
+  background: var(--danger-subtle, #2d0d10);
+  color: var(--danger-fg, #f85149);
+}
+
+.privateBadge {
+  background: var(--success-subtle, #0d2d1d);
+  color: var(--success-fg, #3fb950);
+}
+
+.filterBar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.filterSelect {
+  padding: 6px 10px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--canvas-subtle);
+  color: var(--fg);
+}
+
+.warningIcon {
+  color: var(--attention-fg, #d29922);
+  margin-right: 4px;
+}
+
+.emptyState {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .page,
+  .metricGrid,
+  .sectionTitle,
+  .sectionSub,
+  .centered,
+  .tabs,
+  .tab,
+  .tabActive,
+  .tableWrapper,
+  .table,
+  .badge,
+  .critical,
+  .high,
+  .medium,
+  .low,
+  .none,
+  .publicBadge,
+  .privateBadge,
+  .filterBar,
+  .filterSelect,
+  .warningIcon,
+  .emptyState {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/frontend/src/pages/Packages/Packages.test.tsx
+++ b/frontend/src/pages/Packages/Packages.test.tsx
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PackagesPage } from './index';
+import type {
+  PackageSummary,
+  PackageAlertList,
+  PackageInventory,
+  StaleImageList,
+} from '../../api/packages';
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const mockSummary: PackageSummary = {
+  total_packages: 25,
+  public_packages: 3,
+  private_packages: 22,
+  by_type: { npm: 10, docker: 8, maven: 5, nuget: 2 },
+  newly_public: 1,
+  stale_images: 2,
+  open_alerts: 4,
+};
+
+const mockAlerts: PackageAlertList = {
+  alerts: [
+    {
+      id: 1,
+      package_id: 10,
+      package_name: 'my-public-pkg',
+      package_org: 'my-org',
+      alert_type: 'public_exposure',
+      severity: 'high',
+      message: "Package 'my-public-pkg' has public visibility",
+      detected_at: '2024-01-15T10:00:00Z',
+      resolved_at: null,
+      status: 'open',
+    },
+    {
+      id: 2,
+      package_id: 11,
+      package_name: 'old-image',
+      package_org: 'my-org',
+      alert_type: 'stale_image',
+      severity: 'medium',
+      message: "Container image 'old-image' not rebuilt in 120 days",
+      detected_at: '2024-01-10T10:00:00Z',
+      resolved_at: null,
+      status: 'open',
+    },
+  ],
+  total: 2,
+};
+
+const mockInventory: PackageInventory = {
+  items: [
+    {
+      id: 1,
+      org: 'my-org',
+      repo: 'my-org/repo1',
+      name: 'web-app',
+      package_type: 'docker',
+      visibility: 'private',
+      owner: 'dev-user',
+      versions_count: 42,
+      latest_version: 'v2.1.0',
+      last_published_at: '2024-01-20T14:00:00Z',
+      is_stale: false,
+      published_outside_actions: false,
+      published_by_external: false,
+    },
+    {
+      id: 2,
+      org: 'my-org',
+      repo: null,
+      name: '@my-org/shared-lib',
+      package_type: 'npm',
+      visibility: 'public',
+      owner: 'external-user',
+      versions_count: 5,
+      latest_version: '1.0.3',
+      last_published_at: '2023-06-01T00:00:00Z',
+      is_stale: true,
+      published_outside_actions: true,
+      published_by_external: true,
+    },
+  ],
+  total: 2,
+  page: 1,
+  page_size: 50,
+};
+
+const mockStaleImages: StaleImageList = {
+  images: [
+    {
+      id: 11,
+      org: 'my-org',
+      repo: 'my-org/legacy',
+      name: 'legacy-api',
+      last_published_at: '2023-03-01T00:00:00Z',
+      days_since_rebuild: 320,
+      owner: 'dev-user',
+    },
+  ],
+  total: 1,
+  threshold_days: 90,
+};
+
+interface MockQueryReturn<T> {
+  data: T | undefined;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: ReturnType<typeof vi.fn>;
+}
+
+let queryResults: Record<string, MockQueryReturn<unknown>>;
+
+vi.mock('@tanstack/react-query', async () => {
+  const actual =
+    await vi.importActual<typeof import('@tanstack/react-query')>('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: (opts: { queryKey: string[] }) => {
+      const key = opts.queryKey.join('/');
+      return (
+        queryResults[key] ?? { data: undefined, isLoading: true, isError: false, refetch: vi.fn() }
+      );
+    },
+  };
+});
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <PackagesPage />
+    </QueryClientProvider>,
+  );
+}
+
+function loadedResults(): Record<string, MockQueryReturn<unknown>> {
+  return {
+    'packages/summary': {
+      data: mockSummary,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    },
+    'packages/alerts': {
+      data: mockAlerts,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    },
+    'packages/inventory': {
+      data: mockInventory,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    },
+    'packages/stale-images': {
+      data: mockStaleImages,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    },
+  };
+}
+
+describe('PackagesPage', () => {
+  beforeEach(() => {
+    queryResults = {};
+  });
+
+  it('shows spinner while loading', () => {
+    queryResults = {
+      'packages/summary': {
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        refetch: vi.fn(),
+      },
+      'packages/alerts': {
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        refetch: vi.fn(),
+      },
+      'packages/inventory': {
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        refetch: vi.fn(),
+      },
+      'packages/stale-images': {
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        refetch: vi.fn(),
+      },
+    };
+    const { container } = renderPage();
+    expect(container.querySelector('.spinner')).not.toBeNull();
+  });
+
+  it('shows error banner on failure', () => {
+    queryResults = {
+      'packages/summary': {
+        data: undefined,
+        isLoading: false,
+        isError: true,
+        refetch: vi.fn(),
+      },
+      'packages/alerts': {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+      'packages/inventory': {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+      'packages/stale-images': {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+    };
+    renderPage();
+    expect(screen.getByText(/failed to load packages data/i)).toBeDefined();
+  });
+
+  it('renders metric cards with summary data', () => {
+    queryResults = loadedResults();
+    renderPage();
+    expect(screen.getByText('25')).toBeDefined();
+    expect(screen.getByText('Total Packages')).toBeDefined();
+    expect(screen.getByText('Public Packages')).toBeDefined();
+    expect(screen.getByText('Private Packages')).toBeDefined();
+    expect(screen.getByText('Stale Images')).toBeDefined();
+    expect(screen.getByText('Open Alerts')).toBeDefined();
+  });
+
+  it('renders overview tab by default with recent alerts', () => {
+    queryResults = loadedResults();
+    renderPage();
+    expect(screen.getByText('Recent alerts')).toBeDefined();
+    expect(screen.getAllByText(/my-public-pkg/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders packages by type in overview', () => {
+    queryResults = loadedResults();
+    renderPage();
+    expect(screen.getByText('Packages by type')).toBeDefined();
+  });
+
+  it('switches to inventory tab', () => {
+    queryResults = loadedResults();
+    renderPage();
+    fireEvent.click(screen.getByText('Inventory'));
+    expect(screen.getByText('web-app')).toBeDefined();
+    expect(screen.getByText('@my-org/shared-lib')).toBeDefined();
+  });
+
+  it('switches to alerts tab', () => {
+    queryResults = loadedResults();
+    renderPage();
+    fireEvent.click(screen.getByText('Alerts'));
+    expect(screen.getByText('public_exposure')).toBeDefined();
+    expect(screen.getByText('stale_image')).toBeDefined();
+  });
+
+  it('switches to container health tab', () => {
+    queryResults = loadedResults();
+    renderPage();
+    fireEvent.click(screen.getByText('Container Health'));
+    expect(screen.getByText('legacy-api')).toBeDefined();
+    expect(screen.getByText('320 days')).toBeDefined();
+  });
+
+  it('renders tabs with correct ARIA roles', () => {
+    queryResults = loadedResults();
+    renderPage();
+    const tablist = screen.getByRole('tablist');
+    expect(tablist).toBeDefined();
+    const tabs = screen.getAllByRole('tab');
+    expect(tabs.length).toBe(4);
+  });
+
+  it('shows empty state when no alerts', () => {
+    const emptyAlerts: PackageAlertList = { alerts: [], total: 0 };
+    queryResults = {
+      ...loadedResults(),
+      'packages/alerts': {
+        data: emptyAlerts,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+    };
+    renderPage();
+    expect(screen.getByText('No package security alerts.')).toBeDefined();
+  });
+
+  it('shows empty state when no inventory', () => {
+    const emptyInv: PackageInventory = { items: [], total: 0, page: 1, page_size: 50 };
+    queryResults = {
+      ...loadedResults(),
+      'packages/inventory': {
+        data: emptyInv,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+    };
+    renderPage();
+    fireEvent.click(screen.getByText('Inventory'));
+    expect(screen.getByText('No packages found.')).toBeDefined();
+  });
+
+  it('shows all container images up to date when no stale images', () => {
+    const emptyStale: StaleImageList = { images: [], total: 0, threshold_days: 90 };
+    queryResults = {
+      ...loadedResults(),
+      'packages/stale-images': {
+        data: emptyStale,
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      },
+    };
+    renderPage();
+    fireEvent.click(screen.getByText('Container Health'));
+    expect(screen.getByText('All container images are up to date.')).toBeDefined();
+  });
+
+  it('displays visibility badges in inventory', () => {
+    queryResults = loadedResults();
+    renderPage();
+    fireEvent.click(screen.getByText('Inventory'));
+    // Both public and private visibility badges should be present
+    expect(screen.getByText('private')).toBeDefined();
+    expect(screen.getByText('public')).toBeDefined();
+  });
+
+  it('displays flag icons for flagged packages in inventory', () => {
+    queryResults = loadedResults();
+    renderPage();
+    fireEvent.click(screen.getByText('Inventory'));
+    // The second package has all flags set
+    expect(screen.getByText('⏰')).toBeDefined();
+    expect(screen.getByText('⚠️')).toBeDefined();
+    expect(screen.getByText('🔓')).toBeDefined();
+  });
+});

--- a/frontend/src/pages/Packages/index.tsx
+++ b/frontend/src/pages/Packages/index.tsx
@@ -1,0 +1,400 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { MetricCard } from '../../components/primitives/MetricCard';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import {
+  getPackageSummary,
+  getPackageAlerts,
+  getPackageInventory,
+  getStaleImages,
+} from '../../api/packages';
+import type {
+  PackageSummary,
+  PackageAlertList,
+  PackageInventory,
+  StaleImageList,
+} from '../../api/packages';
+import styles from './Packages.module.css';
+
+type TabKey = 'overview' | 'inventory' | 'alerts' | 'container-health';
+
+/* ── Severity badge ─────────────────────────────────────────────────────── */
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const key = severity.toLowerCase();
+  const cls =
+    key === 'critical'
+      ? styles.critical
+      : key === 'high'
+        ? styles.high
+        : key === 'medium'
+          ? styles.medium
+          : key === 'low'
+            ? styles.low
+            : styles.none;
+  return <span className={`${styles.badge} ${cls}`}>{severity}</span>;
+}
+
+/* ── Visibility badge ───────────────────────────────────────────────────── */
+
+function VisibilityBadge({ visibility }: { visibility: string }) {
+  const cls = visibility === 'public' ? styles.publicBadge : styles.privateBadge;
+  return <span className={`${styles.badge} ${cls}`}>{visibility}</span>;
+}
+
+/* ── Overview tab ───────────────────────────────────────────────────────── */
+
+function OverviewTab({
+  summary,
+  alerts,
+}: {
+  summary: PackageSummary | undefined;
+  alerts: PackageAlertList | undefined;
+}) {
+  const recentAlerts = alerts?.alerts?.slice(0, 5) ?? [];
+
+  return (
+    <div>
+      {/* By type breakdown */}
+      {summary && Object.keys(summary.by_type).length > 0 && (
+        <>
+          <div className={styles.sectionTitle}>Packages by type</div>
+          <div className={styles.metricGrid}>
+            {Object.entries(summary.by_type).map(([type, count]) => (
+              <MetricCard key={type} value={String(count)} label={type} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Recent alerts */}
+      <div className={styles.sectionTitle} style={{ marginTop: 24 }}>
+        Recent alerts
+      </div>
+      {recentAlerts.length === 0 ? (
+        <div className={styles.emptyState}>No package security alerts.</div>
+      ) : (
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th scope="col">Package</th>
+                <th scope="col">Alert</th>
+                <th scope="col">Severity</th>
+                <th scope="col">Status</th>
+                <th scope="col">Detected</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recentAlerts.map((alert) => (
+                <tr key={alert.id}>
+                  <td>
+                    {alert.package_org}/{alert.package_name}
+                  </td>
+                  <td>{alert.message}</td>
+                  <td>
+                    <SeverityBadge severity={alert.severity} />
+                  </td>
+                  <td>{alert.status}</td>
+                  <td>{new Date(alert.detected_at).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Inventory tab ──────────────────────────────────────────────────────── */
+
+function InventoryTab({ data }: { data: PackageInventory | undefined }) {
+  const items = data?.items ?? [];
+
+  if (items.length === 0) {
+    return <div className={styles.emptyState}>No packages found.</div>;
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col">Org</th>
+            <th scope="col">Type</th>
+            <th scope="col">Visibility</th>
+            <th scope="col">Versions</th>
+            <th scope="col">Latest</th>
+            <th scope="col">Last Published</th>
+            <th scope="col">Flags</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((pkg) => (
+            <tr key={pkg.id}>
+              <td>
+                <strong>{pkg.name}</strong>
+                {pkg.repo && (
+                  <div style={{ fontSize: 11, color: 'var(--fg-muted)' }}>{pkg.repo}</div>
+                )}
+              </td>
+              <td>{pkg.org}</td>
+              <td>{pkg.package_type}</td>
+              <td>
+                <VisibilityBadge visibility={pkg.visibility} />
+              </td>
+              <td>{pkg.versions_count}</td>
+              <td>{pkg.latest_version ?? '—'}</td>
+              <td>
+                {pkg.last_published_at ? new Date(pkg.last_published_at).toLocaleDateString() : '—'}
+              </td>
+              <td>
+                {pkg.is_stale && <span className={styles.warningIcon}>⏰</span>}
+                {pkg.published_outside_actions && <span className={styles.warningIcon}>⚠️</span>}
+                {pkg.published_by_external && <span className={styles.warningIcon}>🔓</span>}
+                {!pkg.is_stale &&
+                  !pkg.published_outside_actions &&
+                  !pkg.published_by_external &&
+                  '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* ── Alerts tab ─────────────────────────────────────────────────────────── */
+
+function AlertsTab({ data }: { data: PackageAlertList | undefined }) {
+  const alerts = data?.alerts ?? [];
+
+  if (alerts.length === 0) {
+    return <div className={styles.emptyState}>No package security alerts.</div>;
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th scope="col">Package</th>
+            <th scope="col">Type</th>
+            <th scope="col">Severity</th>
+            <th scope="col">Message</th>
+            <th scope="col">Status</th>
+            <th scope="col">Detected</th>
+            <th scope="col">Resolved</th>
+          </tr>
+        </thead>
+        <tbody>
+          {alerts.map((alert) => (
+            <tr key={alert.id}>
+              <td>
+                {alert.package_org}/{alert.package_name}
+              </td>
+              <td>{alert.alert_type}</td>
+              <td>
+                <SeverityBadge severity={alert.severity} />
+              </td>
+              <td>{alert.message}</td>
+              <td>{alert.status}</td>
+              <td>{new Date(alert.detected_at).toLocaleString()}</td>
+              <td>{alert.resolved_at ? new Date(alert.resolved_at).toLocaleString() : '—'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* ── Container Health tab ───────────────────────────────────────────────── */
+
+function ContainerHealthTab({ data }: { data: StaleImageList | undefined }) {
+  const images = data?.images ?? [];
+  const threshold = data?.threshold_days ?? 90;
+
+  return (
+    <div>
+      <div className={styles.sectionSub}>
+        Container images not rebuilt in over {threshold} days.
+      </div>
+      {images.length === 0 ? (
+        <div className={styles.emptyState}>All container images are up to date.</div>
+      ) : (
+        <div className={styles.tableWrapper}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th scope="col">Image</th>
+                <th scope="col">Org</th>
+                <th scope="col">Repo</th>
+                <th scope="col">Last Rebuilt</th>
+                <th scope="col">Days Since Rebuild</th>
+                <th scope="col">Owner</th>
+              </tr>
+            </thead>
+            <tbody>
+              {images.map((img) => (
+                <tr key={img.id}>
+                  <td>
+                    <strong>{img.name}</strong>
+                  </td>
+                  <td>{img.org}</td>
+                  <td>{img.repo ?? '—'}</td>
+                  <td>
+                    {img.last_published_at
+                      ? new Date(img.last_published_at).toLocaleDateString()
+                      : 'Never'}
+                  </td>
+                  <td>
+                    <span
+                      style={{
+                        color:
+                          img.days_since_rebuild > 180
+                            ? 'var(--danger-fg, #f85149)'
+                            : 'var(--attention-fg, #d29922)',
+                      }}
+                    >
+                      {img.days_since_rebuild} days
+                    </span>
+                  </td>
+                  <td>{img.owner ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* ── Main page ──────────────────────────────────────────────────────────── */
+
+export function PackagesPage() {
+  const [activeTab, setActiveTab] = useState<TabKey>('overview');
+
+  const summaryQuery = useQuery({
+    queryKey: ['packages', 'summary'],
+    queryFn: getPackageSummary,
+    staleTime: 60_000,
+  });
+
+  const alertsQuery = useQuery({
+    queryKey: ['packages', 'alerts'],
+    queryFn: () => getPackageAlerts({ status: 'open' }),
+    staleTime: 60_000,
+  });
+
+  const inventoryQuery = useQuery({
+    queryKey: ['packages', 'inventory'],
+    queryFn: () => getPackageInventory(),
+    staleTime: 60_000,
+  });
+
+  const staleQuery = useQuery({
+    queryKey: ['packages', 'stale-images'],
+    queryFn: () => getStaleImages(),
+    staleTime: 60_000,
+  });
+
+  const isLoading =
+    summaryQuery.isLoading ||
+    alertsQuery.isLoading ||
+    inventoryQuery.isLoading ||
+    staleQuery.isLoading;
+  const isError =
+    summaryQuery.isError || alertsQuery.isError || inventoryQuery.isError || staleQuery.isError;
+
+  if (isLoading) {
+    return (
+      <div className={styles.centered}>
+        <Spinner size={28} />
+      </div>
+    );
+  }
+
+  if (isError) {
+    const retryAll = () => {
+      void summaryQuery.refetch();
+      void alertsQuery.refetch();
+      void inventoryQuery.refetch();
+      void staleQuery.refetch();
+    };
+    return <ErrorBanner message="Failed to load packages data" onRetry={retryAll} />;
+  }
+
+  const summary = summaryQuery.data;
+
+  return (
+    <div className={styles.page}>
+      <h2>Packages Monitoring</h2>
+
+      {/* ── Summary strip ────────────────────────────────────────────── */}
+      <div className={styles.metricGrid}>
+        <MetricCard
+          value={String(summary?.total_packages ?? 0)}
+          label="Total Packages"
+          helpText="Total number of packages across all monitored organisations."
+        />
+        <MetricCard
+          value={String(summary?.public_packages ?? 0)}
+          label="Public Packages"
+          accent={summary != null && summary.public_packages > 0}
+          helpText="Packages with public visibility — potential data exposure risk."
+        />
+        <MetricCard
+          value={String(summary?.private_packages ?? 0)}
+          label="Private Packages"
+          helpText="Packages with private visibility."
+        />
+        <MetricCard
+          value={String(summary?.stale_images ?? 0)}
+          label="Stale Images"
+          accent={summary != null && summary.stale_images > 0}
+          helpText="Container images not rebuilt in over 90 days."
+        />
+        <MetricCard
+          value={String(summary?.open_alerts ?? 0)}
+          label="Open Alerts"
+          accent={summary != null && summary.open_alerts > 0}
+          helpText="Active security alerts requiring attention."
+        />
+      </div>
+
+      {/* ── Tabs ─────────────────────────────────────────────────────── */}
+      <div className={styles.tabs} role="tablist">
+        {(
+          [
+            ['overview', 'Overview'],
+            ['inventory', 'Inventory'],
+            ['alerts', 'Alerts'],
+            ['container-health', 'Container Health'],
+          ] as const
+        ).map(([key, label]) => (
+          <button
+            key={key}
+            role="tab"
+            aria-selected={activeTab === key}
+            className={`${styles.tab} ${activeTab === key ? styles.tabActive : ''}`}
+            onClick={() => setActiveTab(key)}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* ── Tab content ──────────────────────────────────────────────── */}
+      {activeTab === 'overview' && <OverviewTab summary={summary} alerts={alertsQuery.data} />}
+      {activeTab === 'inventory' && <InventoryTab data={inventoryQuery.data} />}
+      {activeTab === 'alerts' && <AlertsTab data={alertsQuery.data} />}
+      {activeTab === 'container-health' && <ContainerHealthTab data={staleQuery.data} />}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Comprehensive GitHub Packages monitoring with security alerts, inventory management, and container health tracking.

### Features
- **Public exposure detection** — flags public packages with High/Medium severity alerts
- **Container health** — tracks stale images (>90 days since rebuild)
- **Supply chain indicators** — flags external publishers and unexpected registry types
- **Package inventory** — full inventory with type/visibility/org filtering
- **Background sync** — Celery worker syncs from GitHub API every 6 hours

### Backend
- `packages` and `package_alerts` tables (migration 0057)
- 4 API endpoints: summary, alerts, inventory, stale-images
- Background sync worker with alert generation/resolution
- 37 new tests

### Frontend
- New `/packages` page with 4 tabs: Overview, Inventory, Alerts, Container Health
- Sidebar nav entry under Security section
- 14 new tests

### Validation
- ✅ 2,782 backend + 1,677 frontend tests passing

Closes #164