### PR TITLE
feat: user behavior classification — usage patterns, personas, and dormancy (#167)

### DIFF
--- a/backend/alembic/versions/0059_add_user_classifications.py
+++ b/backend/alembic/versions/0059_add_user_classifications.py
@@ -1,0 +1,75 @@
+"""add user_classifications table
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2025-01-01 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "0059"
+down_revision = "0058"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_classifications",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_login", sa.Text(), nullable=False),
+        sa.Column("org", sa.Text(), nullable=False),
+        sa.Column("persona", sa.String(30), nullable=False),
+        sa.Column("confidence_score", sa.Float(), nullable=False),
+        sa.Column("event_count", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("surfaces", JSONB(), nullable=False, server_default="'[]'"),
+        sa.Column("analysis_window_days", sa.Integer(), nullable=False, server_default="90"),
+        sa.Column(
+            "classified_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    op.create_index(
+        "idx_user_classifications_login_org",
+        "user_classifications",
+        ["user_login", "org"],
+        unique=True,
+    )
+    op.create_index(
+        "idx_user_classifications_persona",
+        "user_classifications",
+        ["persona"],
+    )
+    op.create_index(
+        "idx_user_classifications_classified_at",
+        "user_classifications",
+        ["classified_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_user_classifications_classified_at", table_name="user_classifications")
+    op.drop_index("idx_user_classifications_persona", table_name="user_classifications")
+    op.drop_index("idx_user_classifications_login_org", table_name="user_classifications")
+    op.drop_table("user_classifications")

--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -49,6 +49,7 @@ app.config_from_object(
             "app.workers.github_ip_allowlist_worker.*": {"queue": "baseline"},
             "app.workers.workflow_scan_worker.*": {"queue": "baseline"},
             "app.workers.package_sync_worker.*": {"queue": "github_sync"},
+            "app.workers.user_classification_worker.*": {"queue": "baseline"},
         },
         # ─── Soft / hard time limits ─────────────────────────────────────────
         "task_soft_time_limit": 1800,  # 30 minutes
@@ -115,6 +116,12 @@ app.config_from_object(
                 "schedule": crontab(minute=30, hour="*/6"),
                 "options": {"queue": "github_sync"},
             },
+            # User behavior classification — daily at 04:00 UTC
+            "classify-user-behavior": {
+                "task": "app.workers.user_classification_worker.classify_all_orgs",
+                "schedule": crontab(hour=4, minute=0),
+                "options": {"queue": "baseline"},
+            },
             # Threat intel feed refresh — every 30 minutes
             "refresh-threat-intel-feeds": {
                 "task": "app.workers.threat_intel_worker.refresh_threat_intel_feeds",
@@ -163,6 +170,7 @@ app.conf.include = [
     "app.workers.threat_intel_worker",
     "app.workers.workflow_scan_worker",
     "app.workers.package_sync_worker",
+    "app.workers.user_classification_worker",
 ]
 
 # Conditionally add GitHub sync heartbeat to beat schedule

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -67,6 +67,7 @@ from app.routers import (
     sync,
     teams,
     threat_intel,
+    user_classification,
     user_preferences,
     workflow_metrics,
     workflow_scanner,
@@ -736,6 +737,7 @@ def create_app() -> FastAPI:
     app.include_router(copilot_governance.router, prefix=API_PREFIX)
     app.include_router(user_preferences.router, prefix=API_PREFIX)
     app.include_router(dashboard_config.router, prefix=API_PREFIX)
+    app.include_router(user_classification.router, prefix=API_PREFIX)
 
     return app
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -61,6 +61,7 @@ from app.models.system_health import SystemHealthEvent
 from app.models.team import Team, TeamMembership, TeamRoleAssignment
 from app.models.threat_intel import ThreatIntelDomain, ThreatIntelFeed, ThreatIntelIndicator
 from app.models.user import RbacRole, UserRoleAssignment
+from app.models.user_classification import UserClassification
 from app.models.workflow_finding import WorkflowFinding
 from app.models.workflow_scan_activity import WorkflowScanActivity
 
@@ -136,6 +137,7 @@ __all__ = [
     "Team",
     "TeamMembership",
     "TeamRoleAssignment",
+    "UserClassification",
     "UserRoleAssignment",
     "WorkflowFinding",
     "WorkflowScanActivity",

--- a/backend/app/models/user_classification.py
+++ b/backend/app/models/user_classification.py
@@ -1,0 +1,41 @@
+"""SQLAlchemy ORM model for user behavior classifications."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, Index, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.audit_event import Base
+
+
+class UserClassification(Base):
+    """Stores per-user behavioral persona classification results."""
+
+    __tablename__ = "user_classifications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_login: Mapped[str] = mapped_column(Text, nullable=False)
+    org: Mapped[str] = mapped_column(Text, nullable=False)
+    persona: Mapped[str] = mapped_column(String(30), nullable=False)
+    confidence_score: Mapped[float] = mapped_column(Float, nullable=False)
+    event_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    surfaces: Mapped[list[str]] = mapped_column(JSONB, nullable=False, server_default=text("'[]'"))
+    analysis_window_days: Mapped[int] = mapped_column(Integer, nullable=False, default=90)
+    classified_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+
+    __table_args__ = (
+        Index("idx_user_classifications_login_org", "user_login", "org"),
+        Index("idx_user_classifications_persona", "persona"),
+        Index("idx_user_classifications_classified_at", "classified_at"),
+    )

--- a/backend/app/routers/user_classification.py
+++ b/backend/app/routers/user_classification.py
@@ -1,0 +1,95 @@
+"""User behavior classification router.
+
+Provides endpoints for persona distribution summaries, paginated user
+classifications, and triggering manual classification runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import AuthenticatedUser, get_current_user, get_db
+from app.services import rbac_service
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/user-classification", tags=["user-classification"])
+
+
+async def _resolve_orgs(
+    db: AsyncSession,
+    current_user: AuthenticatedUser,
+) -> list[str]:
+    """Resolve RBAC-scoped orgs and raise 403 when the list is empty."""
+    scoped_orgs = await rbac_service.get_scoped_orgs(db, current_user)
+    if not scoped_orgs and current_user.scope_type != "global":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No org access",
+        )
+    return scoped_orgs
+
+
+@router.get("/summary", response_model=dict[str, Any])
+async def classification_summary(
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Return persona distribution summary for scoped orgs."""
+    from app.services.user_classification_service import get_classification_summary
+
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    return await get_classification_summary(db, scoped_orgs)
+
+
+@router.get("/users", response_model=dict[str, Any])
+async def list_classified_users(
+    persona: str | None = Query(default=None),
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1, le=200),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Return paginated user classifications with optional persona filter."""
+    from app.services.user_classification_service import get_user_classifications
+
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    return await get_user_classifications(
+        db, scoped_orgs, persona=persona, page=page, page_size=page_size
+    )
+
+
+@router.post("/run", response_model=dict[str, Any])
+async def trigger_classification_run(
+    window_days: int = Query(default=90, ge=1, le=365),
+    current_user: AuthenticatedUser = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Trigger a manual classification run for all scoped orgs."""
+    from app.services.user_classification_service import classify_users
+
+    scoped_orgs = await _resolve_orgs(db, current_user)
+    if not scoped_orgs:
+        return {"status": "ok", "orgs_processed": 0, "users_classified": 0}
+
+    total_classified = 0
+    for org in scoped_orgs:
+        count = await classify_users(db=db, org=org, window_days=window_days)
+        total_classified += count
+
+    logger.info(
+        "user_classification.manual_run",
+        actor=current_user.github_login,
+        orgs=len(scoped_orgs),
+        users_classified=total_classified,
+    )
+
+    return {
+        "status": "ok",
+        "orgs_processed": len(scoped_orgs),
+        "users_classified": total_classified,
+    }

--- a/backend/app/services/user_classification_service.py
+++ b/backend/app/services/user_classification_service.py
@@ -1,0 +1,419 @@
+"""User behavior classification engine.
+
+Classifies GitHub users into behavioral personas based on audit log activity
+patterns within a configurable analysis window.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = structlog.get_logger(__name__)
+
+# ─── Persona constants ────────────────────────────────────────────────────────
+
+PERSONA_POWER_USER = "Power User"
+PERSONA_WEB_UI_ONLY = "Web UI Only"
+PERSONA_IDE_ONLY = "IDE Only"
+PERSONA_API_CLI_ONLY = "API/CLI Only"
+PERSONA_COPILOT_ACTIVE = "Copilot Active"
+PERSONA_TRULY_DORMANT = "Truly Dormant"
+PERSONA_LIGHTLY_ACTIVE = "Lightly Active"
+PERSONA_ADMIN_ONLY = "Admin Only"
+PERSONA_CICD_BOT = "CI/CD Bot"
+
+ALL_PERSONAS = [
+    PERSONA_POWER_USER,
+    PERSONA_WEB_UI_ONLY,
+    PERSONA_IDE_ONLY,
+    PERSONA_API_CLI_ONLY,
+    PERSONA_COPILOT_ACTIVE,
+    PERSONA_TRULY_DORMANT,
+    PERSONA_LIGHTLY_ACTIVE,
+    PERSONA_ADMIN_ONLY,
+    PERSONA_CICD_BOT,
+]
+
+# ─── Surface classification helpers ──────────────────────────────────────────
+
+WEB_ACTIONS = {
+    "org.update_member",
+    "repo.create",
+    "repo.destroy",
+    "repo.access",
+    "team.add_member",
+    "team.remove_member",
+    "team.create",
+    "team.destroy",
+    "protected_branch.create",
+    "protected_branch.destroy",
+    "hook.create",
+    "hook.destroy",
+    "environment.create",
+}
+WEB_NAMESPACES = {
+    "repo",
+    "team",
+    "hook",
+    "protected_branch",
+    "environment",
+    "project",
+    "pages",
+    "discussion",
+    "issue",
+    "pull_request",
+}
+
+GIT_ACTIONS = {"git.clone", "git.push", "git.fetch"}
+
+API_NAMESPACES = {"api"}
+
+COPILOT_NAMESPACES = {"copilot"}
+
+ADMIN_NAMESPACES = {
+    "org",
+    "enterprise",
+    "business",
+    "billing",
+    "audit_log",
+    "integration_installation",
+    "oauth_application",
+}
+
+PASSIVE_ACTIONS = {"git.clone", "git.fetch", "repo.access"}
+
+CICD_ACTOR_PATTERNS = ("[bot]", "github-actions", "dependabot")
+
+
+def _classify_surface(action: str, namespace: str) -> str:
+    """Map an event action/namespace to a surface category."""
+    if namespace in COPILOT_NAMESPACES or action.startswith("copilot"):
+        return "copilot"
+    if action in GIT_ACTIONS:
+        return "git"
+    if namespace in API_NAMESPACES or action.startswith("api."):
+        return "api"
+    if namespace in WEB_NAMESPACES or action in WEB_ACTIONS:
+        return "web"
+    if namespace in ADMIN_NAMESPACES:
+        return "admin"
+    return "web"  # default fallback for unrecognized actions
+
+
+def classify_single_user(
+    *,
+    event_count: int,
+    surface_counts: dict[str, int],
+    is_bot: bool,
+    passive_count: int,
+) -> tuple[str, float, list[str]]:
+    """Classify a single user based on their activity metrics.
+
+    Returns (persona, confidence_score, surfaces).
+    """
+    if event_count == 0:
+        return PERSONA_TRULY_DORMANT, 1.0, []
+
+    active_surfaces = [s for s, c in surface_counts.items() if c > 0]
+    total = sum(surface_counts.values())
+
+    # CI/CD Bot — machine-like patterns
+    if is_bot or any(pattern in str(surface_counts) for pattern in CICD_ACTOR_PATTERNS):
+        cicd_count = surface_counts.get("api", 0) + surface_counts.get("git", 0)
+        if is_bot and cicd_count > 0:
+            confidence = min(0.95, 0.7 + (cicd_count / max(total, 1)) * 0.25)
+            return PERSONA_CICD_BOT, confidence, active_surfaces
+
+    # Lightly Active — very low event count, mostly passive
+    if event_count < 5 and passive_count == event_count:
+        return PERSONA_LIGHTLY_ACTIVE, 0.9, active_surfaces
+    if event_count < 5:
+        return PERSONA_LIGHTLY_ACTIVE, 0.75, active_surfaces
+
+    # Copilot Active — has copilot events
+    copilot_count = surface_counts.get("copilot", 0)
+    if copilot_count > 0:
+        confidence = min(0.95, 0.7 + (copilot_count / max(total, 1)) * 0.25)
+        return PERSONA_COPILOT_ACTIVE, confidence, active_surfaces
+
+    # Admin Only — actions concentrated in admin namespaces
+    admin_count = surface_counts.get("admin", 0)
+    non_admin = total - admin_count
+    if admin_count > 0 and non_admin == 0:
+        return PERSONA_ADMIN_ONLY, 0.95, active_surfaces
+    if admin_count > 0 and (admin_count / max(total, 1)) > 0.8:
+        confidence = min(0.9, 0.6 + (admin_count / max(total, 1)) * 0.3)
+        return PERSONA_ADMIN_ONLY, confidence, active_surfaces
+
+    # Power User — active across 3+ surfaces with high volume
+    non_admin_surfaces = [s for s in active_surfaces if s != "admin"]
+    if len(non_admin_surfaces) >= 3 and event_count >= 20:
+        confidence = min(0.95, 0.7 + (len(non_admin_surfaces) / 5) * 0.25)
+        return PERSONA_POWER_USER, confidence, active_surfaces
+
+    # Dominant surface classification
+    if total > 0:
+        dominant = max(surface_counts, key=lambda s: surface_counts.get(s, 0))
+        dominant_ratio = surface_counts.get(dominant, 0) / total
+
+        if dominant == "web" and dominant_ratio >= 0.6:
+            return PERSONA_WEB_UI_ONLY, min(0.95, 0.5 + dominant_ratio * 0.4), active_surfaces
+        if dominant == "git" and dominant_ratio >= 0.6:
+            return PERSONA_IDE_ONLY, min(0.95, 0.5 + dominant_ratio * 0.4), active_surfaces
+        if dominant == "api" and dominant_ratio >= 0.6:
+            return PERSONA_API_CLI_ONLY, min(0.95, 0.5 + dominant_ratio * 0.4), active_surfaces
+
+    # Power User fallback for multi-surface users
+    if len(non_admin_surfaces) >= 2 and event_count >= 10:
+        return PERSONA_POWER_USER, 0.6, active_surfaces
+
+    # Default to dominant surface or web
+    return PERSONA_WEB_UI_ONLY, 0.5, active_surfaces
+
+
+async def classify_users(
+    db: AsyncSession,
+    org: str,
+    window_days: int = 90,
+) -> int:
+    """Classify all users in an org by their audit log activity.
+
+    Returns the number of users classified.
+    """
+    now = datetime.now(UTC)
+    classified_count = 0
+
+    # Get all members of the org (actors with events + members with zero events)
+    result = await db.execute(
+        text("""
+            SELECT
+                actor,
+                COUNT(*) AS event_count,
+                BOOL_OR(actor_is_bot) AS is_bot,
+                COALESCE(
+                    jsonb_object_agg(
+                        COALESCE(namespace, 'unknown'),
+                        cnt
+                    ) FILTER (WHERE namespace IS NOT NULL),
+                    '{}'::jsonb
+                ) AS namespace_counts,
+                COALESCE(
+                    jsonb_object_agg(
+                        COALESCE(action, 'unknown'),
+                        action_cnt
+                    ) FILTER (WHERE action IS NOT NULL),
+                    '{}'::jsonb
+                ) AS action_counts,
+                COUNT(*) FILTER (
+                    WHERE action IN ('git.clone', 'git.fetch', 'repo.access')
+                ) AS passive_count
+            FROM (
+                SELECT
+                    actor,
+                    actor_is_bot,
+                    namespace,
+                    action,
+                    COUNT(*) OVER (PARTITION BY actor, namespace) AS cnt,
+                    COUNT(*) OVER (PARTITION BY actor, action) AS action_cnt
+                FROM events
+                WHERE org = :org
+                  AND created_at >= NOW() - MAKE_INTERVAL(days => :window_days)
+                  AND actor IS NOT NULL
+                  AND actor != ''
+            ) sub
+            GROUP BY actor
+        """),
+        {"org": org, "window_days": window_days},
+    )
+
+    rows = result.fetchall()
+
+    for row in rows:
+        actor = row[0]
+        event_count = int(row[1])
+        is_bot = bool(row[2])
+        namespace_counts: dict[str, int] = row[3] if isinstance(row[3], dict) else {}
+        action_counts: dict[str, int] = row[4] if isinstance(row[4], dict) else {}
+        passive_count = int(row[5])
+
+        # Build surface counts from namespace and action data
+        surface_counts: dict[str, int] = {}
+        for ns, count in namespace_counts.items():
+            surface = _classify_surface(ns, ns)
+            surface_counts[surface] = surface_counts.get(surface, 0) + int(count)
+
+        # Override with specific action-based classification
+        for action, count in action_counts.items():
+            ns = action.split(".")[0] if "." in action else action
+            surface = _classify_surface(action, ns)
+            # Don't double-count; use action-level for specific git/api actions
+            if action in GIT_ACTIONS or ns in API_NAMESPACES or ns in COPILOT_NAMESPACES:
+                surface_counts[surface] = max(surface_counts.get(surface, 0), int(count))
+
+        persona, confidence, surfaces = classify_single_user(
+            event_count=event_count,
+            surface_counts=surface_counts,
+            is_bot=is_bot,
+            passive_count=passive_count,
+        )
+
+        # Upsert classification
+        await db.execute(
+            text("""
+                INSERT INTO user_classifications
+                    (user_login, org, persona, confidence_score, event_count,
+                     surfaces, analysis_window_days, classified_at, updated_at)
+                VALUES
+                    (:user_login, :org, :persona, :confidence_score, :event_count,
+                     :surfaces, :window_days, :classified_at, :classified_at)
+                ON CONFLICT (user_login, org)
+                    WHERE user_login = :user_login AND org = :org
+                DO UPDATE SET
+                    persona = EXCLUDED.persona,
+                    confidence_score = EXCLUDED.confidence_score,
+                    event_count = EXCLUDED.event_count,
+                    surfaces = EXCLUDED.surfaces,
+                    analysis_window_days = EXCLUDED.analysis_window_days,
+                    classified_at = EXCLUDED.classified_at,
+                    updated_at = EXCLUDED.classified_at
+            """),
+            {
+                "user_login": actor,
+                "org": org,
+                "persona": persona,
+                "confidence_score": confidence,
+                "event_count": event_count,
+                "surfaces": surfaces,
+                "window_days": window_days,
+                "classified_at": now,
+            },
+        )
+        classified_count += 1
+
+    logger.info(
+        "user_classification.classify_complete",
+        org=org,
+        classified_count=classified_count,
+        window_days=window_days,
+    )
+    return classified_count
+
+
+async def get_classification_summary(
+    db: AsyncSession,
+    scoped_orgs: list[str],
+) -> dict[str, Any]:
+    """Return aggregate persona breakdown for the given orgs."""
+    result = await db.execute(
+        text("""
+            SELECT
+                persona,
+                COUNT(*) AS user_count,
+                AVG(confidence_score) AS avg_confidence,
+                SUM(event_count) AS total_events
+            FROM user_classifications
+            WHERE org = ANY(:orgs)
+            GROUP BY persona
+            ORDER BY user_count DESC
+        """),
+        {"orgs": scoped_orgs},
+    )
+
+    personas: list[dict[str, Any]] = []
+    total_users = 0
+    dormant_count = 0
+    power_user_count = 0
+
+    for row in result.fetchall():
+        count = int(row[1])
+        total_users += count
+        if row[0] == PERSONA_TRULY_DORMANT:
+            dormant_count = count
+        if row[0] == PERSONA_POWER_USER:
+            power_user_count = count
+        personas.append(
+            {
+                "persona": row[0],
+                "user_count": count,
+                "avg_confidence": round(float(row[2]), 3),
+                "total_events": int(row[3]),
+            }
+        )
+
+    return {
+        "personas": personas,
+        "total_users": total_users,
+        "dormant_count": dormant_count,
+        "dormant_pct": round(dormant_count / max(total_users, 1) * 100, 1),
+        "power_user_count": power_user_count,
+        "power_user_pct": round(power_user_count / max(total_users, 1) * 100, 1),
+    }
+
+
+async def get_user_classifications(
+    db: AsyncSession,
+    scoped_orgs: list[str],
+    persona: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> dict[str, Any]:
+    """Return paginated user classifications with optional persona filter."""
+    offset = (page - 1) * page_size
+
+    # Build count query
+    count_params: dict[str, Any] = {"orgs": scoped_orgs}
+    count_sql = """
+        SELECT COUNT(*) FROM user_classifications
+        WHERE org = ANY(:orgs)
+    """
+    if persona:
+        count_sql += " AND persona = :persona"
+        count_params["persona"] = persona
+
+    count_result = await db.execute(text(count_sql), count_params)
+    total = count_result.scalar() or 0
+
+    # Build data query
+    data_params: dict[str, Any] = {
+        "orgs": scoped_orgs,
+        "limit": page_size,
+        "offset": offset,
+    }
+    data_sql = """
+        SELECT id, user_login, org, persona, confidence_score,
+               event_count, surfaces, analysis_window_days, classified_at
+        FROM user_classifications
+        WHERE org = ANY(:orgs)
+    """
+    if persona:
+        data_sql += " AND persona = :persona"
+        data_params["persona"] = persona
+    data_sql += " ORDER BY event_count DESC, user_login ASC LIMIT :limit OFFSET :offset"
+
+    data_result = await db.execute(text(data_sql), data_params)
+    users = [
+        {
+            "id": row[0],
+            "user_login": row[1],
+            "org": row[2],
+            "persona": row[3],
+            "confidence_score": round(float(row[4]), 3),
+            "event_count": int(row[5]),
+            "surfaces": row[6] if isinstance(row[6], list) else [],
+            "analysis_window_days": int(row[7]),
+            "classified_at": row[8].isoformat() if row[8] else None,
+        }
+        for row in data_result.fetchall()
+    ]
+
+    return {
+        "users": users,
+        "total": int(total),
+        "page": page,
+        "page_size": page_size,
+    }

--- a/backend/app/workers/user_classification_worker.py
+++ b/backend/app/workers/user_classification_worker.py
@@ -1,0 +1,80 @@
+"""Celery worker: daily user behavior classification.
+
+Classifies users across all active orgs into behavioral personas based on
+audit log event patterns.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+
+import structlog
+from celery import Task
+
+from app.celery_app import celery_app
+from app.database import AsyncSessionLocal
+
+logger = structlog.get_logger(__name__)
+
+
+@celery_app.task(
+    name="app.workers.user_classification_worker.classify_all_orgs",
+    bind=True,
+    max_retries=2,
+)
+def classify_all_orgs(self: Task) -> dict[str, object]:
+    """Celery beat task: classify users for all orgs with recent activity."""
+    try:
+        result = asyncio.run(_classify_all())
+        return {
+            "status": "ok",
+            "orgs_processed": result["orgs"],
+            "users_classified": result["users"],
+        }
+    except Exception as exc:
+        logger.error("user_classification_worker.task_failed", error=str(exc))
+        backoff = min(30 * (2**self.request.retries), 600)
+        jitter = secrets.randbelow(max(int(backoff * 0.1), 1))
+        raise self.retry(exc=exc, countdown=backoff + jitter) from exc
+
+
+async def _classify_all() -> dict[str, int]:
+    """Classify users for all orgs that have recent events."""
+    from sqlalchemy import text
+
+    from app.services.user_classification_service import classify_users
+
+    total_users = 0
+    total_orgs = 0
+
+    async with AsyncSessionLocal() as session:
+        try:
+            # Get distinct orgs with recent activity
+            orgs_result = await session.execute(
+                text("""
+                    SELECT DISTINCT org
+                    FROM events
+                    WHERE org IS NOT NULL
+                      AND created_at >= NOW() - INTERVAL '90 days'
+                    LIMIT 500
+                """)
+            )
+            orgs = [row[0] for row in orgs_result.fetchall()]
+
+            for org in orgs:
+                count = await classify_users(db=session, org=org, window_days=90)
+                total_users += count
+                total_orgs += 1
+
+            await session.commit()
+            logger.info(
+                "user_classification_worker.complete",
+                orgs_processed=total_orgs,
+                users_classified=total_users,
+            )
+        except Exception:
+            await session.rollback()
+            raise
+
+    return {"orgs": total_orgs, "users": total_users}

--- a/backend/tests/test_user_classification_model.py
+++ b/backend/tests/test_user_classification_model.py
@@ -1,0 +1,47 @@
+"""Tests for the UserClassification model."""
+
+from __future__ import annotations
+
+from app.models.user_classification import UserClassification
+
+
+class TestUserClassificationModel:
+    """Validate ORM model metadata."""
+
+    def test_tablename(self) -> None:
+        assert UserClassification.__tablename__ == "user_classifications"
+
+    def test_columns_present(self) -> None:
+        column_names = {c.name for c in UserClassification.__table__.columns}
+        expected = {
+            "id",
+            "user_login",
+            "org",
+            "persona",
+            "confidence_score",
+            "event_count",
+            "surfaces",
+            "analysis_window_days",
+            "classified_at",
+            "created_at",
+            "updated_at",
+        }
+        assert expected.issubset(column_names)
+
+    def test_primary_key(self) -> None:
+        pk_cols = [c.name for c in UserClassification.__table__.primary_key.columns]
+        assert pk_cols == ["id"]
+
+    def test_indexes_exist(self) -> None:
+        index_names = {idx.name for idx in UserClassification.__table__.indexes}
+        assert "idx_user_classifications_login_org" in index_names
+        assert "idx_user_classifications_persona" in index_names
+        assert "idx_user_classifications_classified_at" in index_names
+
+    def test_persona_column_length(self) -> None:
+        persona_col = UserClassification.__table__.columns["persona"]
+        assert persona_col.type.length == 30
+
+    def test_confidence_score_is_float(self) -> None:
+        col = UserClassification.__table__.columns["confidence_score"]
+        assert not col.nullable

--- a/backend/tests/test_user_classification_router.py
+++ b/backend/tests/test_user_classification_router.py
@@ -1,0 +1,302 @@
+"""Tests for the user_classification router.
+
+Tests cover:
+- Unauthenticated requests → 401
+- Authenticated request returns 200 with correct schema
+- RBAC scope enforcement (403 when no orgs)
+- Persona filter parameter
+- Manual classification run trigger
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import jwt as pyjwt
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.deps import get_db, get_valkey
+from app.routers import user_classification as uc_module
+
+SECRET = "testsecretkey_for_unit_tests_only_32ch"
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_jwt(sub: str = "testuser", jti: str = "uc-jti") -> str:
+    now = datetime.now(UTC)
+    payload = {
+        "sub": sub,
+        "github_id": 12345,
+        "jti": jti,
+        "exp": now + timedelta(hours=1),
+        "iat": now,
+    }
+    return pyjwt.encode(payload, SECRET, algorithm="HS256")
+
+
+def _make_session(
+    orgs: list[str] | None = None,
+    roles: list[str] | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "github_login": "testuser",
+            "github_id": 12345,
+            "roles": roles or ["analyst"],
+            "scoped_orgs": orgs or ["my-org"],
+            "scoped_repos": [],
+            "scope_type": "scoped",
+            "session_expires_at": "2099-01-01T00:00:00+00:00",
+        }
+    )
+
+
+def _make_mock_db() -> AsyncMock:
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.fetchall.return_value = []
+    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalar.return_value = 0
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=mock_result)
+    return db
+
+
+def _build_app(
+    valkey_session: str | None = None,
+) -> tuple[FastAPI, AsyncMock, AsyncMock]:
+    app = FastAPI()
+    app.include_router(uc_module.router, prefix="/api/v1")
+
+    mock_db = _make_mock_db()
+    mock_valkey = AsyncMock()
+    mock_valkey.get = AsyncMock(return_value=valkey_session)
+    mock_valkey.exists = AsyncMock(return_value=1 if valkey_session else 0)
+
+    async def override_db():
+        yield mock_db
+
+    async def override_valkey():
+        return mock_valkey
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_valkey] = override_valkey
+
+    return app, mock_db, mock_valkey
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+class TestSummaryEndpoint:
+    """Tests for GET /user-classification/summary."""
+
+    def test_unauthenticated_returns_401(self) -> None:
+        app, _, _ = _build_app()
+        client = TestClient(app)
+        resp = client.get("/api/v1/user-classification/summary")
+        assert resp.status_code == 401
+
+    @patch("app.services.rbac_service.get_scoped_orgs", new_callable=AsyncMock)
+    @patch(
+        "app.services.user_classification_service.get_classification_summary",
+        new_callable=AsyncMock,
+    )
+    def test_authenticated_returns_200(
+        self,
+        mock_get_summary: AsyncMock,
+        mock_scoped_orgs: AsyncMock,
+    ) -> None:
+        session_data = _make_session()
+        app, _, _ = _build_app(valkey_session=session_data)
+        client = TestClient(app)
+
+        mock_scoped_orgs.return_value = ["my-org"]
+        mock_get_summary.return_value = {
+            "personas": [
+                {
+                    "persona": "Power User",
+                    "user_count": 5,
+                    "avg_confidence": 0.85,
+                    "total_events": 500,
+                }
+            ],
+            "total_users": 5,
+            "dormant_count": 0,
+            "dormant_pct": 0.0,
+            "power_user_count": 5,
+            "power_user_pct": 100.0,
+        }
+
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/user-classification/summary",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "personas" in data
+        assert "total_users" in data
+
+
+class TestUsersEndpoint:
+    """Tests for GET /user-classification/users."""
+
+    def test_unauthenticated_returns_401(self) -> None:
+        app, _, _ = _build_app()
+        client = TestClient(app)
+        resp = client.get("/api/v1/user-classification/users")
+        assert resp.status_code == 401
+
+    @patch("app.services.rbac_service.get_scoped_orgs", new_callable=AsyncMock)
+    @patch(
+        "app.services.user_classification_service.get_user_classifications",
+        new_callable=AsyncMock,
+    )
+    def test_authenticated_returns_paginated_users(
+        self,
+        mock_get_users: AsyncMock,
+        mock_scoped_orgs: AsyncMock,
+    ) -> None:
+        session_data = _make_session()
+        app, _, _ = _build_app(valkey_session=session_data)
+        client = TestClient(app)
+
+        mock_scoped_orgs.return_value = ["my-org"]
+        mock_get_users.return_value = {
+            "users": [
+                {
+                    "id": 1,
+                    "user_login": "octocat",
+                    "org": "my-org",
+                    "persona": "Power User",
+                    "confidence_score": 0.85,
+                    "event_count": 100,
+                    "surfaces": ["web", "git", "api"],
+                    "analysis_window_days": 90,
+                    "classified_at": "2025-01-01T00:00:00+00:00",
+                }
+            ],
+            "total": 1,
+            "page": 1,
+            "page_size": 50,
+        }
+
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/user-classification/users",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "users" in data
+        assert "total" in data
+        assert data["page"] == 1
+
+    @patch("app.services.rbac_service.get_scoped_orgs", new_callable=AsyncMock)
+    @patch(
+        "app.services.user_classification_service.get_user_classifications",
+        new_callable=AsyncMock,
+    )
+    def test_persona_filter_passed(
+        self,
+        mock_get_users: AsyncMock,
+        mock_scoped_orgs: AsyncMock,
+    ) -> None:
+        session_data = _make_session()
+        app, _, _ = _build_app(valkey_session=session_data)
+        client = TestClient(app)
+
+        mock_scoped_orgs.return_value = ["my-org"]
+        mock_get_users.return_value = {
+            "users": [],
+            "total": 0,
+            "page": 1,
+            "page_size": 50,
+        }
+
+        token = _make_jwt()
+        resp = client.get(
+            "/api/v1/user-classification/users?persona=Power+User",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        # Verify the filter was passed through
+        mock_get_users.assert_called_once()
+        call_kwargs = mock_get_users.call_args
+        assert call_kwargs[1].get("persona") == "Power User" or (
+            len(call_kwargs[0]) >= 3 and call_kwargs[0][2] == "Power User"
+        )
+
+
+class TestRunEndpoint:
+    """Tests for POST /user-classification/run."""
+
+    def test_unauthenticated_returns_401(self) -> None:
+        app, _, _ = _build_app()
+        client = TestClient(app)
+        resp = client.post("/api/v1/user-classification/run")
+        assert resp.status_code == 401
+
+    @patch("app.services.rbac_service.get_scoped_orgs", new_callable=AsyncMock)
+    @patch(
+        "app.services.user_classification_service.classify_users",
+        new_callable=AsyncMock,
+    )
+    def test_manual_run_returns_ok(
+        self,
+        mock_classify: AsyncMock,
+        mock_scoped_orgs: AsyncMock,
+    ) -> None:
+        session_data = _make_session()
+        app, _, _ = _build_app(valkey_session=session_data)
+        client = TestClient(app)
+
+        mock_scoped_orgs.return_value = ["my-org"]
+        mock_classify.return_value = 10
+
+        token = _make_jwt()
+        resp = client.post(
+            "/api/v1/user-classification/run",
+            cookies={"access_token": token},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["users_classified"] == 10
+        assert data["orgs_processed"] == 1
+
+    @patch("app.services.rbac_service.get_scoped_orgs", new_callable=AsyncMock)
+    def test_no_orgs_returns_empty(
+        self,
+        mock_scoped_orgs: AsyncMock,
+    ) -> None:
+        session_data = _make_session()
+        app, _, _ = _build_app(valkey_session=session_data)
+        client = TestClient(app)
+
+        mock_scoped_orgs.return_value = []
+
+        token = _make_jwt()
+        resp = client.post(
+            "/api/v1/user-classification/run",
+            cookies={"access_token": token},
+        )
+        # global scope_type or empty list → depends on scope_type
+        # With scoped and empty orgs → 403
+        assert resp.status_code in (200, 403)
+
+
+class TestRouterMetadata:
+    """Verify router configuration."""
+
+    def test_router_prefix(self) -> None:
+        assert uc_module.router.prefix == "/user-classification"
+
+    def test_router_tags(self) -> None:
+        assert "user-classification" in uc_module.router.tags

--- a/backend/tests/test_user_classification_service.py
+++ b/backend/tests/test_user_classification_service.py
@@ -1,0 +1,226 @@
+"""Tests for user_classification_service.classify_single_user logic."""
+
+from __future__ import annotations
+
+from app.services.user_classification_service import (
+    ALL_PERSONAS,
+    PERSONA_ADMIN_ONLY,
+    PERSONA_API_CLI_ONLY,
+    PERSONA_CICD_BOT,
+    PERSONA_COPILOT_ACTIVE,
+    PERSONA_IDE_ONLY,
+    PERSONA_LIGHTLY_ACTIVE,
+    PERSONA_POWER_USER,
+    PERSONA_TRULY_DORMANT,
+    PERSONA_WEB_UI_ONLY,
+    classify_single_user,
+)
+
+
+class TestClassifySingleUser:
+    """Unit tests for the pure classification function."""
+
+    def test_zero_events_is_truly_dormant(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=0,
+            surface_counts={},
+            is_bot=False,
+            passive_count=0,
+        )
+        assert persona == PERSONA_TRULY_DORMANT
+        assert confidence == 1.0
+        assert surfaces == []
+
+    def test_low_passive_only_is_lightly_active(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=3,
+            surface_counts={"git": 3},
+            is_bot=False,
+            passive_count=3,
+        )
+        assert persona == PERSONA_LIGHTLY_ACTIVE
+        assert confidence == 0.9
+
+    def test_low_events_mixed_is_lightly_active(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=4,
+            surface_counts={"web": 2, "git": 2},
+            is_bot=False,
+            passive_count=1,
+        )
+        assert persona == PERSONA_LIGHTLY_ACTIVE
+        assert confidence == 0.75
+
+    def test_bot_with_activity_is_cicd_bot(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=100,
+            surface_counts={"api": 80, "git": 20},
+            is_bot=True,
+            passive_count=5,
+        )
+        assert persona == PERSONA_CICD_BOT
+        assert 0.7 <= confidence <= 0.95
+
+    def test_copilot_events_detected(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=50,
+            surface_counts={"web": 30, "copilot": 20},
+            is_bot=False,
+            passive_count=0,
+        )
+        assert persona == PERSONA_COPILOT_ACTIVE
+        assert 0.7 <= confidence <= 0.95
+
+    def test_admin_only_pure(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=20,
+            surface_counts={"admin": 20},
+            is_bot=False,
+            passive_count=0,
+        )
+        assert persona == PERSONA_ADMIN_ONLY
+        assert confidence == 0.95
+
+    def test_admin_mostly(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=100,
+            surface_counts={"admin": 85, "web": 15},
+            is_bot=False,
+            passive_count=0,
+        )
+        assert persona == PERSONA_ADMIN_ONLY
+
+    def test_power_user_multi_surface(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=100,
+            surface_counts={"web": 40, "git": 30, "api": 30},
+            is_bot=False,
+            passive_count=5,
+        )
+        assert persona == PERSONA_POWER_USER
+        assert 0.7 <= confidence <= 0.95
+
+    def test_web_ui_dominant(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=50,
+            surface_counts={"web": 45, "git": 5},
+            is_bot=False,
+            passive_count=2,
+        )
+        assert persona == PERSONA_WEB_UI_ONLY
+
+    def test_ide_dominant(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=50,
+            surface_counts={"git": 45, "web": 5},
+            is_bot=False,
+            passive_count=2,
+        )
+        assert persona == PERSONA_IDE_ONLY
+
+    def test_api_cli_dominant(self) -> None:
+        persona, confidence, surfaces = classify_single_user(
+            event_count=50,
+            surface_counts={"api": 45, "web": 5},
+            is_bot=False,
+            passive_count=2,
+        )
+        assert persona == PERSONA_API_CLI_ONLY
+
+    def test_confidence_always_between_0_and_1(self) -> None:
+        """Verify confidence is always in [0, 1] for various inputs."""
+        test_cases = [
+            {
+                "event_count": 0,
+                "surface_counts": {},
+                "is_bot": False,
+                "passive_count": 0,
+            },
+            {
+                "event_count": 1000,
+                "surface_counts": {"web": 500, "git": 300, "api": 200},
+                "is_bot": False,
+                "passive_count": 10,
+            },
+            {
+                "event_count": 1,
+                "surface_counts": {"web": 1},
+                "is_bot": True,
+                "passive_count": 1,
+            },
+            {
+                "event_count": 500,
+                "surface_counts": {"admin": 500},
+                "is_bot": False,
+                "passive_count": 0,
+            },
+        ]
+        for kwargs in test_cases:
+            _, confidence, _ = classify_single_user(**kwargs)
+            assert 0.0 <= confidence <= 1.0, f"Confidence {confidence} out of range for {kwargs}"
+
+    def test_all_personas_constant_list(self) -> None:
+        assert len(ALL_PERSONAS) == 9
+
+    def test_surfaces_returned_correctly(self) -> None:
+        _, _, surfaces = classify_single_user(
+            event_count=100,
+            surface_counts={"web": 40, "git": 30, "api": 30},
+            is_bot=False,
+            passive_count=5,
+        )
+        assert set(surfaces) == {"web", "git", "api"}
+
+    def test_bot_no_cicd_events_still_classified(self) -> None:
+        """Bot with no api/git events should not be CI/CD bot."""
+        persona, _, _ = classify_single_user(
+            event_count=10,
+            surface_counts={"web": 10},
+            is_bot=True,
+            passive_count=0,
+        )
+        # Bot but only web actions — shouldn't be CI/CD bot
+        assert persona != PERSONA_CICD_BOT
+
+    def test_power_user_fallback_two_surfaces(self) -> None:
+        persona, confidence, _ = classify_single_user(
+            event_count=30,
+            surface_counts={"web": 15, "git": 15},
+            is_bot=False,
+            passive_count=2,
+        )
+        assert persona == PERSONA_POWER_USER
+        assert confidence == 0.6
+
+
+class TestClassifySingleUserEdgeCases:
+    """Edge cases for classification logic."""
+
+    def test_single_event_passive(self) -> None:
+        persona, _, _ = classify_single_user(
+            event_count=1,
+            surface_counts={"git": 1},
+            is_bot=False,
+            passive_count=1,
+        )
+        assert persona == PERSONA_LIGHTLY_ACTIVE
+
+    def test_exactly_five_events_not_lightly_active(self) -> None:
+        """5 events should not be Lightly Active (threshold is <5)."""
+        persona, _, _ = classify_single_user(
+            event_count=5,
+            surface_counts={"web": 5},
+            is_bot=False,
+            passive_count=0,
+        )
+        assert persona != PERSONA_LIGHTLY_ACTIVE
+
+    def test_copilot_takes_priority_over_power_user(self) -> None:
+        """If copilot events exist, Copilot Active should be assigned even with 3+ surfaces."""
+        persona, _, _ = classify_single_user(
+            event_count=100,
+            surface_counts={"web": 30, "git": 30, "api": 20, "copilot": 20},
+            is_bot=False,
+            passive_count=0,
+        )
+        assert persona == PERSONA_COPILOT_ACTIVE

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { AdvancedSecurityPage } from './pages/AdvancedSecurity';
 import { PlaybooksPage } from './pages/Playbooks';
 import { SupplyChainPage } from './pages/SupplyChain';
 import { PackagesPage } from './pages/Packages';
+import { UserBehaviorPage } from './pages/UserBehavior';
 import { ThreatIntelPage } from './pages/ThreatIntel';
 import { SyncStatusPage } from './pages/SyncStatus';
 import { NotificationsPage } from './pages/Notifications';
@@ -73,6 +74,7 @@ export const router = createBrowserRouter([
       { path: '/playbooks', element: <PlaybooksPage /> },
       { path: '/velocity', element: <VelocityPage /> },
       { path: '/devactivity', element: <DevActivityPage /> },
+      { path: '/user-behavior', element: <UserBehaviorPage /> },
       { path: '/copilot', element: <Navigate to="/copilot/overview" replace /> },
       { path: '/copilot/:tab', element: <CopilotPage /> },
       { path: '/health', element: <Navigate to="/health/repos" replace /> },

--- a/frontend/src/api/userClassification.ts
+++ b/frontend/src/api/userClassification.ts
@@ -1,0 +1,74 @@
+import { api } from './client';
+
+/** A single persona bucket in the summary response. */
+export interface PersonaSummary {
+  persona: string;
+  user_count: number;
+  avg_confidence: number;
+  total_events: number;
+}
+
+/** Summary response from GET /user-classification/summary. */
+export interface ClassificationSummaryResponse {
+  personas: PersonaSummary[];
+  total_users: number;
+  dormant_count: number;
+  dormant_pct: number;
+  power_user_count: number;
+  power_user_pct: number;
+}
+
+/** A single classified user record. */
+export interface ClassifiedUser {
+  id: number;
+  user_login: string;
+  org: string;
+  persona: string;
+  confidence_score: number;
+  event_count: number;
+  surfaces: string[];
+  analysis_window_days: number;
+  classified_at: string | null;
+}
+
+/** Paginated user list from GET /user-classification/users. */
+export interface ClassifiedUsersResponse {
+  users: ClassifiedUser[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+/** Response from POST /user-classification/run. */
+export interface ClassificationRunResponse {
+  status: string;
+  orgs_processed: number;
+  users_classified: number;
+}
+
+/** Fetch the persona distribution summary. */
+export function getClassificationSummary(): Promise<ClassificationSummaryResponse> {
+  return api.get<ClassificationSummaryResponse>('/user-classification/summary');
+}
+
+/** Fetch paginated classified users with optional filters. */
+export function getClassifiedUsers(params?: {
+  persona?: string;
+  page?: number;
+  page_size?: number;
+}): Promise<ClassifiedUsersResponse> {
+  const queryParams: Record<string, string | number> = {};
+  if (params?.persona) queryParams.persona = params.persona;
+  if (params?.page) queryParams.page = params.page;
+  if (params?.page_size) queryParams.page_size = params.page_size;
+  return api.get<ClassifiedUsersResponse>('/user-classification/users', queryParams);
+}
+
+/** Trigger a manual classification run. */
+export function triggerClassificationRun(windowDays?: number): Promise<ClassificationRunResponse> {
+  const params: Record<string, number> = {};
+  if (windowDays !== undefined) params.window_days = windowDays;
+  return api.post<ClassificationRunResponse>(
+    `/user-classification/run${Object.keys(params).length ? `?window_days=${params.window_days}` : ''}`,
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -420,6 +420,19 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
             Developer Activity
           </NavItem>
         )}
+        {hasPermission('events', 'view') && (
+          <NavItem
+            to="/user-behavior"
+            onClick={onMobileClose}
+            icon={
+              <svg width="16" height="16" fill="currentColor" viewBox="0 0 16 16">
+                <path d="M1.5 14.25c0 .138.112.25.25.25H7v-1.5H2.5v-2.25a.25.25 0 01.25-.25h2.5a.75.75 0 000-1.5h-2.5A1.75 1.75 0 001 10.75v2.75c0 .414.336.75.75.75zM9 14.5h4.25a.25.25 0 00.25-.25v-2.75a1.75 1.75 0 00-1.75-1.75h-2.5a.75.75 0 000 1.5h2.5a.25.25 0 01.25.25v2.25H9zM8 9a3 3 0 100-6 3 3 0 000 6zM8 4.5a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM3.5 6.5a2 2 0 100-4 2 2 0 000 4zm0-2.75a.75.75 0 110 1.5.75.75 0 010-1.5zM12.5 6.5a2 2 0 100-4 2 2 0 000 4zm0-2.75a.75.75 0 110 1.5.75.75 0 010-1.5z" />
+              </svg>
+            }
+          >
+            User Behavior
+          </NavItem>
+        )}
         {features.copilot_insights && hasPermission('events', 'view') && (
           <NavItem
             to="/copilot"

--- a/frontend/src/pages/UserBehavior/UserBehavior.module.css
+++ b/frontend/src/pages/UserBehavior/UserBehavior.module.css
@@ -1,0 +1,133 @@
+.page {
+  padding: 24px;
+}
+
+.metricsRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.metricCard {
+  padding: 16px;
+  background: var(--bg-secondary, #161b22);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.metricValue {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--fg);
+  line-height: 1.2;
+}
+
+.metricLabel {
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-top: 4px;
+}
+
+.chartUserRow {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+@media (max-width: 900px) {
+  .chartUserRow {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chartCard {
+  padding: 16px;
+  background: var(--bg-secondary, #161b22);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.chartTitle {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 12px;
+}
+
+.tableCard {
+  padding: 16px;
+  background: var(--bg-secondary, #161b22);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.filterRow {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.filterSelect {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.filterSelect:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.surfaceList {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.surfaceTag {
+  display: inline-block;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+}
+
+.pagination {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 16px;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+.paginationBtn {
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.paginationBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.paginationBtn:hover:not(:disabled) {
+  background: var(--bg-secondary, #161b22);
+}

--- a/frontend/src/pages/UserBehavior/UserBehavior.test.tsx
+++ b/frontend/src/pages/UserBehavior/UserBehavior.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/utils';
+import { UserBehaviorPage } from './index';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('echarts-for-react', () => ({
+  __esModule: true,
+  default: () => <div data-testid="echarts-mock">Chart</div>,
+}));
+
+const mockSummary = {
+  personas: [
+    { persona: 'Power User', user_count: 10, avg_confidence: 0.85, total_events: 5000 },
+    { persona: 'Web UI Only', user_count: 20, avg_confidence: 0.8, total_events: 2000 },
+    { persona: 'Truly Dormant', user_count: 15, avg_confidence: 1.0, total_events: 0 },
+  ],
+  total_users: 45,
+  dormant_count: 15,
+  dormant_pct: 33.3,
+  power_user_count: 10,
+  power_user_pct: 22.2,
+};
+
+const mockUsers = {
+  users: [
+    {
+      id: 1,
+      user_login: 'octocat',
+      org: 'my-org',
+      persona: 'Power User',
+      confidence_score: 0.85,
+      event_count: 500,
+      surfaces: ['web', 'git', 'api'],
+      analysis_window_days: 90,
+      classified_at: '2025-01-01T00:00:00+00:00',
+    },
+    {
+      id: 2,
+      user_login: 'dormant-user',
+      org: 'my-org',
+      persona: 'Truly Dormant',
+      confidence_score: 1.0,
+      event_count: 0,
+      surfaces: [],
+      analysis_window_days: 90,
+      classified_at: '2025-01-01T00:00:00+00:00',
+    },
+  ],
+  total: 2,
+  page: 1,
+  page_size: 50,
+};
+
+const mockRun = { status: 'ok', orgs_processed: 1, users_classified: 45 };
+
+vi.mock('../../api/userClassification', () => ({
+  getClassificationSummary: vi.fn(() => Promise.resolve(mockSummary)),
+  getClassifiedUsers: vi.fn(() => Promise.resolve(mockUsers)),
+  triggerClassificationRun: vi.fn(() => Promise.resolve(mockRun)),
+}));
+
+vi.mock('../../hooks/useHelp', () => ({
+  useHelp: () => ({ isOpen: false, toggle: vi.fn(), helpKey: null }),
+  HelpProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UserBehaviorPage', () => {
+  it('renders page title and description', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByText('User Behavior')).toBeInTheDocument();
+    expect(screen.getByText(/Classify users by audit log activity/)).toBeInTheDocument();
+  });
+
+  it('displays key metrics after loading', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByTestId('total-users')).toHaveTextContent('45');
+    expect(screen.getByTestId('dormant-pct')).toHaveTextContent('33.3%');
+    expect(screen.getByTestId('power-user-pct')).toHaveTextContent('22.2%');
+  });
+
+  it('renders the donut chart', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByTestId('echarts-mock')).toBeInTheDocument();
+  });
+
+  it('renders user table with classified users', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByText('octocat')).toBeInTheDocument();
+    expect(screen.getByText('dormant-user')).toBeInTheDocument();
+  });
+
+  it('renders persona badges in table', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByText('Power User')).toBeInTheDocument();
+    expect(screen.getByText('Truly Dormant')).toBeInTheDocument();
+  });
+
+  it('has a persona filter dropdown', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    const select = await screen.findByLabelText(/Filter by persona/i);
+    expect(select).toBeInTheDocument();
+    expect(select).toHaveValue('');
+  });
+
+  it('has a Run Classification button', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByText('Run Classification')).toBeInTheDocument();
+  });
+
+  it('renders surface tags for users', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByText('web')).toBeInTheDocument();
+    expect(screen.getByText('git')).toBeInTheDocument();
+    expect(screen.getByText('api')).toBeInTheDocument();
+  });
+
+  it('persona filter changes trigger new query', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<UserBehaviorPage />);
+
+    const select = await screen.findByLabelText(/Filter by persona/i);
+    await user.selectOptions(select, 'Power User');
+    expect(select).toHaveValue('Power User');
+  });
+
+  it('shows Persona Distribution chart title', async () => {
+    renderWithProviders(<UserBehaviorPage />);
+    expect(await screen.findByText('Persona Distribution')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/UserBehavior/index.tsx
+++ b/frontend/src/pages/UserBehavior/index.tsx
@@ -1,0 +1,328 @@
+import { useState, useMemo } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import ReactECharts from 'echarts-for-react';
+import {
+  getClassificationSummary,
+  getClassifiedUsers,
+  triggerClassificationRun,
+} from '../../api/userClassification';
+import type { ClassifiedUser } from '../../api/userClassification';
+import { PageHeader } from '../../components/common/PageHeader';
+import { SkeletonCard } from '../../components/common/SkeletonCard';
+import { DataTable } from '../../components/primitives/DataTable';
+import type { ColumnDef } from '../../components/primitives/DataTable';
+import { Label } from '../../components/primitives/Label';
+import styles from './UserBehavior.module.css';
+
+const PERSONA_COLORS: Record<string, string> = {
+  'Power User': '#bc8cff',
+  'Web UI Only': '#58a6ff',
+  'IDE Only': '#3fb950',
+  'API/CLI Only': '#d29922',
+  'Copilot Active': '#f778ba',
+  'Truly Dormant': '#484f58',
+  'Lightly Active': '#8b949e',
+  'Admin Only': '#f0883e',
+  'CI/CD Bot': '#79c0ff',
+};
+
+const PERSONA_VARIANTS: Record<
+  string,
+  'danger' | 'attention' | 'success' | 'done' | 'muted' | 'accent' | 'severe'
+> = {
+  'Power User': 'accent',
+  'Web UI Only': 'success',
+  'IDE Only': 'success',
+  'API/CLI Only': 'attention',
+  'Copilot Active': 'accent',
+  'Truly Dormant': 'muted',
+  'Lightly Active': 'muted',
+  'Admin Only': 'severe',
+  'CI/CD Bot': 'done',
+};
+
+const ALL_PERSONAS = [
+  'Power User',
+  'Web UI Only',
+  'IDE Only',
+  'API/CLI Only',
+  'Copilot Active',
+  'Truly Dormant',
+  'Lightly Active',
+  'Admin Only',
+  'CI/CD Bot',
+];
+
+const PAGE_SIZE = 50;
+
+export function UserBehaviorPage() {
+  const queryClient = useQueryClient();
+  const [personaFilter, setPersonaFilter] = useState<string>('');
+  const [page, setPage] = useState(1);
+
+  const {
+    data: summary,
+    isLoading: summaryLoading,
+    error: summaryError,
+  } = useQuery({
+    queryKey: ['user-classification', 'summary'],
+    queryFn: getClassificationSummary,
+    staleTime: 60_000,
+  });
+
+  const {
+    data: usersData,
+    isLoading: usersLoading,
+    error: usersError,
+  } = useQuery({
+    queryKey: ['user-classification', 'users', personaFilter, page],
+    queryFn: () =>
+      getClassifiedUsers({
+        persona: personaFilter || undefined,
+        page,
+        page_size: PAGE_SIZE,
+      }),
+    staleTime: 30_000,
+  });
+
+  const runMutation = useMutation({
+    mutationFn: () => triggerClassificationRun(90),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-classification'] });
+    },
+  });
+
+  // Donut chart option
+  const chartOption = useMemo(() => {
+    if (!summary?.personas?.length) return null;
+    const data = summary.personas.map((p) => ({
+      name: p.persona,
+      value: p.user_count,
+    }));
+    const colors = summary.personas.map((p) => PERSONA_COLORS[p.persona] ?? '#8b949e');
+
+    return {
+      tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+      legend: {
+        orient: 'vertical' as const,
+        right: 10,
+        top: 'center',
+        textStyle: { color: '#8b949e', fontSize: 12 },
+      },
+      series: [
+        {
+          type: 'pie',
+          radius: ['50%', '75%'],
+          center: ['35%', '50%'],
+          avoidLabelOverlap: false,
+          label: { show: false },
+          data,
+          itemStyle: { borderRadius: 4, borderWidth: 2, borderColor: 'transparent' },
+          color: colors,
+        },
+      ],
+    };
+  }, [summary]);
+
+  // Table columns
+  const columns: ColumnDef<ClassifiedUser>[] = useMemo(
+    () => [
+      {
+        key: 'user_login',
+        header: 'User',
+        sortable: true,
+        filterable: true,
+        render: (row) => <strong>{row.user_login}</strong>,
+        sortValue: (row) => row.user_login,
+        filterValue: (row) => row.user_login,
+      },
+      {
+        key: 'org',
+        header: 'Org',
+        sortable: true,
+        filterable: true,
+        render: (row) => row.org,
+        sortValue: (row) => row.org,
+        filterValue: (row) => row.org,
+      },
+      {
+        key: 'persona',
+        header: 'Persona',
+        sortable: true,
+        render: (row) => (
+          <Label variant={PERSONA_VARIANTS[row.persona] ?? 'muted'}>{row.persona}</Label>
+        ),
+        sortValue: (row) => row.persona,
+      },
+      {
+        key: 'confidence_score',
+        header: 'Confidence',
+        sortable: true,
+        render: (row) => `${(row.confidence_score * 100).toFixed(0)}%`,
+        sortValue: (row) => row.confidence_score,
+        width: '100px',
+      },
+      {
+        key: 'event_count',
+        header: 'Events',
+        sortable: true,
+        render: (row) => row.event_count.toLocaleString(),
+        sortValue: (row) => row.event_count,
+        width: '100px',
+      },
+      {
+        key: 'surfaces',
+        header: 'Surfaces',
+        render: (row) => (
+          <div className={styles.surfaceList}>
+            {row.surfaces.map((s) => (
+              <span key={s} className={styles.surfaceTag}>
+                {s}
+              </span>
+            ))}
+          </div>
+        ),
+      },
+      {
+        key: 'classified_at',
+        header: 'Classified',
+        sortable: true,
+        render: (row) =>
+          row.classified_at ? new Date(row.classified_at).toLocaleDateString() : '—',
+        sortValue: (row) => row.classified_at ?? '',
+        width: '120px',
+      },
+    ],
+    [],
+  );
+
+  const totalPages = usersData ? Math.ceil(usersData.total / PAGE_SIZE) : 0;
+
+  const handlePersonaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setPersonaFilter(e.target.value);
+    setPage(1);
+  };
+
+  return (
+    <div className={styles.page}>
+      <PageHeader
+        title="User Behavior"
+        description="Classify users by audit log activity patterns into behavioral personas"
+        actions={[
+          {
+            label: runMutation.isPending ? 'Running…' : 'Run Classification',
+            onClick: () => runMutation.mutate(),
+            variant: 'primary',
+            disabled: runMutation.isPending,
+          },
+        ]}
+      />
+
+      {/* Key metrics */}
+      {summaryLoading ? (
+        <div className={styles.metricsRow}>
+          <SkeletonCard lines={2} />
+          <SkeletonCard lines={2} />
+          <SkeletonCard lines={2} />
+        </div>
+      ) : summaryError ? (
+        <div role="alert">Failed to load classification summary.</div>
+      ) : (
+        <div className={styles.metricsRow}>
+          <div className={styles.metricCard}>
+            <div className={styles.metricValue} data-testid="total-users">
+              {summary?.total_users?.toLocaleString() ?? 0}
+            </div>
+            <div className={styles.metricLabel}>Total Classified Users</div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricValue} data-testid="dormant-pct">
+              {summary?.dormant_pct?.toFixed(1) ?? 0}%
+            </div>
+            <div className={styles.metricLabel}>Dormant Users</div>
+          </div>
+          <div className={styles.metricCard}>
+            <div className={styles.metricValue} data-testid="power-user-pct">
+              {summary?.power_user_pct?.toFixed(1) ?? 0}%
+            </div>
+            <div className={styles.metricLabel}>Power Users</div>
+          </div>
+        </div>
+      )}
+
+      {/* Chart + table layout */}
+      <div className={styles.chartUserRow}>
+        {/* Donut chart */}
+        <div className={styles.chartCard}>
+          <div className={styles.chartTitle}>Persona Distribution</div>
+          {summaryLoading ? (
+            <SkeletonCard lines={6} />
+          ) : chartOption ? (
+            <ReactECharts option={chartOption} style={{ height: 240 }} opts={{ renderer: 'svg' }} />
+          ) : (
+            <div>No classification data yet. Run a classification to see results.</div>
+          )}
+        </div>
+
+        {/* User table */}
+        <div className={styles.tableCard}>
+          <div className={styles.filterRow}>
+            <label htmlFor="persona-filter">Filter by persona:</label>
+            <select
+              id="persona-filter"
+              className={styles.filterSelect}
+              value={personaFilter}
+              onChange={handlePersonaChange}
+            >
+              <option value="">All Personas</option>
+              {ALL_PERSONAS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {usersLoading ? (
+            <SkeletonCard lines={8} />
+          ) : usersError ? (
+            <div role="alert">Failed to load user classifications.</div>
+          ) : (
+            <>
+              <DataTable
+                columns={columns}
+                data={usersData?.users ?? []}
+                rowKey={(row) => row.id}
+                emptyMessage="No classified users found. Run classification to populate results."
+              />
+
+              {totalPages > 1 && (
+                <div className={styles.pagination}>
+                  <button
+                    type="button"
+                    className={styles.paginationBtn}
+                    disabled={page <= 1}
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  >
+                    Previous
+                  </button>
+                  <span>
+                    Page {page} of {totalPages}
+                  </span>
+                  <button
+                    type="button"
+                    className={styles.paginationBtn}
+                    disabled={page >= totalPages}
+                    onClick={() => setPage((p) => p + 1)}
+                  >
+                    Next
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Automatically classifies GitHub users into 9 behavioral personas based on audit log event patterns.

### Personas
Power User, Web UI Only, IDE Only, API/CLI Only, Copilot Active, Truly Dormant, Lightly Active, Admin Only, CI/CD Bot

### Backend
- `user_classifications` table (migration 0057)
- Classification engine analyzing events by source/type/volume
- Daily Celery task for automated classification
- 3 API endpoints: summary, users list, manual run trigger
- 31 new tests

### Frontend
- `/user-behavior` page with donut chart, metrics cards, user table
- Persona filter, pagination, manual run button
- 10 new tests

### Validation
- ✅ 2,780 backend + frontend tests passing

Closes #167