### PR TITLE
fix: resolve migration JSONB default and frontend test failures

### DIFF
--- a/backend/alembic/versions/0059_add_user_classifications.py
+++ b/backend/alembic/versions/0059_add_user_classifications.py
@@ -27,7 +27,7 @@ def upgrade() -> None:
         sa.Column("persona", sa.String(30), nullable=False),
         sa.Column("confidence_score", sa.Float(), nullable=False),
         sa.Column("event_count", sa.Integer(), nullable=False, server_default="0"),
-        sa.Column("surfaces", JSONB(), nullable=False, server_default="'[]'"),
+        sa.Column("surfaces", JSONB(), nullable=False, server_default=sa.text("'[]'")),
         sa.Column("analysis_window_days", sa.Integer(), nullable=False, server_default="90"),
         sa.Column(
             "classified_at",

--- a/frontend/src/hooks/useFeatures.test.tsx
+++ b/frontend/src/hooks/useFeatures.test.tsx
@@ -58,10 +58,10 @@ describe('useFeatures', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.features.copilot_insights).toBe(true);
+      expect(result.current.features.velocity).toBe(false);
     });
 
-    expect(result.current.features.velocity).toBe(false);
+    expect(result.current.features.copilot_insights).toBe(true);
     expect(result.current.isLoading).toBe(false);
   });
 

--- a/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.test.tsx
+++ b/frontend/src/pages/AdvancedSecurity/AdvancedSecurity.test.tsx
@@ -282,11 +282,7 @@ describe('AdvancedSecurityPage', () => {
   it('code scanning tab cards are clickable', async () => {
     renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=code' });
 
-    await waitFor(() => {
-      expect(screen.getByText('Critical')).toBeInTheDocument();
-    });
-
-    const criticalCard = screen.getByRole('button', { name: 'Critical' });
+    const criticalCard = await screen.findByRole('button', { name: 'Critical' });
     expect(criticalCard).toBeInTheDocument();
 
     const highCard = screen.getByRole('button', { name: 'High' });
@@ -322,11 +318,7 @@ describe('AdvancedSecurityPage', () => {
   it('clicking code scanning Critical card sets severity filter', async () => {
     renderWithProviders(<AdvancedSecurityPage />, { route: '/security?tab=code' });
 
-    await waitFor(() => {
-      expect(screen.getByText('Critical')).toBeInTheDocument();
-    });
-
-    const criticalCard = screen.getByRole('button', { name: 'Critical' });
+    const criticalCard = await screen.findByRole('button', { name: 'Critical' });
     fireEvent.click(criticalCard);
 
     // The severity filter select should now show "critical"

--- a/frontend/src/pages/CrossOrg/CrossOrg.test.tsx
+++ b/frontend/src/pages/CrossOrg/CrossOrg.test.tsx
@@ -112,8 +112,10 @@ describe('CrossOrgPage — Correlations Tab', () => {
 
   it('shows total actors count in tab badge', async () => {
     renderWithProviders(<CrossOrgPage />);
+    // Wait for data to load first
+    await screen.findByText('jdoe');
     // Tab badge shows the total count — find it within the tab button
-    const correlationsTab = await screen.findByRole('button', { name: /correlations/i });
+    const correlationsTab = screen.getByRole('button', { name: /correlations/i });
     expect(within(correlationsTab).getByText('2')).toBeInTheDocument();
   });
 

--- a/frontend/src/pages/Dashboard/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../../test/utils';
 import { DashboardPage } from './index';
@@ -186,7 +186,9 @@ describe('DashboardPage', () => {
     renderWithProviders(<DashboardPage />);
 
     await screen.findByText('stale repos');
-    expect(screen.getByText('1')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
   });
 
   /* ---------------------------------------------------------------- */

--- a/frontend/src/pages/DevActivity/DevActivity.test.tsx
+++ b/frontend/src/pages/DevActivity/DevActivity.test.tsx
@@ -180,8 +180,10 @@ describe('DevActivityPage', () => {
   it('PR authorship bars are clickable with role="button" and clickableBar class', async () => {
     renderWithProviders(<DevActivityPage />);
 
-    // Wait for data to render
+    // Wait for actual data-driven content to render
     await screen.findByText('PR authorship share');
+    // Wait a tick for query data to populate the bars
+    await screen.findAllByText(/@alice/);
 
     const barRows = document.querySelectorAll('.barRow.clickableBar');
     expect(barRows.length).toBeGreaterThanOrEqual(5); // at least 5 PR authorship bars
@@ -211,7 +213,7 @@ describe('DevActivityPage', () => {
   it('activity concentration bars are clickable', async () => {
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Event activity share');
+    await screen.findAllByText(/@alice/);
 
     // Concentration section also uses clickableBar rows
     const allClickableBars = document.querySelectorAll('.clickableBar[role="button"]');
@@ -238,8 +240,8 @@ describe('DevActivityPage', () => {
   it('developer card stat numbers are clickable with clickableStat class', async () => {
     renderWithProviders(<DevActivityPage />);
 
-    // Wait for dev cards to render
-    await screen.findByText('Developer cards');
+    // Wait for dev cards to render (data-driven)
+    await screen.findByLabelText('View details for alice');
 
     const clickableStats = document.querySelectorAll('.clickableStat[role="button"]');
     // Each dev card has 3 clickable stats (repos, PRs, flags/detections)
@@ -269,7 +271,7 @@ describe('DevActivityPage', () => {
     renderWithProviders(<DevActivityPage />);
 
     // Wait for dev cards to render
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
 
     // Click the first dev card (alice)
     const aliceCard = screen.getByLabelText('View details for alice');
@@ -287,7 +289,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -302,7 +304,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -318,7 +320,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -337,7 +339,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -354,7 +356,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -370,7 +372,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -384,7 +386,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const bobCard = screen.getByLabelText('View details for bob');
     bobCard.focus();
     await user.keyboard('{Enter}');
@@ -404,8 +406,8 @@ describe('DevActivityPage', () => {
   it('renders Git operations card with metric values', async () => {
     renderWithProviders(<DevActivityPage />);
 
-    expect(await screen.findByText('Git operations')).toBeInTheDocument();
-    expect(screen.getByText('353')).toBeInTheDocument();
+    expect(await screen.findByText('353')).toBeInTheDocument();
+    expect(screen.getByText('Git operations')).toBeInTheDocument();
     expect(screen.getByText('159')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.getByText('Clones')).toBeInTheDocument();
@@ -523,7 +525,7 @@ describe('DevActivityPage', () => {
   it('developer cards show last active time', async () => {
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
 
     // Developer cards should show last active time
     const lastActiveElements = screen.getAllByText(/Last active/);
@@ -534,7 +536,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 
@@ -547,7 +549,7 @@ describe('DevActivityPage', () => {
     const user = userEvent.setup();
     renderWithProviders(<DevActivityPage />);
 
-    await screen.findByText('Developer cards');
+    await screen.findByLabelText('View details for alice');
     const aliceCard = screen.getByLabelText('View details for alice');
     await user.click(aliceCard);
 

--- a/frontend/src/pages/Integrations/SyncPanel.test.tsx
+++ b/frontend/src/pages/Integrations/SyncPanel.test.tsx
@@ -496,7 +496,7 @@ describe('ScheduleSection', () => {
     mockGetSyncStatus.mockResolvedValue(completedRun);
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     expect(screen.getByLabelText('Enable automatic sync schedule')).not.toBeChecked();
     expect(screen.getByText('Not scheduled')).toBeInTheDocument();
@@ -508,7 +508,7 @@ describe('ScheduleSection', () => {
     mockGetSyncSchedule.mockResolvedValue(enabledSchedule);
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     expect(screen.getByLabelText('Enable automatic sync schedule')).toBeChecked();
     // Check the dropdowns have the right values
@@ -522,7 +522,7 @@ describe('ScheduleSection', () => {
     mockGetSyncStatus.mockResolvedValue(completedRun);
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     expect(screen.getByRole('button', { name: 'Save Schedule' })).toBeDisabled();
   });
@@ -532,7 +532,7 @@ describe('ScheduleSection', () => {
     mockGetSyncStatus.mockResolvedValue(completedRun);
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     await user.click(screen.getByLabelText('Enable automatic sync schedule'));
     expect(screen.getByRole('button', { name: 'Save Schedule' })).toBeEnabled();
@@ -547,7 +547,7 @@ describe('ScheduleSection', () => {
     });
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     await user.click(screen.getByLabelText('Enable automatic sync schedule'));
     await user.click(screen.getByRole('button', { name: 'Save Schedule' }));
@@ -563,7 +563,7 @@ describe('ScheduleSection', () => {
     });
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     await user.click(screen.getByLabelText('Enable automatic sync schedule'));
     await user.click(screen.getByRole('button', { name: 'Save Schedule' }));
@@ -578,7 +578,7 @@ describe('ScheduleSection', () => {
     mockUpdateSyncSchedule.mockRejectedValue(new Error('Server error'));
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     await user.click(screen.getByLabelText('Enable automatic sync schedule'));
     await user.click(screen.getByRole('button', { name: 'Save Schedule' }));
@@ -610,7 +610,7 @@ describe('ScheduleSection', () => {
     mockGetSyncStatus.mockResolvedValue(completedRun);
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     await user.selectOptions(screen.getByLabelText('Schedule interval'), '48');
     expect(screen.getByRole('button', { name: 'Save Schedule' })).toBeEnabled();
@@ -621,7 +621,7 @@ describe('ScheduleSection', () => {
     mockGetSyncStatus.mockResolvedValue(completedRun);
     renderWithProviders(<SyncPanel />);
     await waitFor(() => {
-      expect(screen.getByTestId('schedule-section')).toBeInTheDocument();
+      expect(screen.getByLabelText('Enable automatic sync schedule')).toBeInTheDocument();
     });
     await user.selectOptions(screen.getByLabelText('Sync scope'), 'teams');
     expect(screen.getByRole('button', { name: 'Save Schedule' })).toBeEnabled();

--- a/frontend/src/pages/Profile/Profile.test.tsx
+++ b/frontend/src/pages/Profile/Profile.test.tsx
@@ -205,6 +205,7 @@ describe('ProfilePage', () => {
     await waitFor(() => {
       expect(mockUpdateUserPreferences).toHaveBeenCalledWith(
         expect.objectContaining({ theme: 'dark' }),
+        expect.anything(),
       );
     });
 
@@ -267,7 +268,10 @@ describe('ProfilePage', () => {
     await user.click(revokeButton);
 
     await waitFor(() => {
-      expect(mockRevokeSession).toHaveBeenCalledWith('def67890-5555-6666-7777-888888888888');
+      expect(mockRevokeSession).toHaveBeenCalledWith(
+        'def67890-5555-6666-7777-888888888888',
+        expect.anything(),
+      );
     });
   });
 

--- a/frontend/src/pages/Rules/RuleWizard.test.tsx
+++ b/frontend/src/pages/Rules/RuleWizard.test.tsx
@@ -39,7 +39,7 @@ describe('RuleWizard', () => {
     renderWithProviders(<RuleWizard onClose={() => {}} onCreated={() => {}} />);
 
     expect(await screen.findByLabelText(/rule wizard progress/i)).toBeInTheDocument();
-    expect(screen.getByText(/start from scratch/i)).toBeInTheDocument();
+    expect(await screen.findByText(/start from scratch/i)).toBeInTheDocument();
   });
 
   it('navigates forward and backward through steps', async () => {


### PR DESCRIPTION
Fixes two CI blockers:

## 1. Migration 0059 JSONB server_default quoting bug
The `surfaces` column's `server_default="'[]'"` caused PostgreSQL triple-quoting (`DEFAULT '''[]'''`). Fixed by using `sa.text("'[]'")` which passes the expression verbatim.

## 2. 32 frontend test failures across 9 files
Root cause: tests were querying for data-driven DOM elements synchronously after awaiting static headers that render before async data loads. Fixes:

| File | Issue | Fix |
|------|-------|-----|
| `useFeatures.test` | `waitFor` matched placeholder data | Wait for value that differs from placeholder |
| `DevActivity.test` | Static headers found before query data | Use `findByLabelText`/`findAllByText` for data elements |
| `SyncPanel.test` | `schedule-section` testid matches loading state | Wait for form label instead |
| `AdvancedSecurity.test` | `Critical` text in dropdown options | Use `findByRole('button')` to wait for MetricCard |
| `CrossOrg.test` | Tab button found before badge data loads | Wait for table data first |
| `Dashboard.test` | Count found before repo health loads | Wrap in `waitFor` |
| `Profile.test` | React Query passes mutation context as 2nd arg | Add `expect.anything()` for context |
| `RuleWizard.test` | Template text not available until query resolves | Use `findByText` (async) |

## Verification
- ✅ All 1703 frontend tests pass (128 files)
- ✅ All 2828 backend tests pass
- ✅ Frontend lint: 0 errors
- ✅ TypeScript: 0 errors
- ✅ Frontend build succeeds
- ✅ Backend ruff check + format: pass
- ✅ Migration chain intact (head: 0059)