### PR TITLE
fix: use async query in WidgetCatalog empty state test

### DIFF
--- a/frontend/src/components/widgets/WidgetCatalog.test.tsx
+++ b/frontend/src/components/widgets/WidgetCatalog.test.tsx
@@ -136,6 +136,6 @@ describe('WidgetCatalog', () => {
 
     await user.type(screen.getByRole('searchbox', { name: /search widgets/i }), 'zzzznonexistent');
 
-    expect(screen.getByText('No widgets match your search.')).toBeInTheDocument();
+    expect(await screen.findByText('No widgets match your search.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes the last remaining frontend test failure — WidgetCatalog 'shows empty state when no widgets match search' was using sync `getByText` for content that renders after a state update from `userEvent.type`. Switched to `findByText` (async).