### PR TITLE
fix(copilot): include regular_users in adoption response for tier filtering

### DIFF
--- a/backend/app/services/copilot_metrics_service.py
+++ b/backend/app/services/copilot_metrics_service.py
@@ -1081,6 +1081,7 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
             "tiers": [],
             "total_adoption": 0,
             "power_users": [],
+            "regular_users": [],
             "feature_adoption": [],
             "minimal_users": [],
         }
@@ -1142,6 +1143,7 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
         has_seat_data = False
 
     power_users: list[dict[str, Any]] = []
+    regular_users: list[dict[str, Any]] = []
     minimal_users: list[dict[str, Any]] = []
     tier_counts = {"power": 0, "regular": 0, "minimal": 0, "inactive": 0}
 
@@ -1157,6 +1159,17 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
                         "user": login,
                         "days_active": 20,
                         "features_used": 3,
+                        "last_activity": datetime.now(UTC).isoformat(),
+                        "editor": "VS Code",
+                        "credits_consumed": round(credits, 2),
+                    }
+                )
+            elif tier == "regular":
+                regular_users.append(
+                    {
+                        "user": login,
+                        "days_active": 10,
+                        "features_used": 2,
                         "last_activity": datetime.now(UTC).isoformat(),
                         "editor": "VS Code",
                         "credits_consumed": round(credits, 2),
@@ -1195,6 +1208,16 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
 
             if tier == "power":
                 power_users.append(
+                    {
+                        "user": login,
+                        "days_active": _days_since_last_activity(last_activity),
+                        "features_used": _count_features(seat),
+                        "last_activity": last_activity,
+                        "editor": last_editor,
+                    }
+                )
+            elif tier == "regular":
+                regular_users.append(
                     {
                         "user": login,
                         "days_active": _days_since_last_activity(last_activity),
@@ -1332,6 +1355,7 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
         "tiers": tiers,
         "total_adoption": total_adoption,
         "power_users": power_users,
+        "regular_users": regular_users,
         "feature_adoption": feature_adoption,
         "minimal_users": minimal_users,
     }

--- a/frontend/src/api/copilotMetrics.ts
+++ b/frontend/src/api/copilotMetrics.ts
@@ -38,6 +38,7 @@ export interface CopilotAdoption {
   tiers: AdoptionTier[];
   total_adoption: number;
   power_users: PowerUser[];
+  regular_users: PowerUser[];
   feature_adoption: Array<{
     feature: string;
     active_users: number;

--- a/frontend/src/pages/Copilot/AdoptionPane.tsx
+++ b/frontend/src/pages/Copilot/AdoptionPane.tsx
@@ -37,6 +37,7 @@ export function AdoptionPane() {
   const tiers = adoption?.tiers ?? [];
   const totalAdoption = adoption?.total_adoption ?? 0;
   const powerUsers = adoption?.power_users ?? [];
+  const regularUsers = adoption?.regular_users ?? [];
   const featureAdoption = adoption?.feature_adoption ?? [];
   const minimalUsers = adoption?.minimal_users ?? [];
 
@@ -55,15 +56,12 @@ export function AdoptionPane() {
     setActiveTier((prev) => (prev === tierId ? null : tierId));
   }
 
-  /** Build a unified user list from power_users and minimal_users */
+  /** Build a unified user list from power_users, regular_users, and minimal_users */
   const allUsers: UnifiedUser[] = useMemo(() => {
     const tierColorMap: Record<string, string> = {};
     for (const t of tiers) {
       tierColorMap[t.id] = t.color;
     }
-
-    const powerSet = new Set(powerUsers.map((u) => u.user));
-    const minimalSet = new Set(minimalUsers.map((u) => u.user));
 
     const users: UnifiedUser[] = [];
 
@@ -78,25 +76,30 @@ export function AdoptionPane() {
       });
     }
 
-    for (const u of minimalUsers) {
-      if (!powerSet.has(u.user)) {
-        users.push({
-          user: u.user,
-          tier: 'minimal',
-          tier_color: tierColorMap['minimal'] ?? '#d29922',
-          days_active: u.days_active,
-          features_used: 1,
-          last_feature: u.last_feature,
-        });
-      }
+    for (const u of regularUsers) {
+      users.push({
+        user: u.user,
+        tier: 'regular',
+        tier_color: tierColorMap['regular'] ?? '#58a6ff',
+        days_active: u.days_active,
+        features_used: u.features_used,
+        last_feature: '',
+      });
     }
 
-    // Any user not in power or minimal is regular (none in current API data, but handles future)
-    // We only have power_users and minimal_users from the API, so this covers all known users
-    void minimalSet;
+    for (const u of minimalUsers) {
+      users.push({
+        user: u.user,
+        tier: 'minimal',
+        tier_color: tierColorMap['minimal'] ?? '#d29922',
+        days_active: u.days_active,
+        features_used: 1,
+        last_feature: u.last_feature,
+      });
+    }
 
     return users;
-  }, [powerUsers, minimalUsers, tiers]);
+  }, [powerUsers, regularUsers, minimalUsers, tiers]);
 
   const filteredUsers = useMemo(() => {
     if (!activeTier) return allUsers;


### PR DESCRIPTION
## Problem

Clicking the 'Regular Users' card (showing 17 users) on the Copilot Adoption page filters the table to show zero results.

## Root Cause

The backend counted regular-tier users in `tier_counts['regular']` (displayed on the card) but never added them to any user list. Only `power_users` and `minimal_users` were returned. The frontend filtered by `tier === 'regular'` which matched nothing.

## Fix

- **Backend**: Add `regular_users` list with the same user detail shape as power_users
- **Frontend**: Add `regular_users` to the `CopilotAdoption` type interface and include them in the unified user list with `tier: 'regular'`

## Testing
- 80 backend tests pass ✅
- 1746 frontend tests pass ✅
- TypeScript clean, lint clean ✅