### PR TITLE
fix(copilot): include inactive_users in adoption response for tier filtering

### DIFF
--- a/backend/app/services/copilot_metrics_service.py
+++ b/backend/app/services/copilot_metrics_service.py
@@ -1084,6 +1084,7 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
             "regular_users": [],
             "feature_adoption": [],
             "minimal_users": [],
+            "inactive_users": [],
         }
 
     num_days = len(days)
@@ -1145,6 +1146,7 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
     power_users: list[dict[str, Any]] = []
     regular_users: list[dict[str, Any]] = []
     minimal_users: list[dict[str, Any]] = []
+    inactive_users: list[dict[str, Any]] = []
     tier_counts = {"power": 0, "regular": 0, "minimal": 0, "inactive": 0}
 
     if has_usage_data and usage_tiers:
@@ -1185,6 +1187,16 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
                         "credits_consumed": round(credits, 2),
                     }
                 )
+            elif tier == "inactive":
+                inactive_users.append(
+                    {
+                        "user": login,
+                        "days_active": 0,
+                        "last_feature": "",
+                        "last_activity": "",
+                        "credits_consumed": round(credits, 2),
+                    }
+                )
 
         # Also account for seated users with no usage data
         if has_seat_data and isinstance(seats_data, list):
@@ -1194,6 +1206,15 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
                 login = assignee.get("login", "")
                 if login and login not in usage_logins:
                     tier_counts["inactive"] += 1
+                    inactive_users.append(
+                        {
+                            "user": login,
+                            "days_active": 0,
+                            "last_feature": "",
+                            "last_activity": "",
+                            "credits_consumed": 0,
+                        }
+                    )
 
     elif has_seat_data:
         assert isinstance(seats_data, list)
@@ -1232,6 +1253,15 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
                         "user": login,
                         "days_active": _days_since_last_activity(last_activity),
                         "last_feature": last_editor or "unknown",
+                        "last_activity": last_activity,
+                    }
+                )
+            elif tier == "inactive":
+                inactive_users.append(
+                    {
+                        "user": login,
+                        "days_active": 0,
+                        "last_feature": "",
                         "last_activity": last_activity,
                     }
                 )
@@ -1358,6 +1388,7 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
         "regular_users": regular_users,
         "feature_adoption": feature_adoption,
         "minimal_users": minimal_users,
+        "inactive_users": inactive_users,
     }
 
 

--- a/frontend/src/api/copilotMetrics.ts
+++ b/frontend/src/api/copilotMetrics.ts
@@ -48,6 +48,7 @@ export interface CopilotAdoption {
     color: string;
   }>;
   minimal_users: MinimalUser[];
+  inactive_users: MinimalUser[];
   error?: string;
   message?: string;
 }

--- a/frontend/src/pages/Copilot/AdoptionPane.tsx
+++ b/frontend/src/pages/Copilot/AdoptionPane.tsx
@@ -40,6 +40,7 @@ export function AdoptionPane() {
   const regularUsers = adoption?.regular_users ?? [];
   const featureAdoption = adoption?.feature_adoption ?? [];
   const minimalUsers = adoption?.minimal_users ?? [];
+  const inactiveUsers = adoption?.inactive_users ?? [];
 
   const [adoptionModal, setAdoptionModal] = useState<AdoptionModal>(null);
   const [activeTier, setActiveTier] = useState<string | null>(null);
@@ -98,8 +99,19 @@ export function AdoptionPane() {
       });
     }
 
+    for (const u of inactiveUsers) {
+      users.push({
+        user: u.user,
+        tier: 'inactive',
+        tier_color: tierColorMap['inactive'] ?? '#8b949e',
+        days_active: 0,
+        features_used: 0,
+        last_feature: '',
+      });
+    }
+
     return users;
-  }, [powerUsers, regularUsers, minimalUsers, tiers]);
+  }, [powerUsers, regularUsers, minimalUsers, inactiveUsers, tiers]);
 
   const filteredUsers = useMemo(() => {
     if (!activeTier) return allUsers;


### PR DESCRIPTION
## Problem

Clicking the 'Inactive' tier card on the Copilot Adoption page shows an empty table.

## Root Cause

Same pattern as #344: inactive users were counted in `tier_counts['inactive']` (displayed on the card) but never added to a user list returned to the frontend.

## Fix

- Backend: Add `inactive_users` list populated in both the usage-data and seat-data paths
- Frontend: Add `inactive_users` to the API type and include them in the unified user table

## Testing
- 80 backend tests pass ✅
- TypeScript clean ✅
- Pre-existing unrelated test failure in Users.test.tsx (present on main)