### PR TITLE
feat(copilot): add missing charts and wire org filter to all panes

### DIFF
--- a/backend/app/routers/copilot.py
+++ b/backend/app/routers/copilot.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from typing import Any
 
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import AuthenticatedUser, get_db, require_permission
@@ -22,12 +22,13 @@ router = APIRouter(prefix="/copilot", tags=["copilot"])
 
 @router.get("/overview", response_model=dict[str, Any])
 async def copilot_overview(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Overview pane: acceptance rates, language breakdown, user counts."""
     try:
-        return await copilot_metrics_service.get_copilot_overview(db)
+        return await copilot_metrics_service.get_copilot_overview(db, org=org)
     except Exception:
         logger.exception("copilot.overview_failed")
         raise HTTPException(
@@ -38,12 +39,13 @@ async def copilot_overview(
 
 @router.get("/adoption", response_model=dict[str, Any])
 async def copilot_adoption(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Adoption pane: user tiers, feature adoption rates, per-user data."""
     try:
-        return await copilot_metrics_service.get_copilot_adoption(db)
+        return await copilot_metrics_service.get_copilot_adoption(db, org=org)
     except Exception:
         logger.exception("copilot.adoption_failed")
         raise HTTPException(
@@ -54,12 +56,13 @@ async def copilot_adoption(
 
 @router.get("/models", response_model=dict[str, Any])
 async def copilot_models(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Models pane: model usage, feature counts, editors."""
     try:
-        return await copilot_metrics_service.get_copilot_models(db)
+        return await copilot_metrics_service.get_copilot_models(db, org=org)
     except Exception:
         logger.exception("copilot.models_failed")
         raise HTTPException(
@@ -70,12 +73,13 @@ async def copilot_models(
 
 @router.get("/model-users", response_model=dict[str, Any])
 async def copilot_model_users(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Per-user Copilot usage breakdown by feature category (28 days)."""
     try:
-        return await copilot_metrics_service.get_copilot_model_users(db)
+        return await copilot_metrics_service.get_copilot_model_users(db, org=org)
     except Exception:
         logger.exception("copilot.model_users_failed")
         raise HTTPException(
@@ -86,12 +90,13 @@ async def copilot_model_users(
 
 @router.get("/anomalies", response_model=dict[str, Any])
 async def copilot_anomalies(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Anomalies pane: detected metric deviations."""
     try:
-        return await copilot_metrics_service.get_copilot_anomalies(db)
+        return await copilot_metrics_service.get_copilot_anomalies(db, org=org)
     except Exception:
         logger.exception("copilot.anomalies_failed")
         raise HTTPException(
@@ -102,12 +107,13 @@ async def copilot_anomalies(
 
 @router.get("/teams", response_model=dict[str, Any])
 async def copilot_teams(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Team-level Copilot adoption breakdown."""
     try:
-        return await copilot_metrics_service.get_copilot_teams(db)
+        return await copilot_metrics_service.get_copilot_teams(db, org=org)
     except Exception:
         logger.exception("copilot.teams_failed")
         raise HTTPException(
@@ -118,12 +124,13 @@ async def copilot_teams(
 
 @router.get("/blockers", response_model=dict[str, Any])
 async def copilot_blockers(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Adoption blockers analysis with recommendations."""
     try:
-        return await copilot_metrics_service.get_copilot_blockers(db)
+        return await copilot_metrics_service.get_copilot_blockers(db, org=org)
     except Exception:
         logger.exception("copilot.blockers_failed")
         raise HTTPException(
@@ -134,12 +141,13 @@ async def copilot_blockers(
 
 @router.get("/policy-changes", response_model=dict[str, Any])
 async def copilot_policy_changes(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Copilot policy change timeline from audit events."""
     try:
-        return await copilot_metrics_service.get_copilot_policy_changes(db)
+        return await copilot_metrics_service.get_copilot_policy_changes(db, org=org)
     except Exception:
         logger.exception("copilot.policy_changes_failed")
         raise HTTPException(
@@ -150,12 +158,13 @@ async def copilot_policy_changes(
 
 @router.get("/roi", response_model=dict[str, Any])
 async def copilot_roi(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Copilot ROI and cost optimization report."""
     try:
-        return await copilot_metrics_service.get_copilot_roi(db)
+        return await copilot_metrics_service.get_copilot_roi(db, org=org)
     except Exception:
         logger.exception("copilot.roi_failed")
         raise HTTPException(
@@ -178,12 +187,13 @@ async def copilot_adoption_thresholds(
 
 @router.get("/billing-overview", response_model=dict[str, Any])
 async def copilot_billing_overview(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Pool info, enterprise budget, spend forecast, pool drawdown."""
     try:
-        return await copilot_metrics_service.get_copilot_billing_overview(db)
+        return await copilot_metrics_service.get_copilot_billing_overview(db, org=org)
     except Exception:
         logger.exception("copilot.billing_overview_failed")
         raise HTTPException(
@@ -194,12 +204,13 @@ async def copilot_billing_overview(
 
 @router.get("/user-budgets", response_model=dict[str, Any])
 async def copilot_user_budgets(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Per-user budget list with consumed/budget/status/utilization %."""
     try:
-        return await copilot_metrics_service.get_copilot_user_budgets(db)
+        return await copilot_metrics_service.get_copilot_user_budgets(db, org=org)
     except Exception:
         logger.exception("copilot.user_budgets_failed")
         raise HTTPException(
@@ -210,14 +221,100 @@ async def copilot_user_budgets(
 
 @router.get("/billing-trends", response_model=dict[str, Any])
 async def copilot_billing_trends(
+    org: str | None = Query(None, description="Filter to a specific org"),
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
     db: AsyncSession = Depends(get_db),
 ) -> dict[str, Any]:
     """Daily credit consumption trends over last 30 days."""
     try:
-        return await copilot_metrics_service.get_copilot_billing_trends(db)
+        return await copilot_metrics_service.get_copilot_billing_trends(db, org=org)
     except Exception:
         logger.exception("copilot.billing_trends_failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        ) from None
+
+
+@router.get("/activity", response_model=dict[str, Any])
+async def copilot_activity(
+    org: str | None = Query(None, description="Filter to a specific org"),
+    current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Activity pane: DAU/WAU, completions, acceptance rate, chat per user, requests per mode."""
+    try:
+        return await copilot_metrics_service.get_copilot_activity(db, org=org)
+    except Exception:
+        logger.exception("copilot.activity_failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        ) from None
+
+
+@router.get("/chat-metrics", response_model=dict[str, Any])
+async def copilot_chat_metrics(
+    org: str | None = Query(None, description="Filter to a specific org"),
+    current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Chat metrics pane: interactions, code actions, active users, action rate."""
+    try:
+        return await copilot_metrics_service.get_copilot_chat_metrics(db, org=org)
+    except Exception:
+        logger.exception("copilot.chat_metrics_failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        ) from None
+
+
+@router.get("/language-breakdown", response_model=dict[str, Any])
+async def copilot_language_breakdown(
+    org: str | None = Query(None, description="Filter to a specific org"),
+    current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Language breakdown: per-day, distribution, models, editors, top languages."""
+    try:
+        return await copilot_metrics_service.get_copilot_language_breakdown(db, org=org)
+    except Exception:
+        logger.exception("copilot.language_breakdown_failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        ) from None
+
+
+@router.get("/pr-metrics", response_model=dict[str, Any])
+async def copilot_pr_metrics(
+    org: str | None = Query(None, description="Filter to a specific org"),
+    current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """PR metrics pane: activity, contributions, review suggestions."""
+    try:
+        return await copilot_metrics_service.get_copilot_pr_metrics(db, org=org)
+    except Exception:
+        logger.exception("copilot.pr_metrics_failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        ) from None
+
+
+@router.get("/agent-activity", response_model=dict[str, Any])
+async def copilot_agent_activity(
+    org: str | None = Query(None, description="Filter to a specific org"),
+    current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Agent activity pane: daily lines, lines by mode/model/language."""
+    try:
+        return await copilot_metrics_service.get_copilot_agent_activity(db, org=org)
+    except Exception:
+        logger.exception("copilot.agent_activity_failed")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Internal server error",

--- a/backend/app/routers/copilot.py
+++ b/backend/app/routers/copilot.py
@@ -68,6 +68,22 @@ async def copilot_models(
         ) from None
 
 
+@router.get("/model-users", response_model=dict[str, Any])
+async def copilot_model_users(
+    current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),
+    db: AsyncSession = Depends(get_db),
+) -> dict[str, Any]:
+    """Per-user Copilot usage breakdown by feature category (28 days)."""
+    try:
+        return await copilot_metrics_service.get_copilot_model_users(db)
+    except Exception:
+        logger.exception("copilot.model_users_failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Internal server error",
+        ) from None
+
+
 @router.get("/anomalies", response_model=dict[str, Any])
 async def copilot_anomalies(
     current_user: AuthenticatedUser = Depends(require_permission("copilot", "view")),

--- a/backend/app/services/copilot_metrics_service.py
+++ b/backend/app/services/copilot_metrics_service.py
@@ -862,7 +862,7 @@ async def _reconstruct_seats_from_db(db: AsyncSession) -> list[dict[str, Any]]:
 # ── Public API ────────────────────────────────────────────────────────────────
 
 
-async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_overview(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Data for the Overview pane: acceptance rates, language breakdown, user counts.
 
     Queries copilot_daily_metrics directly for reliable aggregates regardless
@@ -879,19 +879,21 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
 
     # Query 35 days of summary data (grouped by date across all orgs) to compute
     # 7-day rolling averages over the latest 28 days.
-    summary_result = await db.execute(
-        select(
-            CopilotDailyMetric.date,
-            func.sum(CopilotDailyMetric.active_users).label("active_users"),
-            func.sum(CopilotDailyMetric.engaged_users).label("engaged_users"),
-            func.sum(CopilotDailyMetric.total_suggestions).label("total_suggestions"),
-            func.sum(CopilotDailyMetric.total_acceptances).label("total_acceptances"),
-        )
-        .where(CopilotDailyMetric.metric_type == "summary")
-        .group_by(CopilotDailyMetric.date)
+    summary_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.active_users).label("active_users"),
+        func.sum(CopilotDailyMetric.engaged_users).label("engaged_users"),
+        func.sum(CopilotDailyMetric.total_suggestions).label("total_suggestions"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("total_acceptances"),
+    ).where(CopilotDailyMetric.metric_type == "summary")
+    if org:
+        summary_query = summary_query.where(CopilotDailyMetric.org_slug == org)
+    summary_query = (
+        summary_query.group_by(CopilotDailyMetric.date)
         .order_by(CopilotDailyMetric.date.desc())
         .limit(35)
     )
+    summary_result = await db.execute(summary_query)
     summary_rows = list(summary_result.all())
 
     if not summary_rows:
@@ -929,21 +931,21 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
         rate_values.append(round(pct, 1))
 
     # Language breakdown from DB (all available days)
-    lang_result = await db.execute(
-        select(
-            CopilotDailyMetric.language,
-            func.sum(CopilotDailyMetric.total_suggestions).label("total_sugg"),
-            func.sum(CopilotDailyMetric.total_acceptances).label("total_acc"),
-        )
-        .where(
-            CopilotDailyMetric.metric_type == "completions",
-            CopilotDailyMetric.language.isnot(None),
-            CopilotDailyMetric.model.is_(None),
-        )
-        .group_by(CopilotDailyMetric.language)
-        .order_by(desc("total_sugg"))
-        .limit(10)
+    lang_query = select(
+        CopilotDailyMetric.language,
+        func.sum(CopilotDailyMetric.total_suggestions).label("total_sugg"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("total_acc"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.isnot(None),
+        CopilotDailyMetric.model.is_(None),
     )
+    if org:
+        lang_query = lang_query.where(CopilotDailyMetric.org_slug == org)
+    lang_query = (
+        lang_query.group_by(CopilotDailyMetric.language).order_by(desc("total_sugg")).limit(10)
+    )
+    lang_result = await db.execute(lang_query)
     lang_rows = list(lang_result.all())
     grand_total = sum(row.total_sugg for row in lang_rows) or 1
     lang_items: list[dict[str, Any]] = [
@@ -958,27 +960,30 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
     # Active users: count distinct users with activity in last 28 days
     # from CopilotSeatSnapshot (matches what GitHub insights tab shows)
     cutoff_date = (datetime.now(UTC) - timedelta(days=28)).date()
-    active_result = await db.execute(
-        select(func.count(func.distinct(CopilotSeatSnapshot.github_login))).where(
-            CopilotSeatSnapshot.last_activity_at
-            >= datetime.combine(cutoff_date, datetime.min.time()).replace(tzinfo=UTC)
-        )
+    active_query = select(func.count(func.distinct(CopilotSeatSnapshot.github_login))).where(
+        CopilotSeatSnapshot.last_activity_at
+        >= datetime.combine(cutoff_date, datetime.min.time()).replace(tzinfo=UTC)
     )
+    if org:
+        active_query = active_query.where(CopilotSeatSnapshot.org_slug == org)
+    active_result = await db.execute(active_query)
     total_active = active_result.scalar() or 0
 
     # Provisioned seats: count distinct users in the latest snapshot
-    latest_snapshot_date_result = await db.execute(
-        select(func.max(CopilotSeatSnapshot.snapshot_date))
-    )
+    latest_snap_query = select(func.max(CopilotSeatSnapshot.snapshot_date))
+    if org:
+        latest_snap_query = latest_snap_query.where(CopilotSeatSnapshot.org_slug == org)
+    latest_snapshot_date_result = await db.execute(latest_snap_query)
     latest_snapshot_date = latest_snapshot_date_result.scalar()
 
     total_provisioned = 0
     if latest_snapshot_date:
-        prov_result = await db.execute(
-            select(func.count(func.distinct(CopilotSeatSnapshot.github_login))).where(
-                CopilotSeatSnapshot.snapshot_date == latest_snapshot_date
-            )
+        prov_query = select(func.count(func.distinct(CopilotSeatSnapshot.github_login))).where(
+            CopilotSeatSnapshot.snapshot_date == latest_snapshot_date
         )
+        if org:
+            prov_query = prov_query.where(CopilotSeatSnapshot.org_slug == org)
+        prov_result = await db.execute(prov_query)
         total_provisioned = prov_result.scalar() or 0
 
     # Engaged users from summary rows
@@ -1103,7 +1108,7 @@ def _build_overview_from_raw(days: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_adoption(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Data for the Adoption pane: tiers, feature adoption, per-user data."""
     try:
         raw = await _read_metrics_from_store(db)
@@ -1145,17 +1150,17 @@ async def get_copilot_adoption(db: AsyncSession) -> dict[str, Any]:
         now = datetime.now(UTC)
         period_start = (now - __import__("datetime").timedelta(days=28)).date()
 
-        usage_result = await db.execute(
-            select(
-                CopilotUsageReport.github_login,
-                sa_func.avg(CopilotUsageReport.total_credits_consumed).label("avg_daily"),
-                sa_func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
-                sa_func.count(CopilotUsageReport.report_date).label("active_days"),
-                sa_func.max(CopilotUsageReport.report_date).label("last_active_date"),
-            )
-            .where(CopilotUsageReport.report_date >= period_start)
-            .group_by(CopilotUsageReport.github_login)
-        )
+        usage_query = select(
+            CopilotUsageReport.github_login,
+            sa_func.avg(CopilotUsageReport.total_credits_consumed).label("avg_daily"),
+            sa_func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
+            sa_func.count(CopilotUsageReport.report_date).label("active_days"),
+            sa_func.max(CopilotUsageReport.report_date).label("last_active_date"),
+        ).where(CopilotUsageReport.report_date >= period_start)
+        if org:
+            usage_query = usage_query.where(CopilotUsageReport.org_slug == org)
+        usage_query = usage_query.group_by(CopilotUsageReport.github_login)
+        usage_result = await db.execute(usage_query)
         usage_rows = usage_result.fetchall()
         if usage_rows:
             has_usage_data = True
@@ -1469,7 +1474,7 @@ def _count_features(seat: dict[str, Any]) -> int:
     return max(1, count)
 
 
-async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_models(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Data for the Models pane: model usage, feature counts, editors.
 
     Queries copilot_daily_metrics directly for reliable aggregates.
@@ -1483,19 +1488,19 @@ async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
     # ── Model usage from language_model rows ──────────────────────────────────
     from sqlalchemy import desc, func
 
-    model_result = await db.execute(
-        select(
-            CopilotDailyMetric.model,
-            func.sum(CopilotDailyMetric.total_suggestions).label("total_sugg"),
-            func.sum(CopilotDailyMetric.engaged_users).label("total_engaged"),
-        )
-        .where(
-            CopilotDailyMetric.model.isnot(None),
-        )
-        .group_by(CopilotDailyMetric.model)
-        .order_by(desc("total_engaged"))
-        .limit(10)
+    model_query = select(
+        CopilotDailyMetric.model,
+        func.sum(CopilotDailyMetric.total_suggestions).label("total_sugg"),
+        func.sum(CopilotDailyMetric.engaged_users).label("total_engaged"),
+    ).where(
+        CopilotDailyMetric.model.isnot(None),
     )
+    if org:
+        model_query = model_query.where(CopilotDailyMetric.org_slug == org)
+    model_query = (
+        model_query.group_by(CopilotDailyMetric.model).order_by(desc("total_engaged")).limit(10)
+    )
+    model_result = await db.execute(model_query)
     model_rows = list(model_result.all())
     total_model = sum(row.total_engaged for row in model_rows) or 1
     models_list: list[dict[str, Any]] = [
@@ -1508,20 +1513,20 @@ async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
     ]
 
     # ── Editor breakdown ──────────────────────────────────────────────────────
-    editor_result = await db.execute(
-        select(
-            CopilotDailyMetric.editor,
-            func.sum(CopilotDailyMetric.total_suggestions).label("total_sugg"),
-            func.sum(CopilotDailyMetric.total_acceptances).label("total_acc"),
-        )
-        .where(
-            CopilotDailyMetric.metric_type == "completions",
-            CopilotDailyMetric.editor.isnot(None),
-        )
-        .group_by(CopilotDailyMetric.editor)
-        .order_by(desc("total_sugg"))
-        .limit(10)
+    editor_query = select(
+        CopilotDailyMetric.editor,
+        func.sum(CopilotDailyMetric.total_suggestions).label("total_sugg"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("total_acc"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.editor.isnot(None),
     )
+    if org:
+        editor_query = editor_query.where(CopilotDailyMetric.org_slug == org)
+    editor_query = (
+        editor_query.group_by(CopilotDailyMetric.editor).order_by(desc("total_sugg")).limit(10)
+    )
+    editor_result = await db.execute(editor_query)
     editor_rows = list(editor_result.all())
     total_editor = sum(row.total_sugg for row in editor_rows) or 1
     editors_list: list[dict[str, Any]] = [
@@ -1540,19 +1545,19 @@ async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
         "dotcom_chat": "Dotcom chat",
         "pr": "PR summaries",
     }
-    feature_result = await db.execute(
-        select(
-            CopilotDailyMetric.metric_type,
-            func.sum(CopilotDailyMetric.engaged_users).label("total_engaged"),
-        )
-        .where(
-            CopilotDailyMetric.metric_type.in_(list(feature_type_map.keys())),
-            CopilotDailyMetric.language.is_(None),
-            CopilotDailyMetric.editor.is_(None),
-            CopilotDailyMetric.model.is_(None),
-        )
-        .group_by(CopilotDailyMetric.metric_type)
+    feature_query = select(
+        CopilotDailyMetric.metric_type,
+        func.sum(CopilotDailyMetric.engaged_users).label("total_engaged"),
+    ).where(
+        CopilotDailyMetric.metric_type.in_(list(feature_type_map.keys())),
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
     )
+    if org:
+        feature_query = feature_query.where(CopilotDailyMetric.org_slug == org)
+    feature_query = feature_query.group_by(CopilotDailyMetric.metric_type)
+    feature_result = await db.execute(feature_query)
     feature_rows = list(feature_result.all())
     features_list: list[dict[str, Any]] = []
     for i, row in enumerate(feature_rows):
@@ -1577,40 +1582,42 @@ async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
     start_date = end_date - timedelta(days=27)
 
     # Model time series (engaged users per day per model)
-    model_ts_result = await db.execute(
-        select(
-            CopilotDailyMetric.date,
-            CopilotDailyMetric.model,
-            func.sum(CopilotDailyMetric.engaged_users).label("daily_engaged"),
-        )
-        .where(
-            CopilotDailyMetric.model.isnot(None),
-            CopilotDailyMetric.date >= start_date,
-            CopilotDailyMetric.date <= end_date,
-        )
-        .group_by(CopilotDailyMetric.date, CopilotDailyMetric.model)
-        .order_by(CopilotDailyMetric.date)
+    model_ts_query = select(
+        CopilotDailyMetric.date,
+        CopilotDailyMetric.model,
+        func.sum(CopilotDailyMetric.engaged_users).label("daily_engaged"),
+    ).where(
+        CopilotDailyMetric.model.isnot(None),
+        CopilotDailyMetric.date >= start_date,
+        CopilotDailyMetric.date <= end_date,
     )
+    if org:
+        model_ts_query = model_ts_query.where(CopilotDailyMetric.org_slug == org)
+    model_ts_query = model_ts_query.group_by(
+        CopilotDailyMetric.date, CopilotDailyMetric.model
+    ).order_by(CopilotDailyMetric.date)
+    model_ts_result = await db.execute(model_ts_query)
     model_ts_rows = list(model_ts_result.all())
 
     # Feature time series (engaged users per day per metric_type)
-    feature_ts_result = await db.execute(
-        select(
-            CopilotDailyMetric.date,
-            CopilotDailyMetric.metric_type,
-            func.sum(CopilotDailyMetric.engaged_users).label("daily_engaged"),
-        )
-        .where(
-            CopilotDailyMetric.metric_type.in_(list(feature_type_map.keys())),
-            CopilotDailyMetric.language.is_(None),
-            CopilotDailyMetric.editor.is_(None),
-            CopilotDailyMetric.model.is_(None),
-            CopilotDailyMetric.date >= start_date,
-            CopilotDailyMetric.date <= end_date,
-        )
-        .group_by(CopilotDailyMetric.date, CopilotDailyMetric.metric_type)
-        .order_by(CopilotDailyMetric.date)
+    feature_ts_query = select(
+        CopilotDailyMetric.date,
+        CopilotDailyMetric.metric_type,
+        func.sum(CopilotDailyMetric.engaged_users).label("daily_engaged"),
+    ).where(
+        CopilotDailyMetric.metric_type.in_(list(feature_type_map.keys())),
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= start_date,
+        CopilotDailyMetric.date <= end_date,
     )
+    if org:
+        feature_ts_query = feature_ts_query.where(CopilotDailyMetric.org_slug == org)
+    feature_ts_query = feature_ts_query.group_by(
+        CopilotDailyMetric.date, CopilotDailyMetric.metric_type
+    ).order_by(CopilotDailyMetric.date)
+    feature_ts_result = await db.execute(feature_ts_query)
     feature_ts_rows = list(feature_ts_result.all())
 
     # Build date list
@@ -1654,7 +1661,7 @@ async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
     }
 
 
-async def get_copilot_model_users(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_model_users(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Per-user Copilot usage breakdown by feature category.
 
     Returns sortable/filterable data showing credits consumed by each user
@@ -1671,21 +1678,22 @@ async def get_copilot_model_users(db: AsyncSession) -> dict[str, Any]:
     now = datetime.now(UTC)
     period_start = (now - timedelta(days=28)).date()
 
-    result = await db.execute(
-        select(
-            CopilotUsageReport.github_login,
-            func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
-            func.sum(CopilotUsageReport.completions_credits).label("completions"),
-            func.sum(CopilotUsageReport.chat_credits).label("chat"),
-            func.sum(CopilotUsageReport.pr_credits).label("pr"),
-            func.sum(CopilotUsageReport.other_credits).label("other"),
-            func.count(CopilotUsageReport.report_date).label("days_active"),
-            func.max(CopilotUsageReport.report_date).label("last_active"),
-        )
-        .where(CopilotUsageReport.report_date >= period_start)
-        .group_by(CopilotUsageReport.github_login)
-        .order_by(func.sum(CopilotUsageReport.total_credits_consumed).desc())
+    model_users_query = select(
+        CopilotUsageReport.github_login,
+        func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
+        func.sum(CopilotUsageReport.completions_credits).label("completions"),
+        func.sum(CopilotUsageReport.chat_credits).label("chat"),
+        func.sum(CopilotUsageReport.pr_credits).label("pr"),
+        func.sum(CopilotUsageReport.other_credits).label("other"),
+        func.count(CopilotUsageReport.report_date).label("days_active"),
+        func.max(CopilotUsageReport.report_date).label("last_active"),
+    ).where(CopilotUsageReport.report_date >= period_start)
+    if org:
+        model_users_query = model_users_query.where(CopilotUsageReport.org_slug == org)
+    model_users_query = model_users_query.group_by(CopilotUsageReport.github_login).order_by(
+        func.sum(CopilotUsageReport.total_credits_consumed).desc()
     )
+    result = await db.execute(model_users_query)
     rows = result.fetchall()
 
     users: list[dict[str, Any]] = []
@@ -1818,7 +1826,7 @@ def _build_models_from_raw(days: list[dict[str, Any]]) -> dict[str, Any]:
     return {"models": models_list, "features": features_list, "editors": editors_list}
 
 
-async def get_copilot_anomalies(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_anomalies(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Data for the Anomalies pane: detect metric deviations from baselines."""
     try:
         raw = await _read_metrics_from_store(db)
@@ -2055,14 +2063,14 @@ async def get_copilot_anomalies(db: AsyncSession) -> dict[str, Any]:
 
         now = datetime.now(UTC)
         one_day_ago = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        policy_result = await db.execute(
-            select(AuditEvent)
-            .where(
-                AuditEvent.action.like("copilot%"),
-                AuditEvent.created_at >= one_day_ago,
-            )
-            .limit(100)
+        policy_query = select(AuditEvent).where(
+            AuditEvent.action.like("copilot%"),
+            AuditEvent.created_at >= one_day_ago,
         )
+        if org:
+            policy_query = policy_query.where(AuditEvent.org == org)
+        policy_query = policy_query.limit(100)
+        policy_result = await db.execute(policy_query)
         recent_policy_events = list(policy_result.scalars().all())
         if len(recent_policy_events) > 5:
             anomaly_id += 1
@@ -2094,7 +2102,7 @@ async def get_copilot_anomalies(db: AsyncSession) -> dict[str, Any]:
 # ── Team-level breakdown (#76) ────────────────────────────────────────────────
 
 
-async def get_copilot_teams(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_teams(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Aggregate per-user Copilot metrics by GitHub team membership.
 
     Cross-references seat data with org_teams and org_team_members tables
@@ -2115,10 +2123,16 @@ async def get_copilot_teams(db: AsyncSession) -> dict[str, Any]:
             login_to_seat[login.lower()] = seat
 
     # Fetch team memberships from DB
-    team_result = await db.execute(select(OrgTeam))
+    team_query = select(OrgTeam)
+    if org:
+        team_query = team_query.where(OrgTeam.org == org)
+    team_result = await db.execute(team_query)
     teams = list(team_result.scalars().all())
 
-    member_result = await db.execute(select(OrgTeamMember))
+    member_query = select(OrgTeamMember)
+    if org:
+        member_query = member_query.where(OrgTeamMember.org == org)
+    member_result = await db.execute(member_query)
     members = list(member_result.scalars().all())
 
     # Build team → members mapping
@@ -2187,7 +2201,7 @@ async def get_copilot_teams(db: AsyncSession) -> dict[str, Any]:
 # ── Adoption Blockers (#77) ──────────────────────────────────────────────────
 
 
-async def get_copilot_blockers(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_blockers(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Identify and categorize Copilot adoption blockers.
 
     Cross-references seat data, policy events, and content exclusions to
@@ -2212,7 +2226,10 @@ async def get_copilot_blockers(db: AsyncSession) -> dict[str, Any]:
 
     # Get team members who don't have seats (no_seat blocker)
     try:
-        member_result = await db.execute(select(OrgTeamMember))
+        member_query = select(OrgTeamMember)
+        if org:
+            member_query = member_query.where(OrgTeamMember.org == org)
+        member_result = await db.execute(member_query)
         all_members = list(member_result.scalars().all())
     except Exception as exc:
         logger.error("copilot_blockers.query_team_members_failed", error=str(exc), exc_info=True)
@@ -2352,7 +2369,7 @@ async def get_copilot_blockers(db: AsyncSession) -> dict[str, Any]:
 # ── Policy Change Timeline (#78) ─────────────────────────────────────────────
 
 
-async def get_copilot_policy_changes(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_policy_changes(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Query audit events for Copilot policy changes.
 
     Searches the events table for ``copilot.*`` and ``copilot_policy.*``
@@ -2360,14 +2377,13 @@ async def get_copilot_policy_changes(db: AsyncSession) -> dict[str, Any]:
     """
     from app.models.audit_event import AuditEvent
 
-    result = await db.execute(
-        select(AuditEvent)
-        .where(
-            AuditEvent.action.like("copilot%"),
-        )
-        .order_by(AuditEvent.created_at.desc())
-        .limit(200)
+    policy_query = select(AuditEvent).where(
+        AuditEvent.action.like("copilot%"),
     )
+    if org:
+        policy_query = policy_query.where(AuditEvent.org == org)
+    policy_query = policy_query.order_by(AuditEvent.created_at.desc()).limit(200)
+    result = await db.execute(policy_query)
     events = list(result.scalars().all())
 
     timeline: list[dict[str, Any]] = []
@@ -2409,7 +2425,7 @@ def _describe_policy_action(action: str, data: dict[str, Any]) -> str:
 # ── ROI & Cost Optimization (#85) ────────────────────────────────────────────
 
 
-async def get_copilot_roi(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_roi(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Comprehensive Copilot ROI report.
 
     Calculates seat cost, utilization, waste, savings opportunities,
@@ -2430,7 +2446,11 @@ async def get_copilot_roi(db: AsyncSession) -> dict[str, Any]:
     # Get cost config
     from app.models.org_config import OrgConfig
 
-    config_result = await db.execute(select(OrgConfig).limit(1))
+    config_query = select(OrgConfig)
+    if org:
+        config_query = config_query.where(OrgConfig.org_slug == org)
+    config_query = config_query.limit(1)
+    config_result = await db.execute(config_query)
     org_config_row = config_result.scalars().first()
     cost_override: float | None = (
         float(org_config_row.copilot_cost_per_seat)
@@ -2504,7 +2524,7 @@ async def get_copilot_roi(db: AsyncSession) -> dict[str, Any]:
             }
         )
 
-    teams_data = await get_copilot_teams(db)
+    teams_data = await get_copilot_teams(db, org=org)
     if isinstance(teams_data, dict) and teams_data.get("at_risk_count", 0) > 0:
         at_risk = teams_data["at_risk_count"]
         recommendations.append(
@@ -2687,7 +2707,9 @@ async def get_copilot_roi(db: AsyncSession) -> dict[str, Any]:
 # ── Billing / UBB service functions ──────────────────────────────────────────
 
 
-async def get_copilot_billing_overview(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_billing_overview(
+    db: AsyncSession, *, org: str | None = None
+) -> dict[str, Any]:
     """Pool overview: total AI credits, consumed this period, forecast, remaining."""
     from sqlalchemy import func
 
@@ -2701,14 +2723,15 @@ async def get_copilot_billing_overview(db: AsyncSession) -> dict[str, Any]:
     period_start = now.replace(day=1).date()
 
     # Aggregate total credits consumed this billing period
-    result = await db.execute(
-        select(
-            func.coalesce(func.sum(CopilotUsageReport.total_credits_consumed), 0),
-            func.coalesce(func.sum(CopilotUsageReport.budget_amount), 0),
-            func.count(func.distinct(CopilotUsageReport.github_login)),
-            func.count(func.distinct(CopilotUsageReport.report_date)),
-        ).where(CopilotUsageReport.report_date >= period_start)
-    )
+    billing_query = select(
+        func.coalesce(func.sum(CopilotUsageReport.total_credits_consumed), 0),
+        func.coalesce(func.sum(CopilotUsageReport.budget_amount), 0),
+        func.count(func.distinct(CopilotUsageReport.github_login)),
+        func.count(func.distinct(CopilotUsageReport.report_date)),
+    ).where(CopilotUsageReport.report_date >= period_start)
+    if org:
+        billing_query = billing_query.where(CopilotUsageReport.org_slug == org)
+    result = await db.execute(billing_query)
     row = result.one()
     total_consumed = float(row[0])
     total_budgets = float(row[1])
@@ -2746,7 +2769,7 @@ async def get_copilot_billing_overview(db: AsyncSession) -> dict[str, Any]:
     }
 
 
-async def get_copilot_user_budgets(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_user_budgets(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Per-user budget list with consumed/budget/status/utilization %."""
     from sqlalchemy import func
 
@@ -2760,18 +2783,19 @@ async def get_copilot_user_budgets(db: AsyncSession) -> dict[str, Any]:
     period_start = now.replace(day=1).date()
 
     # Aggregate per-user for current billing period (across all orgs)
-    result = await db.execute(
-        select(
-            CopilotUsageReport.github_login,
-            func.sum(CopilotUsageReport.total_credits_consumed).label("consumed"),
-            func.max(CopilotUsageReport.budget_amount).label("budget"),
-            func.max(CopilotUsageReport.budget_consumed).label("budget_consumed"),
-            func.bool_or(CopilotUsageReport.is_blocked).label("is_blocked"),
-        )
-        .where(CopilotUsageReport.report_date >= period_start)
-        .group_by(CopilotUsageReport.github_login)
-        .order_by(func.sum(CopilotUsageReport.total_credits_consumed).desc())
+    budgets_query = select(
+        CopilotUsageReport.github_login,
+        func.sum(CopilotUsageReport.total_credits_consumed).label("consumed"),
+        func.max(CopilotUsageReport.budget_amount).label("budget"),
+        func.max(CopilotUsageReport.budget_consumed).label("budget_consumed"),
+        func.bool_or(CopilotUsageReport.is_blocked).label("is_blocked"),
+    ).where(CopilotUsageReport.report_date >= period_start)
+    if org:
+        budgets_query = budgets_query.where(CopilotUsageReport.org_slug == org)
+    budgets_query = budgets_query.group_by(CopilotUsageReport.github_login).order_by(
+        func.sum(CopilotUsageReport.total_credits_consumed).desc()
     )
+    result = await db.execute(budgets_query)
     rows = result.fetchall()
 
     users: list[dict[str, Any]] = []
@@ -2830,7 +2854,7 @@ async def get_copilot_user_budgets(db: AsyncSession) -> dict[str, Any]:
     }
 
 
-async def get_copilot_billing_trends(db: AsyncSession) -> dict[str, Any]:
+async def get_copilot_billing_trends(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
     """Daily credit consumption trends over last 30 days."""
     from sqlalchemy import func
 
@@ -2843,20 +2867,21 @@ async def get_copilot_billing_trends(db: AsyncSession) -> dict[str, Any]:
     now = datetime.now(UTC)
     thirty_days_ago = (now - __import__("datetime").timedelta(days=30)).date()
 
-    result = await db.execute(
-        select(
-            CopilotUsageReport.report_date,
-            func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
-            func.sum(CopilotUsageReport.completions_credits).label("completions"),
-            func.sum(CopilotUsageReport.chat_credits).label("chat"),
-            func.sum(CopilotUsageReport.pr_credits).label("pr"),
-            func.sum(CopilotUsageReport.other_credits).label("other"),
-            func.count(func.distinct(CopilotUsageReport.github_login)).label("users"),
-        )
-        .where(CopilotUsageReport.report_date >= thirty_days_ago)
-        .group_by(CopilotUsageReport.report_date)
-        .order_by(CopilotUsageReport.report_date)
+    trends_query = select(
+        CopilotUsageReport.report_date,
+        func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
+        func.sum(CopilotUsageReport.completions_credits).label("completions"),
+        func.sum(CopilotUsageReport.chat_credits).label("chat"),
+        func.sum(CopilotUsageReport.pr_credits).label("pr"),
+        func.sum(CopilotUsageReport.other_credits).label("other"),
+        func.count(func.distinct(CopilotUsageReport.github_login)).label("users"),
+    ).where(CopilotUsageReport.report_date >= thirty_days_ago)
+    if org:
+        trends_query = trends_query.where(CopilotUsageReport.org_slug == org)
+    trends_query = trends_query.group_by(CopilotUsageReport.report_date).order_by(
+        CopilotUsageReport.report_date
     )
+    result = await db.execute(trends_query)
     rows = result.fetchall()
 
     trends: list[dict[str, Any]] = []
@@ -2876,4 +2901,610 @@ async def get_copilot_billing_trends(db: AsyncSession) -> dict[str, Any]:
     return {
         "trends": trends,
         "period_days": 30,
+    }
+
+
+# ── Copilot Metrics Viewer Chart Functions ────────────────────────────────────
+
+
+async def get_copilot_activity(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
+    """DAU/WAU lines, completions count, acceptance rate bars, chat per user, requests per mode.
+
+    Returns 28 days of daily activity data for the Copilot activity dashboard.
+    """
+    from sqlalchemy import func
+
+    from app.models.copilot_metrics import CopilotDailyMetric
+
+    err = await _check_feature_enabled(db)
+    if err is not None:
+        return err
+
+    cutoff = (datetime.now(UTC) - timedelta(days=28)).date()
+
+    # DAU from summary rows (null dimensions)
+    summary_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.active_users).label("active_users"),
+    ).where(
+        CopilotDailyMetric.metric_type == "summary",
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        summary_query = summary_query.where(CopilotDailyMetric.org_slug == org)
+    summary_query = summary_query.group_by(CopilotDailyMetric.date).order_by(
+        CopilotDailyMetric.date
+    )
+    summary_result = await db.execute(summary_query)
+    summary_rows = list(summary_result.all())
+
+    # Completions per day
+    comp_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.total_suggestions).label("suggestions"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("acceptances"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        comp_query = comp_query.where(CopilotDailyMetric.org_slug == org)
+    comp_query = comp_query.group_by(CopilotDailyMetric.date).order_by(CopilotDailyMetric.date)
+    comp_result = await db.execute(comp_query)
+    comp_rows = list(comp_result.all())
+
+    # Chat requests per day
+    chat_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.total_suggestions).label("chat_requests"),
+    ).where(
+        CopilotDailyMetric.metric_type == "chat",
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        chat_query = chat_query.where(CopilotDailyMetric.org_slug == org)
+    chat_query = chat_query.group_by(CopilotDailyMetric.date).order_by(CopilotDailyMetric.date)
+    chat_result = await db.execute(chat_query)
+    chat_rows = list(chat_result.all())
+
+    # Requests per mode (all metric_types grouped by date + type)
+    mode_query = select(
+        CopilotDailyMetric.date,
+        CopilotDailyMetric.metric_type,
+        func.sum(CopilotDailyMetric.total_suggestions).label("requests"),
+    ).where(
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+        CopilotDailyMetric.metric_type.in_(["completions", "chat", "dotcom_chat", "pr"]),
+    )
+    if org:
+        mode_query = mode_query.where(CopilotDailyMetric.org_slug == org)
+    mode_query = mode_query.group_by(
+        CopilotDailyMetric.date, CopilotDailyMetric.metric_type
+    ).order_by(CopilotDailyMetric.date)
+    mode_result = await db.execute(mode_query)
+    mode_rows = list(mode_result.all())
+
+    # Build lookup maps
+    summary_map: dict[date_type, int] = {r.date: int(r.active_users or 0) for r in summary_rows}
+    comp_map: dict[date_type, tuple[int, int]] = {
+        r.date: (int(r.suggestions or 0), int(r.acceptances or 0)) for r in comp_rows
+    }
+    chat_map: dict[date_type, int] = {r.date: int(r.chat_requests or 0) for r in chat_rows}
+
+    # Mode map: date -> {metric_type: count}
+    mode_map: dict[date_type, dict[str, int]] = {}
+    for r in mode_rows:
+        mode_map.setdefault(r.date, {})[r.metric_type] = int(r.requests or 0)
+
+    # Collect all dates in order
+    all_dates_set: set[date_type] = set()
+    all_dates_set.update(summary_map.keys())
+    all_dates_set.update(comp_map.keys())
+    all_dates_set.update(chat_map.keys())
+    all_dates = sorted(all_dates_set)
+
+    dates: list[str] = []
+    ide_dau: list[int] = []
+    ide_wau: list[int] = []
+    completions_count: list[int] = []
+    completions_accepted: list[int] = []
+    acceptance_rate_pct: list[float] = []
+    chat_requests_per_user: list[float] = []
+    rpm_dates: list[str] = []
+    rpm_completions: list[int] = []
+    rpm_chat: list[int] = []
+    rpm_dotcom_chat: list[int] = []
+    rpm_pr: list[int] = []
+
+    for i, d in enumerate(all_dates):
+        dates.append(d.isoformat())
+        dau = summary_map.get(d, 0)
+        ide_dau.append(dau)
+
+        # 7-day rolling sum of DAU as WAU approximation
+        start_idx = max(0, i - 6)
+        wau_sum = sum(summary_map.get(all_dates[j], 0) for j in range(start_idx, i + 1))
+        ide_wau.append(wau_sum)
+
+        sugg, acc = comp_map.get(d, (0, 0))
+        completions_count.append(sugg)
+        completions_accepted.append(acc)
+        acceptance_rate_pct.append(round(acc / sugg * 100, 1) if sugg > 0 else 0.0)
+
+        chat_req = chat_map.get(d, 0)
+        chat_requests_per_user.append(round(chat_req / dau, 1) if dau > 0 else 0.0)
+
+        rpm_dates.append(d.isoformat())
+        mode_day = mode_map.get(d, {})
+        rpm_completions.append(mode_day.get("completions", 0))
+        rpm_chat.append(mode_day.get("chat", 0))
+        rpm_dotcom_chat.append(mode_day.get("dotcom_chat", 0))
+        rpm_pr.append(mode_day.get("pr", 0))
+
+    return {
+        "dates": dates,
+        "ide_dau": ide_dau,
+        "ide_wau": ide_wau,
+        "completions_count": completions_count,
+        "completions_accepted": completions_accepted,
+        "acceptance_rate_pct": acceptance_rate_pct,
+        "chat_requests_per_user": chat_requests_per_user,
+        "requests_per_mode": {
+            "dates": rpm_dates,
+            "completions": rpm_completions,
+            "chat": rpm_chat,
+            "dotcom_chat": rpm_dotcom_chat,
+            "pr": rpm_pr,
+        },
+    }
+
+
+async def get_copilot_chat_metrics(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
+    """Chat-specific time series: interactions, code actions, active users, action rate.
+
+    Returns 28 days of chat and dotcom_chat data.
+    """
+    from sqlalchemy import func
+
+    from app.models.copilot_metrics import CopilotDailyMetric
+
+    err = await _check_feature_enabled(db)
+    if err is not None:
+        return err
+
+    cutoff = (datetime.now(UTC) - timedelta(days=28)).date()
+
+    # Chat + dotcom_chat aggregated per day
+    chat_metrics_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.total_suggestions).label("interactions"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("code_actions"),
+        func.sum(CopilotDailyMetric.active_users).label("active_users"),
+    ).where(
+        CopilotDailyMetric.metric_type.in_(["chat", "dotcom_chat"]),
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        chat_metrics_query = chat_metrics_query.where(CopilotDailyMetric.org_slug == org)
+    chat_metrics_query = chat_metrics_query.group_by(CopilotDailyMetric.date).order_by(
+        CopilotDailyMetric.date
+    )
+    result = await db.execute(chat_metrics_query)
+    rows = list(result.all())
+
+    dates: list[str] = []
+    total_interactions: list[int] = []
+    code_actions: list[int] = []
+    active_chat_users: list[int] = []
+    action_rate_pct: list[float] = []
+
+    for r in rows:
+        dates.append(r.date.isoformat())
+        interactions = int(r.interactions or 0)
+        actions = int(r.code_actions or 0)
+        total_interactions.append(interactions)
+        code_actions.append(actions)
+        active_chat_users.append(int(r.active_users or 0))
+        action_rate_pct.append(round(actions / interactions * 100, 1) if interactions > 0 else 0.0)
+
+    return {
+        "dates": dates,
+        "total_interactions": total_interactions,
+        "code_actions": code_actions,
+        "active_chat_users": active_chat_users,
+        "action_rate_pct": action_rate_pct,
+    }
+
+
+async def get_copilot_language_breakdown(
+    db: AsyncSession, *, org: str | None = None
+) -> dict[str, Any]:
+    """Language-level analytics: per-day breakdown, distribution, models, editors.
+
+    Returns language data for the language breakdown dashboard.
+    """
+    from sqlalchemy import desc, func
+
+    from app.models.copilot_metrics import CopilotDailyMetric
+
+    err = await _check_feature_enabled(db)
+    if err is not None:
+        return err
+
+    cutoff = (datetime.now(UTC) - timedelta(days=28)).date()
+
+    # Determine top 8 languages by total suggestions
+    top_langs_query = select(
+        CopilotDailyMetric.language,
+        func.sum(CopilotDailyMetric.total_suggestions).label("total"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.isnot(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        top_langs_query = top_langs_query.where(CopilotDailyMetric.org_slug == org)
+    top_langs_query = (
+        top_langs_query.group_by(CopilotDailyMetric.language).order_by(desc("total")).limit(8)
+    )
+    top_langs_result = await db.execute(top_langs_query)
+    top_langs_rows = list(top_langs_result.all())
+    top_langs = [r.language for r in top_langs_rows]
+
+    if not top_langs:
+        return {
+            "dates": [],
+            "language_per_day": {},
+            "language_distribution": [],
+            "model_per_language": {"labels": [], "series": []},
+            "acceptance_by_editor": [],
+            "top_by_generations": [],
+            "top_by_lines": [],
+        }
+
+    # language_per_day: daily suggestions per language
+    lang_day_query = select(
+        CopilotDailyMetric.date,
+        CopilotDailyMetric.language,
+        func.sum(CopilotDailyMetric.total_suggestions).label("suggestions"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.in_(top_langs),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        lang_day_query = lang_day_query.where(CopilotDailyMetric.org_slug == org)
+    lang_day_query = lang_day_query.group_by(
+        CopilotDailyMetric.date, CopilotDailyMetric.language
+    ).order_by(CopilotDailyMetric.date)
+    lang_day_result = await db.execute(lang_day_query)
+    lang_day_rows = list(lang_day_result.all())
+
+    # Collect all dates
+    all_dates_set: set[date_type] = {r.date for r in lang_day_rows}
+    all_dates = sorted(all_dates_set)
+    dates = [d.isoformat() for d in all_dates]
+
+    # Build per-language daily map
+    lang_day_map: dict[str, dict[date_type, int]] = {lang: {} for lang in top_langs}
+    for r in lang_day_rows:
+        if r.language in lang_day_map:
+            lang_day_map[r.language][r.date] = int(r.suggestions or 0)
+
+    language_per_day: dict[str, list[int]] = {
+        lang: [lang_day_map[lang].get(d, 0) for d in all_dates] for lang in top_langs
+    }
+
+    # language_distribution: aggregated totals with colors
+    language_distribution: list[dict[str, Any]] = [
+        {
+            "name": r.language,
+            "value": int(r.total or 0),
+            "color": _lang_color(r.language),
+        }
+        for r in top_langs_rows
+    ]
+
+    # model_per_language: suggestions by language + model
+    model_lang_query = select(
+        CopilotDailyMetric.language,
+        CopilotDailyMetric.model,
+        func.sum(CopilotDailyMetric.total_suggestions).label("suggestions"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.in_(top_langs),
+        CopilotDailyMetric.model.isnot(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        model_lang_query = model_lang_query.where(CopilotDailyMetric.org_slug == org)
+    model_lang_query = model_lang_query.group_by(
+        CopilotDailyMetric.language, CopilotDailyMetric.model
+    ).order_by(desc("suggestions"))
+    model_lang_result = await db.execute(model_lang_query)
+    model_lang_rows = list(model_lang_result.all())
+
+    # Pivot: collect unique models and build series
+    model_lang_map: dict[str, dict[str, int]] = {}
+    for ml_row in model_lang_rows:
+        if ml_row.model is not None and ml_row.language is not None:
+            model_lang_map.setdefault(ml_row.model, {})[ml_row.language] = int(
+                ml_row.suggestions or 0
+            )
+
+    model_series: list[dict[str, Any]] = [
+        {"name": model, "data": [lang_data.get(lang, 0) for lang in top_langs]}
+        for model, lang_data in model_lang_map.items()
+    ]
+
+    # acceptance_by_editor
+    editor_query = select(
+        CopilotDailyMetric.editor,
+        func.sum(CopilotDailyMetric.total_suggestions).label("suggestions"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("acceptances"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.editor.isnot(None),
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        editor_query = editor_query.where(CopilotDailyMetric.org_slug == org)
+    editor_query = editor_query.group_by(CopilotDailyMetric.editor).order_by(desc("acceptances"))
+    editor_result = await db.execute(editor_query)
+    editor_rows = list(editor_result.all())
+    acceptance_by_editor: list[dict[str, Any]] = [
+        {
+            "editor": r.editor,
+            "rate": round(int(r.acceptances or 0) / int(r.suggestions or 1) * 100, 1),
+        }
+        for r in editor_rows
+        if int(r.suggestions or 0) > 0
+    ]
+
+    # top_by_generations: top 5 languages by total_suggestions
+    top_by_generations: list[dict[str, Any]] = [
+        {"language": r.language, "count": int(r.total or 0)} for r in top_langs_rows[:5]
+    ]
+
+    # top_by_lines: top 5 languages by total_lines_accepted
+    lines_query = select(
+        CopilotDailyMetric.language,
+        func.sum(CopilotDailyMetric.total_lines_accepted).label("lines"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.isnot(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        lines_query = lines_query.where(CopilotDailyMetric.org_slug == org)
+    lines_query = lines_query.group_by(CopilotDailyMetric.language).order_by(desc("lines")).limit(5)
+    lines_result = await db.execute(lines_query)
+    lines_rows = list(lines_result.all())
+    top_by_lines: list[dict[str, Any]] = [
+        {"language": r.language, "lines": int(r.lines or 0)} for r in lines_rows
+    ]
+
+    return {
+        "dates": dates,
+        "language_per_day": language_per_day,
+        "language_distribution": language_distribution,
+        "model_per_language": {
+            "labels": top_langs,
+            "series": model_series,
+        },
+        "acceptance_by_editor": acceptance_by_editor,
+        "top_by_generations": top_by_generations,
+        "top_by_lines": top_by_lines,
+    }
+
+
+async def get_copilot_pr_metrics(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
+    """PR-related time series: active users, contributions, review suggestions.
+
+    Returns 28 days of PR metric_type data.
+    """
+    from sqlalchemy import func
+
+    from app.models.copilot_metrics import CopilotDailyMetric
+
+    err = await _check_feature_enabled(db)
+    if err is not None:
+        return err
+
+    cutoff = (datetime.now(UTC) - timedelta(days=28)).date()
+
+    pr_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.active_users).label("active_users"),
+        func.sum(CopilotDailyMetric.total_suggestions).label("contributions"),
+        func.sum(CopilotDailyMetric.total_acceptances).label("review_suggestions"),
+    ).where(
+        CopilotDailyMetric.metric_type == "pr",
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        pr_query = pr_query.where(CopilotDailyMetric.org_slug == org)
+    pr_query = pr_query.group_by(CopilotDailyMetric.date).order_by(CopilotDailyMetric.date)
+    result = await db.execute(pr_query)
+    rows = list(result.all())
+
+    dates: list[str] = []
+    pr_activity: list[int] = []
+    pr_contributions: list[int] = []
+    review_suggestions: list[int] = []
+
+    for r in rows:
+        dates.append(r.date.isoformat())
+        pr_activity.append(int(r.active_users or 0))
+        pr_contributions.append(int(r.contributions or 0))
+        review_suggestions.append(int(r.review_suggestions or 0))
+
+    return {
+        "dates": dates,
+        "pr_activity": pr_activity,
+        "pr_contributions": pr_contributions,
+        "review_suggestions": review_suggestions,
+    }
+
+
+async def get_copilot_agent_activity(db: AsyncSession, *, org: str | None = None) -> dict[str, Any]:
+    """Agent/LOC activity metrics: daily lines, lines by mode/model/language.
+
+    Returns 28 days of lines-of-code activity data.
+    """
+    from sqlalchemy import desc, func
+
+    from app.models.copilot_metrics import CopilotDailyMetric
+
+    err = await _check_feature_enabled(db)
+    if err is not None:
+        return err
+
+    cutoff = (datetime.now(UTC) - timedelta(days=28)).date()
+
+    # Daily totals (all metric_types, null dimensions)
+    daily_query = select(
+        CopilotDailyMetric.date,
+        func.sum(CopilotDailyMetric.total_lines_suggested).label("lines_added"),
+        func.sum(CopilotDailyMetric.total_lines_accepted).label("lines_accepted"),
+    ).where(
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        daily_query = daily_query.where(CopilotDailyMetric.org_slug == org)
+    daily_query = daily_query.group_by(CopilotDailyMetric.date).order_by(CopilotDailyMetric.date)
+    daily_result = await db.execute(daily_query)
+    daily_rows = list(daily_result.all())
+
+    # Lines by mode per day
+    mode_query = select(
+        CopilotDailyMetric.date,
+        CopilotDailyMetric.metric_type,
+        func.sum(CopilotDailyMetric.total_lines_suggested).label("lines"),
+    ).where(
+        CopilotDailyMetric.language.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+        CopilotDailyMetric.metric_type.in_(["completions", "chat", "pr"]),
+    )
+    if org:
+        mode_query = mode_query.where(CopilotDailyMetric.org_slug == org)
+    mode_query = mode_query.group_by(
+        CopilotDailyMetric.date, CopilotDailyMetric.metric_type
+    ).order_by(CopilotDailyMetric.date)
+    mode_result = await db.execute(mode_query)
+    mode_rows = list(mode_result.all())
+
+    # Lines by model (aggregated)
+    model_query = select(
+        CopilotDailyMetric.model,
+        func.sum(CopilotDailyMetric.total_lines_suggested).label("lines_added"),
+        func.sum(CopilotDailyMetric.total_lines_accepted).label("lines_accepted"),
+    ).where(
+        CopilotDailyMetric.model.isnot(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        model_query = model_query.where(CopilotDailyMetric.org_slug == org)
+    model_query = (
+        model_query.group_by(CopilotDailyMetric.model).order_by(desc("lines_added")).limit(8)
+    )
+    model_result = await db.execute(model_query)
+    model_rows = list(model_result.all())
+
+    # Lines by language (aggregated)
+    lang_query = select(
+        CopilotDailyMetric.language,
+        func.sum(CopilotDailyMetric.total_lines_suggested).label("lines_added"),
+        func.sum(CopilotDailyMetric.total_lines_accepted).label("lines_accepted"),
+    ).where(
+        CopilotDailyMetric.metric_type == "completions",
+        CopilotDailyMetric.language.isnot(None),
+        CopilotDailyMetric.model.is_(None),
+        CopilotDailyMetric.editor.is_(None),
+        CopilotDailyMetric.date >= cutoff,
+    )
+    if org:
+        lang_query = lang_query.where(CopilotDailyMetric.org_slug == org)
+    lang_query = (
+        lang_query.group_by(CopilotDailyMetric.language).order_by(desc("lines_added")).limit(8)
+    )
+    lang_result = await db.execute(lang_query)
+    lang_rows = list(lang_result.all())
+
+    # Build daily arrays
+    all_dates = sorted({r.date for r in daily_rows})
+    dates = [d.isoformat() for d in all_dates]
+    daily_map: dict[date_type, tuple[int, int]] = {
+        r.date: (int(r.lines_added or 0), int(r.lines_accepted or 0)) for r in daily_rows
+    }
+    daily_lines_added = [daily_map.get(d, (0, 0))[0] for d in all_dates]
+    daily_lines_accepted = [daily_map.get(d, (0, 0))[1] for d in all_dates]
+
+    # Build lines_by_mode
+    mode_map: dict[str, dict[date_type, int]] = {"completions": {}, "chat": {}, "pr": {}}
+    for r in mode_rows:
+        if r.metric_type in mode_map:
+            mode_map[r.metric_type][r.date] = int(r.lines or 0)
+
+    lines_by_mode: dict[str, list[int]] = {
+        mode: [day_map.get(d, 0) for d in all_dates] for mode, day_map in mode_map.items()
+    }
+
+    # Build lines_by_model
+    lines_by_model: list[dict[str, Any]] = [
+        {
+            "model": r.model,
+            "lines_added": int(r.lines_added or 0),
+            "lines_accepted": int(r.lines_accepted or 0),
+        }
+        for r in model_rows
+    ]
+
+    # Build lines_by_language
+    lines_by_language: list[dict[str, Any]] = [
+        {
+            "language": r.language,
+            "lines_added": int(r.lines_added or 0),
+            "lines_accepted": int(r.lines_accepted or 0),
+        }
+        for r in lang_rows
+    ]
+
+    return {
+        "dates": dates,
+        "daily_lines_added": daily_lines_added,
+        "daily_lines_accepted": daily_lines_accepted,
+        "lines_by_mode": lines_by_mode,
+        "lines_by_model": lines_by_model,
+        "lines_by_language": lines_by_language,
     }

--- a/backend/app/services/copilot_metrics_service.py
+++ b/backend/app/services/copilot_metrics_service.py
@@ -866,26 +866,31 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
     """Data for the Overview pane: acceptance rates, language breakdown, user counts.
 
     Queries copilot_daily_metrics directly for reliable aggregates regardless
-    of cache format.
+    of cache format.  Returns a proper 7-day rolling acceptance rate over 28 days
+    and accurate seat counts from the CopilotSeatSnapshot table.
     """
-    from app.models.copilot_metrics import CopilotDailyMetric
+    from app.models.copilot_metrics import CopilotDailyMetric, CopilotSeatSnapshot
 
     err = await _check_feature_enabled(db)
     if err is not None:
         return err
 
-    # Query summary rows for acceptance rate (last 7 days)
+    from sqlalchemy import desc, func
+
+    # Query 35 days of summary data (grouped by date across all orgs) to compute
+    # 7-day rolling averages over the latest 28 days.
     summary_result = await db.execute(
         select(
             CopilotDailyMetric.date,
-            CopilotDailyMetric.active_users,
-            CopilotDailyMetric.engaged_users,
-            CopilotDailyMetric.total_suggestions,
-            CopilotDailyMetric.total_acceptances,
+            func.sum(CopilotDailyMetric.active_users).label("active_users"),
+            func.sum(CopilotDailyMetric.engaged_users).label("engaged_users"),
+            func.sum(CopilotDailyMetric.total_suggestions).label("total_suggestions"),
+            func.sum(CopilotDailyMetric.total_acceptances).label("total_acceptances"),
         )
         .where(CopilotDailyMetric.metric_type == "summary")
+        .group_by(CopilotDailyMetric.date)
         .order_by(CopilotDailyMetric.date.desc())
-        .limit(28)
+        .limit(35)
     )
     summary_rows = list(summary_result.all())
 
@@ -903,24 +908,27 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
             "languages": [],
             "total_active_users": 0,
             "total_engaged_users": 0,
+            "total_provisioned_seats": 0,
         }
 
-    # Reverse to chronological order and take last 7
+    # Reverse to chronological order
     summary_rows.reverse()
-    recent = summary_rows[-7:] if len(summary_rows) >= 7 else summary_rows
 
+    # Compute 7-day rolling acceptance rate for each day that has a full window
     rate_labels: list[str] = []
     rate_values: list[float] = []
-    for row in recent:
-        rate_labels.append(_DAY_LABELS[row.date.weekday()])
-        pct = (
-            (row.total_acceptances / row.total_suggestions * 100) if row.total_suggestions else 0.0
-        )
+    for i in range(len(summary_rows)):
+        if i < 6:
+            # Need at least 7 days for a full rolling window
+            continue
+        window = summary_rows[i - 6 : i + 1]
+        total_sugg = sum(r.total_suggestions or 0 for r in window)
+        total_acc = sum(r.total_acceptances or 0 for r in window)
+        pct = (total_acc / total_sugg * 100) if total_sugg > 0 else 0.0
+        rate_labels.append(summary_rows[i].date.isoformat())
         rate_values.append(round(pct, 1))
 
     # Language breakdown from DB (all available days)
-    from sqlalchemy import desc, func
-
     lang_result = await db.execute(
         select(
             CopilotDailyMetric.language,
@@ -947,9 +955,34 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
         for row in lang_rows
     ]
 
-    # Latest user counts
+    # Active users: count distinct users with activity in last 28 days
+    # from CopilotSeatSnapshot (matches what GitHub insights tab shows)
+    cutoff_date = (datetime.now(UTC) - timedelta(days=28)).date()
+    active_result = await db.execute(
+        select(func.count(func.distinct(CopilotSeatSnapshot.github_login))).where(
+            CopilotSeatSnapshot.last_activity_at
+            >= datetime.combine(cutoff_date, datetime.min.time()).replace(tzinfo=UTC)
+        )
+    )
+    total_active = active_result.scalar() or 0
+
+    # Provisioned seats: count distinct users in the latest snapshot
+    latest_snapshot_date_result = await db.execute(
+        select(func.max(CopilotSeatSnapshot.snapshot_date))
+    )
+    latest_snapshot_date = latest_snapshot_date_result.scalar()
+
+    total_provisioned = 0
+    if latest_snapshot_date:
+        prov_result = await db.execute(
+            select(func.count(func.distinct(CopilotSeatSnapshot.github_login))).where(
+                CopilotSeatSnapshot.snapshot_date == latest_snapshot_date
+            )
+        )
+        total_provisioned = prov_result.scalar() or 0
+
+    # Engaged users from summary rows
     latest = summary_rows[-1] if summary_rows else None
-    total_active = latest.active_users if latest else 0
     total_engaged = latest.engaged_users if latest else 0
 
     return {
@@ -959,6 +992,7 @@ async def get_copilot_overview(db: AsyncSession) -> dict[str, Any]:
         "languages": lang_items,
         "total_active_users": total_active,
         "total_engaged_users": total_engaged,
+        "total_provisioned_seats": total_provisioned,
     }
 
 
@@ -984,23 +1018,16 @@ def _build_overview_from_raw(days: list[dict[str, Any]]) -> dict[str, Any]:
             "languages": [],
             "total_active_users": 0,
             "total_engaged_users": 0,
+            "total_provisioned_seats": 0,
         }
 
     # Sort by date
     flat_days.sort(key=lambda d: d.get("day", "") or d.get("date", ""))
-    recent = flat_days[-7:] if len(flat_days) >= 7 else flat_days
 
-    rate_labels: list[str] = []
-    rate_values: list[float] = []
-    for day_obj in recent:
+    # Extract per-day suggestions/acceptances for rolling average calculation
+    daily_data: list[tuple[str, int, int]] = []
+    for day_obj in flat_days:
         date_str = day_obj.get("day", "") or day_obj.get("date", "")
-        try:
-            dt = datetime.fromisoformat(date_str)
-            rate_labels.append(_DAY_LABELS[dt.weekday()])
-        except (ValueError, TypeError):
-            rate_labels.append("?")
-
-        # New format: top-level counts
         total_suggestions = day_obj.get("code_generation_activity_count", 0)
         total_acceptances = day_obj.get("code_acceptance_activity_count", 0)
 
@@ -1013,7 +1040,19 @@ def _build_overview_from_raw(days: list[dict[str, Any]]) -> dict[str, Any]:
                         total_suggestions += lang.get("total_code_suggestions", 0)
                         total_acceptances += lang.get("total_code_acceptances", 0)
 
-        pct = (total_acceptances / total_suggestions * 100) if total_suggestions else 0.0
+        daily_data.append((date_str, total_suggestions, total_acceptances))
+
+    # Compute 7-day rolling acceptance rate
+    rate_labels: list[str] = []
+    rate_values: list[float] = []
+    for i in range(len(daily_data)):
+        if i < 6:
+            continue
+        window = daily_data[i - 6 : i + 1]
+        sugg_sum = sum(d[1] for d in window)
+        acc_sum = sum(d[2] for d in window)
+        pct = (acc_sum / sugg_sum * 100) if sugg_sum > 0 else 0.0
+        rate_labels.append(daily_data[i][0])
         rate_values.append(round(pct, 1))
 
     # Language breakdown
@@ -1060,6 +1099,7 @@ def _build_overview_from_raw(days: list[dict[str, Any]]) -> dict[str, Any]:
         "languages": lang_items[:10],
         "total_active_users": total_active,
         "total_engaged_users": total_engaged,
+        "total_provisioned_seats": 0,
     }
 
 
@@ -1612,6 +1652,59 @@ async def get_copilot_models(db: AsyncSession) -> dict[str, Any]:
         "editors": editors_list,
         "time_series": time_series,
     }
+
+
+async def get_copilot_model_users(db: AsyncSession) -> dict[str, Any]:
+    """Per-user Copilot usage breakdown by feature category.
+
+    Returns sortable/filterable data showing credits consumed by each user
+    across completions, chat, PR review, and other categories.
+    """
+    from sqlalchemy import func
+
+    from app.models.copilot_usage import CopilotUsageReport
+
+    err = await _check_feature_enabled(db)
+    if err is not None:
+        return err
+
+    now = datetime.now(UTC)
+    period_start = (now - timedelta(days=28)).date()
+
+    result = await db.execute(
+        select(
+            CopilotUsageReport.github_login,
+            func.sum(CopilotUsageReport.total_credits_consumed).label("total"),
+            func.sum(CopilotUsageReport.completions_credits).label("completions"),
+            func.sum(CopilotUsageReport.chat_credits).label("chat"),
+            func.sum(CopilotUsageReport.pr_credits).label("pr"),
+            func.sum(CopilotUsageReport.other_credits).label("other"),
+            func.count(CopilotUsageReport.report_date).label("days_active"),
+            func.max(CopilotUsageReport.report_date).label("last_active"),
+        )
+        .where(CopilotUsageReport.report_date >= period_start)
+        .group_by(CopilotUsageReport.github_login)
+        .order_by(func.sum(CopilotUsageReport.total_credits_consumed).desc())
+    )
+    rows = result.fetchall()
+
+    users: list[dict[str, Any]] = []
+    for row in rows:
+        total = float(row[1] or 0)
+        users.append(
+            {
+                "login": row[0],
+                "total_credits": round(total, 2),
+                "completions_credits": round(float(row[2] or 0), 2),
+                "chat_credits": round(float(row[3] or 0), 2),
+                "pr_credits": round(float(row[4] or 0), 2),
+                "other_credits": round(float(row[5] or 0), 2),
+                "days_active": int(row[6] or 0),
+                "last_active": row[7].isoformat() if row[7] else None,
+            }
+        )
+
+    return {"users": users, "total_users": len(users)}
 
 
 def _build_models_from_raw(days: list[dict[str, Any]]) -> dict[str, Any]:

--- a/backend/app/services/report_service.py
+++ b/backend/app/services/report_service.py
@@ -105,20 +105,19 @@ async def get_seat_utilization_report(
     provisioned_seat_count: int = max_row.max_active if max_row and max_row.max_active else 0
 
     # ------------------------------------------------------------------
-    # 2. Per-bucket active seat counts
+    # 2. Per-bucket active seat counts (enterprise-wide, one row per bucket)
     # ------------------------------------------------------------------
     # SECURITY: static clause fragments only, not user input
     stmt = text(f"""
         SELECT
             time_bucket(:interval, created_at)  AS bucket,
-            org,
             COUNT(DISTINCT actor)               AS active_seats
         FROM events
         WHERE created_at >= :start
           {org_filter}
           AND actor IS NOT NULL
-        GROUP BY 1, 2
-        ORDER BY 1 ASC, 2
+        GROUP BY 1
+        ORDER BY 1 ASC
     """)
 
     result = await session.execute(stmt, params)

--- a/backend/tests/test_copilot_metrics.py
+++ b/backend/tests/test_copilot_metrics.py
@@ -240,10 +240,12 @@ class TestCopilotOverview:
     @pytest.mark.asyncio
     async def test_computes_acceptance_rates(self) -> None:
         db = _mock_db_empty_results()
-        sample = _make_sample_days(7)
+        # 7-day rolling window: need 14 days to get 8 data points (i >= 6)
+        sample = _make_sample_days(14)
         with _patch_store(sample):
             result = await copilot_metrics_service.get_copilot_overview(db)
-        assert len(result["acceptance_rate_values"]) == 7
+        # 14 days with rolling window of 7 → 8 data points (indices 6..13)
+        assert len(result["acceptance_rate_values"]) == 8
         assert all(isinstance(v, float) for v in result["acceptance_rate_values"])
         assert all(0 <= v <= 100 for v in result["acceptance_rate_values"])
 
@@ -287,10 +289,11 @@ class TestCopilotOverview:
     @pytest.mark.asyncio
     async def test_handles_fewer_than_seven_days(self) -> None:
         db = _mock_db_empty_results()
+        # 3 days is fewer than the 7-day rolling window → 0 data points
         sample = _make_sample_days(3)
         with _patch_store(sample):
             result = await copilot_metrics_service.get_copilot_overview(db)
-        assert len(result["acceptance_rate_values"]) == 3
+        assert len(result["acceptance_rate_values"]) == 0
 
 
 # ── Service tests: adoption ───────────────────────────────────────────────────
@@ -719,10 +722,11 @@ class TestMissingFields:
     async def test_overview_handles_missing_completions(self) -> None:
         """Days with no copilot_ide_code_completions should not crash."""
         db = _mock_db_empty_results()
+        # Single day → fewer than 7 days → 0 rolling window data points
         sample = [{"date": "2025-01-01", "total_active_users": 5, "total_engaged_users": 3}]
         with _patch_store(sample):
             result = await copilot_metrics_service.get_copilot_overview(db)
-        assert result["acceptance_rate_values"] == [0.0]
+        assert result["acceptance_rate_values"] == []
         assert result["languages"] == []
 
     @pytest.mark.asyncio

--- a/backend/tests/test_copilot_viewer_metrics.py
+++ b/backend/tests/test_copilot_viewer_metrics.py
@@ -1,0 +1,452 @@
+"""Tests for the new Copilot Metrics Viewer chart service functions.
+
+Covers:
+- get_copilot_activity
+- get_copilot_chat_metrics
+- get_copilot_language_breakdown
+- get_copilot_pr_metrics
+- get_copilot_agent_activity
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services import copilot_metrics_service
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _mock_db_with_rows(*row_batches: list[Any]) -> AsyncMock:
+    """Return an AsyncMock db that returns rows sequentially for each execute() call."""
+    db = AsyncMock(spec=AsyncSession)
+    results = []
+    for rows in row_batches:
+        mock_result = MagicMock()
+        mock_result.all.return_value = rows
+        mock_result.scalar_one_or_none.return_value = None
+        results.append(mock_result)
+    db.execute = AsyncMock(side_effect=results)
+    return db
+
+
+def _mock_db_empty() -> AsyncMock:
+    """Return a DB mock where all queries return empty results."""
+    db = AsyncMock(spec=AsyncSession)
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_result.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(return_value=mock_result)
+    return db
+
+
+def _make_row(**kwargs: Any) -> MagicMock:
+    """Create a mock row object with attribute access."""
+    row = MagicMock()
+    for k, v in kwargs.items():
+        setattr(row, k, v)
+    # Also support index access for Row-like objects
+    row.__getitem__ = lambda self, idx: list(kwargs.values())[idx]
+    return row
+
+
+def _patch_enabled():
+    """Patch _check_feature_enabled to return None (enabled)."""
+    return patch.object(copilot_metrics_service, "_check_feature_enabled", return_value=None)
+
+
+# ── Test: get_copilot_activity ────────────────────────────────────────────────
+
+
+class TestGetCopilotActivity:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_disabled(self) -> None:
+        db = _mock_db_empty()
+        with patch.object(
+            copilot_metrics_service,
+            "_check_feature_enabled",
+            return_value={"error": "feature_disabled", "message": "test"},
+        ):
+            result = await copilot_metrics_service.get_copilot_activity(db)
+        assert result["error"] == "feature_disabled"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_with_no_data(self) -> None:
+        db = _mock_db_empty()
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_activity(db)
+        assert result["dates"] == []
+        assert result["ide_dau"] == []
+        assert result["completions_count"] == []
+        assert result["requests_per_mode"]["dates"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_expected_shape(self) -> None:
+        today = date.today()
+        d1 = today - timedelta(days=2)
+        d2 = today - timedelta(days=1)
+
+        # summary rows (query 1)
+        summary_rows = [
+            _make_row(date=d1, active_users=100),
+            _make_row(date=d2, active_users=120),
+        ]
+        # completions rows (query 2)
+        comp_rows = [
+            _make_row(date=d1, suggestions=500, acceptances=200),
+            _make_row(date=d2, suggestions=600, acceptances=250),
+        ]
+        # chat rows (query 3)
+        chat_rows = [
+            _make_row(date=d1, chat_requests=400),
+            _make_row(date=d2, chat_requests=480),
+        ]
+        # mode rows (query 4)
+        mode_rows = [
+            _make_row(date=d1, metric_type="completions", requests=500),
+            _make_row(date=d1, metric_type="chat", requests=400),
+            _make_row(date=d2, metric_type="completions", requests=600),
+            _make_row(date=d2, metric_type="chat", requests=480),
+        ]
+
+        db = _mock_db_with_rows(summary_rows, comp_rows, chat_rows, mode_rows)
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_activity(db)
+
+        assert len(result["dates"]) == 2
+        assert result["ide_dau"] == [100, 120]
+        assert result["completions_count"] == [500, 600]
+        assert result["completions_accepted"] == [200, 250]
+        assert result["acceptance_rate_pct"][0] == round(200 / 500 * 100, 1)
+        assert result["chat_requests_per_user"][0] == round(400 / 100, 1)
+        assert result["requests_per_mode"]["completions"] == [500, 600]
+        assert result["requests_per_mode"]["chat"] == [400, 480]
+
+    @pytest.mark.asyncio
+    async def test_wau_is_rolling_sum(self) -> None:
+        """WAU should be a 7-day rolling sum of DAU."""
+        today = date.today()
+        # Create 3 days of data
+        days = [today - timedelta(days=i) for i in range(2, -1, -1)]
+        summary_rows = [_make_row(date=d, active_users=100) for d in days]
+
+        db = _mock_db_with_rows(summary_rows, [], [], [])
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_activity(db)
+
+        # WAU for day 3 = sum of all 3 days = 300
+        assert result["ide_wau"][2] == 300
+        # WAU for day 1 = just day 1 = 100
+        assert result["ide_wau"][0] == 100
+
+
+# ── Test: get_copilot_chat_metrics ────────────────────────────────────────────
+
+
+class TestGetCopilotChatMetrics:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_disabled(self) -> None:
+        db = _mock_db_empty()
+        with patch.object(
+            copilot_metrics_service,
+            "_check_feature_enabled",
+            return_value={"error": "feature_disabled", "message": "test"},
+        ):
+            result = await copilot_metrics_service.get_copilot_chat_metrics(db)
+        assert result["error"] == "feature_disabled"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_with_no_data(self) -> None:
+        db = _mock_db_empty()
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_chat_metrics(db)
+        assert result["dates"] == []
+        assert result["total_interactions"] == []
+        assert result["code_actions"] == []
+        assert result["active_chat_users"] == []
+        assert result["action_rate_pct"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_values(self) -> None:
+        today = date.today()
+        d1 = today - timedelta(days=1)
+        rows = [
+            _make_row(date=d1, interactions=800, code_actions=200, active_users=95),
+        ]
+        db = _mock_db_with_rows(rows)
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_chat_metrics(db)
+
+        assert result["dates"] == [d1.isoformat()]
+        assert result["total_interactions"] == [800]
+        assert result["code_actions"] == [200]
+        assert result["active_chat_users"] == [95]
+        assert result["action_rate_pct"] == [25.0]
+
+    @pytest.mark.asyncio
+    async def test_action_rate_zero_when_no_interactions(self) -> None:
+        today = date.today()
+        d1 = today - timedelta(days=1)
+        rows = [
+            _make_row(date=d1, interactions=0, code_actions=0, active_users=0),
+        ]
+        db = _mock_db_with_rows(rows)
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_chat_metrics(db)
+        assert result["action_rate_pct"] == [0.0]
+
+
+# ── Test: get_copilot_language_breakdown ──────────────────────────────────────
+
+
+class TestGetCopilotLanguageBreakdown:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_disabled(self) -> None:
+        db = _mock_db_empty()
+        with patch.object(
+            copilot_metrics_service,
+            "_check_feature_enabled",
+            return_value={"error": "feature_disabled", "message": "test"},
+        ):
+            result = await copilot_metrics_service.get_copilot_language_breakdown(db)
+        assert result["error"] == "feature_disabled"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_with_no_data(self) -> None:
+        db = _mock_db_empty()
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_language_breakdown(db)
+        assert result["dates"] == []
+        assert result["language_per_day"] == {}
+        assert result["language_distribution"] == []
+        assert result["model_per_language"] == {"labels": [], "series": []}
+        assert result["acceptance_by_editor"] == []
+        assert result["top_by_generations"] == []
+        assert result["top_by_lines"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_language_data(self) -> None:
+        today = date.today()
+        d1 = today - timedelta(days=1)
+
+        # Query 1: top languages
+        top_langs = [
+            _make_row(language="TypeScript", total=5000),
+            _make_row(language="Python", total=3000),
+        ]
+        # Query 2: language per day
+        lang_day = [
+            _make_row(date=d1, language="TypeScript", suggestions=500),
+            _make_row(date=d1, language="Python", suggestions=300),
+        ]
+        # Query 3: model per language
+        model_lang = [
+            _make_row(language="TypeScript", model="gpt-4o", suggestions=400),
+            _make_row(language="Python", model="gpt-4o", suggestions=250),
+        ]
+        # Query 4: acceptance by editor
+        editors = [
+            _make_row(editor="VS Code", suggestions=1000, acceptances=380),
+        ]
+        # Query 5: top by lines
+        lines = [
+            _make_row(language="TypeScript", lines=20000),
+            _make_row(language="Python", lines=15000),
+        ]
+
+        db = _mock_db_with_rows(top_langs, lang_day, model_lang, editors, lines)
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_language_breakdown(db)
+
+        assert result["dates"] == [d1.isoformat()]
+        assert "TypeScript" in result["language_per_day"]
+        assert "Python" in result["language_per_day"]
+        assert len(result["language_distribution"]) == 2
+        assert result["language_distribution"][0]["name"] == "TypeScript"
+        assert result["language_distribution"][0]["value"] == 5000
+        assert "color" in result["language_distribution"][0]
+        assert result["model_per_language"]["labels"] == ["TypeScript", "Python"]
+        assert len(result["model_per_language"]["series"]) == 1
+        assert result["model_per_language"]["series"][0]["name"] == "gpt-4o"
+        assert result["acceptance_by_editor"][0]["editor"] == "VS Code"
+        assert result["acceptance_by_editor"][0]["rate"] == 38.0
+        assert result["top_by_generations"][0]["language"] == "TypeScript"
+        assert result["top_by_generations"][0]["count"] == 5000
+        assert result["top_by_lines"][0]["language"] == "TypeScript"
+        assert result["top_by_lines"][0]["lines"] == 20000
+
+
+# ── Test: get_copilot_pr_metrics ──────────────────────────────────────────────
+
+
+class TestGetCopilotPrMetrics:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_disabled(self) -> None:
+        db = _mock_db_empty()
+        with patch.object(
+            copilot_metrics_service,
+            "_check_feature_enabled",
+            return_value={"error": "feature_disabled", "message": "test"},
+        ):
+            result = await copilot_metrics_service.get_copilot_pr_metrics(db)
+        assert result["error"] == "feature_disabled"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_with_no_data(self) -> None:
+        db = _mock_db_empty()
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_pr_metrics(db)
+        assert result["dates"] == []
+        assert result["pr_activity"] == []
+        assert result["pr_contributions"] == []
+        assert result["review_suggestions"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_values(self) -> None:
+        today = date.today()
+        d1 = today - timedelta(days=2)
+        d2 = today - timedelta(days=1)
+        rows = [
+            _make_row(date=d1, active_users=10, contributions=50, review_suggestions=30),
+            _make_row(date=d2, active_users=12, contributions=55, review_suggestions=35),
+        ]
+        db = _mock_db_with_rows(rows)
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_pr_metrics(db)
+
+        assert result["dates"] == [d1.isoformat(), d2.isoformat()]
+        assert result["pr_activity"] == [10, 12]
+        assert result["pr_contributions"] == [50, 55]
+        assert result["review_suggestions"] == [30, 35]
+
+
+# ── Test: get_copilot_agent_activity ──────────────────────────────────────────
+
+
+class TestGetCopilotAgentActivity:
+    @pytest.mark.asyncio
+    async def test_returns_error_when_disabled(self) -> None:
+        db = _mock_db_empty()
+        with patch.object(
+            copilot_metrics_service,
+            "_check_feature_enabled",
+            return_value={"error": "feature_disabled", "message": "test"},
+        ):
+            result = await copilot_metrics_service.get_copilot_agent_activity(db)
+        assert result["error"] == "feature_disabled"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_with_no_data(self) -> None:
+        db = _mock_db_empty()
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_agent_activity(db)
+        assert result["dates"] == []
+        assert result["daily_lines_added"] == []
+        assert result["daily_lines_accepted"] == []
+        assert result["lines_by_mode"] == {"completions": [], "chat": [], "pr": []}
+        assert result["lines_by_model"] == []
+        assert result["lines_by_language"] == []
+
+    @pytest.mark.asyncio
+    async def test_returns_correct_values(self) -> None:
+        today = date.today()
+        d1 = today - timedelta(days=1)
+
+        # Query 1: daily totals
+        daily_rows = [
+            _make_row(date=d1, lines_added=5000, lines_accepted=3000),
+        ]
+        # Query 2: lines by mode
+        mode_rows = [
+            _make_row(date=d1, metric_type="completions", lines=4000),
+            _make_row(date=d1, metric_type="chat", lines=800),
+            _make_row(date=d1, metric_type="pr", lines=200),
+        ]
+        # Query 3: lines by model
+        model_rows = [
+            _make_row(model="gpt-4o", lines_added=25000, lines_accepted=15000),
+            _make_row(model="claude-3.5", lines_added=10000, lines_accepted=6000),
+        ]
+        # Query 4: lines by language
+        lang_rows = [
+            _make_row(language="TypeScript", lines_added=20000, lines_accepted=12000),
+            _make_row(language="Python", lines_added=15000, lines_accepted=9000),
+        ]
+
+        db = _mock_db_with_rows(daily_rows, mode_rows, model_rows, lang_rows)
+        with _patch_enabled():
+            result = await copilot_metrics_service.get_copilot_agent_activity(db)
+
+        assert result["dates"] == [d1.isoformat()]
+        assert result["daily_lines_added"] == [5000]
+        assert result["daily_lines_accepted"] == [3000]
+        assert result["lines_by_mode"]["completions"] == [4000]
+        assert result["lines_by_mode"]["chat"] == [800]
+        assert result["lines_by_mode"]["pr"] == [200]
+        assert result["lines_by_model"][0]["model"] == "gpt-4o"
+        assert result["lines_by_model"][0]["lines_added"] == 25000
+        assert result["lines_by_language"][0]["language"] == "TypeScript"
+        assert result["lines_by_language"][0]["lines_accepted"] == 12000
+
+
+# ── Test: Router endpoints ────────────────────────────────────────────────────
+
+
+class TestCopilotViewerRouterAuth:
+    """New copilot viewer endpoints must require authentication."""
+
+    def _get_client(self) -> Any:
+        from fastapi import FastAPI
+        from fastapi.testclient import TestClient
+
+        from app.deps import get_db, get_valkey
+        from app.routers import copilot as copilot_router_module
+
+        app = FastAPI()
+        app.include_router(copilot_router_module.router, prefix="/api/v1")
+
+        mock_db = AsyncMock(spec=AsyncSession)
+
+        async def override_db() -> Any:
+            yield mock_db
+
+        mock_valkey = AsyncMock()
+        mock_valkey.get = AsyncMock(return_value=None)
+        mock_valkey.ping = AsyncMock(return_value=True)
+
+        async def override_valkey() -> Any:
+            yield mock_valkey
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_valkey] = override_valkey
+        return TestClient(app)
+
+    def test_activity_returns_401_unauthenticated(self) -> None:
+        client = self._get_client()
+        resp = client.get("/api/v1/copilot/activity")
+        assert resp.status_code == 401
+
+    def test_chat_metrics_returns_401_unauthenticated(self) -> None:
+        client = self._get_client()
+        resp = client.get("/api/v1/copilot/chat-metrics")
+        assert resp.status_code == 401
+
+    def test_language_breakdown_returns_401_unauthenticated(self) -> None:
+        client = self._get_client()
+        resp = client.get("/api/v1/copilot/language-breakdown")
+        assert resp.status_code == 401
+
+    def test_pr_metrics_returns_401_unauthenticated(self) -> None:
+        client = self._get_client()
+        resp = client.get("/api/v1/copilot/pr-metrics")
+        assert resp.status_code == 401
+
+    def test_agent_activity_returns_401_unauthenticated(self) -> None:
+        client = self._get_client()
+        resp = client.get("/api/v1/copilot/agent-activity")
+        assert resp.status_code == 401

--- a/frontend/src/api/copilotGovernance.ts
+++ b/frontend/src/api/copilotGovernance.ts
@@ -31,8 +31,8 @@ export interface CopilotPolicyViolationsResponse {
   total: number;
 }
 
-export function listCopilotPolicies() {
-  return api.get<CopilotPolicy[]>('/copilot-governance/policies');
+export function listCopilotPolicies(org?: string) {
+  return api.get<CopilotPolicy[]>('/copilot-governance/policies', { org });
 }
 
 export function createCopilotPolicy(body: {
@@ -59,6 +59,7 @@ export function listCopilotViolations(params?: {
   policy_id?: number;
   severity?: string;
   status?: string;
+  org?: string;
   page?: number;
   page_size?: number;
 }) {

--- a/frontend/src/api/copilotMetrics.ts
+++ b/frontend/src/api/copilotMetrics.ts
@@ -7,6 +7,7 @@ export interface CopilotOverview {
   languages: Array<{ lang: string; pct: number; color: string }>;
   total_active_users: number;
   total_engaged_users: number;
+  total_provisioned_seats: number;
   error?: string;
   message?: string;
 }
@@ -233,6 +234,28 @@ export function getCopilotAdoption(): Promise<CopilotAdoption> {
 
 export function getCopilotModels(): Promise<CopilotModels> {
   return api.get<CopilotModels>('/copilot/models');
+}
+
+export interface CopilotModelUser {
+  login: string;
+  total_credits: number;
+  completions_credits: number;
+  chat_credits: number;
+  pr_credits: number;
+  other_credits: number;
+  days_active: number;
+  last_active: string | null;
+}
+
+export interface CopilotModelUsers {
+  users: CopilotModelUser[];
+  total_users: number;
+  error?: string;
+  message?: string;
+}
+
+export function getCopilotModelUsers(): Promise<CopilotModelUsers> {
+  return api.get<CopilotModelUsers>('/copilot/model-users');
 }
 
 export function getCopilotAnomalies(): Promise<CopilotAnomalies> {

--- a/frontend/src/api/copilotMetrics.ts
+++ b/frontend/src/api/copilotMetrics.ts
@@ -224,16 +224,16 @@ export interface CopilotROI {
   message?: string;
 }
 
-export function getCopilotOverview(): Promise<CopilotOverview> {
-  return api.get<CopilotOverview>('/copilot/overview');
+export function getCopilotOverview(org?: string): Promise<CopilotOverview> {
+  return api.get<CopilotOverview>('/copilot/overview', { org });
 }
 
-export function getCopilotAdoption(): Promise<CopilotAdoption> {
-  return api.get<CopilotAdoption>('/copilot/adoption');
+export function getCopilotAdoption(org?: string): Promise<CopilotAdoption> {
+  return api.get<CopilotAdoption>('/copilot/adoption', { org });
 }
 
-export function getCopilotModels(): Promise<CopilotModels> {
-  return api.get<CopilotModels>('/copilot/models');
+export function getCopilotModels(org?: string): Promise<CopilotModels> {
+  return api.get<CopilotModels>('/copilot/models', { org });
 }
 
 export interface CopilotModelUser {
@@ -254,28 +254,28 @@ export interface CopilotModelUsers {
   message?: string;
 }
 
-export function getCopilotModelUsers(): Promise<CopilotModelUsers> {
-  return api.get<CopilotModelUsers>('/copilot/model-users');
+export function getCopilotModelUsers(org?: string): Promise<CopilotModelUsers> {
+  return api.get<CopilotModelUsers>('/copilot/model-users', { org });
 }
 
-export function getCopilotAnomalies(): Promise<CopilotAnomalies> {
-  return api.get<CopilotAnomalies>('/copilot/anomalies');
+export function getCopilotAnomalies(org?: string): Promise<CopilotAnomalies> {
+  return api.get<CopilotAnomalies>('/copilot/anomalies', { org });
 }
 
-export function getCopilotTeams(): Promise<CopilotTeams> {
-  return api.get<CopilotTeams>('/copilot/teams');
+export function getCopilotTeams(org?: string): Promise<CopilotTeams> {
+  return api.get<CopilotTeams>('/copilot/teams', { org });
 }
 
-export function getCopilotBlockers(): Promise<CopilotBlockers> {
-  return api.get<CopilotBlockers>('/copilot/blockers');
+export function getCopilotBlockers(org?: string): Promise<CopilotBlockers> {
+  return api.get<CopilotBlockers>('/copilot/blockers', { org });
 }
 
-export function getCopilotPolicyChanges(): Promise<CopilotPolicyChanges> {
-  return api.get<CopilotPolicyChanges>('/copilot/policy-changes');
+export function getCopilotPolicyChanges(org?: string): Promise<CopilotPolicyChanges> {
+  return api.get<CopilotPolicyChanges>('/copilot/policy-changes', { org });
 }
 
-export function getCopilotROI(): Promise<CopilotROI> {
-  return api.get<CopilotROI>('/copilot/roi');
+export function getCopilotROI(org?: string): Promise<CopilotROI> {
+  return api.get<CopilotROI>('/copilot/roi', { org });
 }
 
 // ── Billing / UBB types ──────────────────────────────────────────────────────
@@ -328,14 +328,108 @@ export interface CopilotBillingTrends {
   message?: string;
 }
 
-export function getCopilotBillingOverview(): Promise<CopilotBillingOverview> {
-  return api.get<CopilotBillingOverview>('/copilot/billing-overview');
+export function getCopilotBillingOverview(org?: string): Promise<CopilotBillingOverview> {
+  return api.get<CopilotBillingOverview>('/copilot/billing-overview', { org });
 }
 
-export function getCopilotUserBudgets(): Promise<CopilotUserBudgets> {
-  return api.get<CopilotUserBudgets>('/copilot/user-budgets');
+export function getCopilotUserBudgets(org?: string): Promise<CopilotUserBudgets> {
+  return api.get<CopilotUserBudgets>('/copilot/user-budgets', { org });
 }
 
-export function getCopilotBillingTrends(): Promise<CopilotBillingTrends> {
-  return api.get<CopilotBillingTrends>('/copilot/billing-trends');
+export function getCopilotBillingTrends(org?: string): Promise<CopilotBillingTrends> {
+  return api.get<CopilotBillingTrends>('/copilot/billing-trends', { org });
+}
+
+// ── Activity metrics types ───────────────────────────────────────────────────
+
+export interface CopilotActivity {
+  dates: string[];
+  ide_dau: number[];
+  ide_wau: number[];
+  completions_count: number[];
+  completions_accepted: number[];
+  acceptance_rate_pct: number[];
+  chat_requests_per_user: number[];
+  requests_per_mode: {
+    dates: string[];
+    completions: number[];
+    chat: number[];
+    dotcom_chat: number[];
+    pr: number[];
+  };
+  error?: string;
+  message?: string;
+}
+
+export function getCopilotActivity(org?: string): Promise<CopilotActivity> {
+  return api.get<CopilotActivity>('/copilot/activity', { org });
+}
+
+// ── Chat metrics types ───────────────────────────────────────────────────────
+
+export interface CopilotChatMetrics {
+  dates: string[];
+  total_interactions: number[];
+  code_actions: number[];
+  active_chat_users: number[];
+  action_rate_pct: number[];
+  error?: string;
+  message?: string;
+}
+
+export function getCopilotChatMetrics(org?: string): Promise<CopilotChatMetrics> {
+  return api.get<CopilotChatMetrics>('/copilot/chat-metrics', { org });
+}
+
+// ── Language breakdown types ─────────────────────────────────────────────────
+
+export interface CopilotLanguageBreakdown {
+  dates: string[];
+  language_per_day: Record<string, number[]>;
+  language_distribution: Array<{ name: string; value: number; color?: string }>;
+  model_per_language: {
+    labels: string[];
+    series: Array<{ name: string; data: number[] }>;
+  };
+  acceptance_by_editor: Array<{ editor: string; rate: number }>;
+  top_by_generations: Array<{ language: string; count: number }>;
+  top_by_lines: Array<{ language: string; lines: number }>;
+  error?: string;
+  message?: string;
+}
+
+export function getCopilotLanguageBreakdown(org?: string): Promise<CopilotLanguageBreakdown> {
+  return api.get<CopilotLanguageBreakdown>('/copilot/language-breakdown', { org });
+}
+
+// ── PR metrics types ─────────────────────────────────────────────────────────
+
+export interface CopilotPRMetrics {
+  dates: string[];
+  pr_activity: number[];
+  pr_contributions: number[];
+  review_suggestions: number[];
+  error?: string;
+  message?: string;
+}
+
+export function getCopilotPRMetrics(org?: string): Promise<CopilotPRMetrics> {
+  return api.get<CopilotPRMetrics>('/copilot/pr-metrics', { org });
+}
+
+// ── Agent activity types ─────────────────────────────────────────────────────
+
+export interface CopilotAgentActivity {
+  dates: string[];
+  daily_lines_added: number[];
+  daily_lines_accepted: number[];
+  lines_by_mode: Record<string, number[]>;
+  lines_by_model: Array<{ model: string; lines_added: number; lines_accepted: number }>;
+  lines_by_language: Array<{ language: string; lines_added: number; lines_accepted: number }>;
+  error?: string;
+  message?: string;
+}
+
+export function getCopilotAgentActivity(org?: string): Promise<CopilotAgentActivity> {
+  return api.get<CopilotAgentActivity>('/copilot/agent-activity', { org });
 }

--- a/frontend/src/components/charts/HorizontalBarChart.tsx
+++ b/frontend/src/components/charts/HorizontalBarChart.tsx
@@ -1,0 +1,133 @@
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+import { useChartColors } from '../../hooks/useChartColors';
+import { describeBarChart, chartToTableData } from '../../utils/chartA11y';
+
+interface HorizontalBarChartProps {
+  title?: string;
+  categories: string[];
+  series: {
+    name: string;
+    data: number[];
+    color?: string;
+  }[];
+  height?: number;
+  xAxisFormatter?: (v: number) => string;
+}
+
+export function HorizontalBarChart({
+  title,
+  categories,
+  series,
+  height = 200,
+  xAxisFormatter,
+}: HorizontalBarChartProps) {
+  const colors = useChartColors();
+
+  const resolveColor = (color: string | undefined, idx: number): string => {
+    if (!color) {
+      const palette = [
+        colors.accent,
+        colors.success,
+        colors.attention,
+        colors.done,
+        colors.danger,
+        '#a371f7',
+        '#79c0ff',
+        '#d2a8ff',
+      ];
+      return palette[idx % palette.length] || '#58a6ff';
+    }
+    const varMatch = color.match(/^var\(--(\w[\w-]*)\)$/);
+    if (varMatch) {
+      const resolved = getComputedStyle(document.documentElement)
+        .getPropertyValue(`--${varMatch[1]}`)
+        .trim();
+      return resolved || colors.accent || '#58a6ff';
+    }
+    return color;
+  };
+
+  const option: EChartsOption = {
+    backgroundColor: 'transparent',
+    textStyle: { color: colors.chartText, fontFamily: 'inherit', fontSize: 11 },
+    grid: { left: 8, right: 16, top: 20, bottom: 20, containLabel: true },
+    yAxis: {
+      type: 'category',
+      data: categories,
+      axisLine: { lineStyle: { color: colors.chartGrid } },
+      axisTick: { show: false },
+      axisLabel: { color: colors.chartTextSecondary, fontSize: 10 },
+    },
+    xAxis: {
+      type: 'value',
+      splitLine: { lineStyle: { color: colors.chartGrid } },
+      axisLabel: {
+        color: colors.chartTextSecondary,
+        fontSize: 10,
+        formatter: xAxisFormatter,
+      },
+    },
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: colors.chartTooltipBg,
+      borderColor: colors.chartTooltipBorder,
+      textStyle: { color: colors.chartTooltipFg, fontSize: 12 },
+    },
+    series: series.map((s, idx) => ({
+      name: s.name,
+      type: 'bar' as const,
+      data: s.data,
+      itemStyle: { color: resolveColor(s.color, idx), borderRadius: [0, 2, 2, 0] },
+      barMaxWidth: 20,
+    })),
+    ...(series.length > 1
+      ? {
+          legend: {
+            bottom: 0,
+            textStyle: { color: colors.chartTextSecondary, fontSize: 10 },
+            itemWidth: 12,
+            itemHeight: 8,
+          },
+        }
+      : {}),
+    ...(title
+      ? {
+          title: {
+            text: title,
+            textStyle: { color: colors.chartText, fontSize: 12, fontWeight: 500 },
+          },
+        }
+      : {}),
+  };
+
+  const ariaLabel = describeBarChart(title, categories, series);
+  const tableData = chartToTableData('Category', categories, series);
+
+  return (
+    <div role="figure" aria-label={ariaLabel}>
+      <ReactECharts option={option} style={{ height }} />
+      <table className="sr-only">
+        <caption>{title ?? 'Horizontal bar chart data'}</caption>
+        <thead>
+          <tr>
+            {tableData.headers.map((h) => (
+              <th key={h} scope="col">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {tableData.rows.map((row, i) => (
+            <tr key={i}>
+              {row.map((cell, j) => (
+                <td key={j}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/StackedBarChart.tsx
+++ b/frontend/src/components/charts/StackedBarChart.tsx
@@ -1,0 +1,130 @@
+import ReactECharts from 'echarts-for-react';
+import type { EChartsOption } from 'echarts';
+import { useChartColors } from '../../hooks/useChartColors';
+import { describeBarChart, chartToTableData } from '../../utils/chartA11y';
+
+interface StackedBarChartProps {
+  title?: string;
+  xAxisData: string[];
+  series: {
+    name: string;
+    data: number[];
+    color?: string;
+  }[];
+  height?: number;
+  yAxisFormatter?: (v: number) => string;
+}
+
+export function StackedBarChart({
+  title,
+  xAxisData,
+  series,
+  height = 200,
+  yAxisFormatter,
+}: StackedBarChartProps) {
+  const colors = useChartColors();
+
+  const resolveColor = (color: string | undefined, idx: number): string => {
+    if (!color) {
+      const palette = [
+        colors.accent,
+        colors.success,
+        colors.attention,
+        colors.done,
+        colors.danger,
+        '#a371f7',
+        '#79c0ff',
+        '#d2a8ff',
+      ];
+      return palette[idx % palette.length] || '#58a6ff';
+    }
+    const varMatch = color.match(/^var\(--(\w[\w-]*)\)$/);
+    if (varMatch) {
+      const resolved = getComputedStyle(document.documentElement)
+        .getPropertyValue(`--${varMatch[1]}`)
+        .trim();
+      return resolved || colors.accent || '#58a6ff';
+    }
+    return color;
+  };
+
+  const option: EChartsOption = {
+    backgroundColor: 'transparent',
+    textStyle: { color: colors.chartText, fontFamily: 'inherit', fontSize: 11 },
+    grid: { left: 8, right: 8, top: 20, bottom: 20, containLabel: true },
+    xAxis: {
+      type: 'category',
+      data: xAxisData,
+      axisLine: { lineStyle: { color: colors.chartGrid } },
+      axisTick: { show: false },
+      axisLabel: { color: colors.chartTextSecondary, fontSize: 10 },
+    },
+    yAxis: {
+      type: 'value',
+      splitLine: { lineStyle: { color: colors.chartGrid } },
+      axisLabel: {
+        color: colors.chartTextSecondary,
+        fontSize: 10,
+        formatter: yAxisFormatter,
+      },
+    },
+    tooltip: {
+      trigger: 'axis',
+      backgroundColor: colors.chartTooltipBg,
+      borderColor: colors.chartTooltipBorder,
+      textStyle: { color: colors.chartTooltipFg, fontSize: 12 },
+    },
+    series: series.map((s, idx) => ({
+      name: s.name,
+      type: 'bar' as const,
+      stack: 'total',
+      data: s.data,
+      itemStyle: { color: resolveColor(s.color, idx), borderRadius: 0 },
+      barMaxWidth: 28,
+    })),
+    legend: {
+      bottom: 0,
+      textStyle: { color: colors.chartTextSecondary, fontSize: 10 },
+      itemWidth: 12,
+      itemHeight: 8,
+    },
+    ...(title
+      ? {
+          title: {
+            text: title,
+            textStyle: { color: colors.chartText, fontSize: 12, fontWeight: 500 },
+          },
+        }
+      : {}),
+  };
+
+  const ariaLabel = describeBarChart(title, xAxisData, series);
+  const tableData = chartToTableData('Category', xAxisData, series);
+
+  return (
+    <div role="figure" aria-label={ariaLabel}>
+      <ReactECharts option={option} style={{ height }} />
+      <table className="sr-only">
+        <caption>{title ?? 'Stacked bar chart data'}</caption>
+        <thead>
+          <tr>
+            {tableData.headers.map((h) => (
+              <th key={h} scope="col">
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {tableData.rows.map((row, i) => (
+            <tr key={i}>
+              {row.map((cell, j) => (
+                <td key={j}>{cell}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/pages/Copilot/ActivityPane.test.tsx
+++ b/frontend/src/pages/Copilot/ActivityPane.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { ActivityPane } from './ActivityPane';
+
+vi.mock('echarts-for-react', () => ({
+  default: () => null,
+}));
+
+const mockGetCopilotActivity = vi.fn();
+
+vi.mock('../../api/copilotMetrics', () => ({
+  getCopilotActivity: (...args: unknown[]) => mockGetCopilotActivity(...args),
+}));
+
+describe('ActivityPane', () => {
+  beforeEach(() => {
+    mockGetCopilotActivity.mockResolvedValue({
+      dates: ['2026-06-01', '2026-06-02', '2026-06-03'],
+      ide_dau: [120, 125, 130],
+      ide_wau: [450, 460, 470],
+      completions_count: [3400, 3500, 3600],
+      completions_accepted: [1200, 1300, 1400],
+      acceptance_rate_pct: [35.2, 37.1, 38.9],
+      chat_requests_per_user: [4.2, 4.5, 4.8],
+      requests_per_mode: {
+        dates: ['2026-06-01', '2026-06-02', '2026-06-03'],
+        completions: [3400, 3500, 3600],
+        chat: [800, 850, 900],
+        dotcom_chat: [200, 210, 220],
+        pr: [50, 55, 60],
+      },
+    });
+  });
+
+  it('renders IDE daily active users chart', async () => {
+    renderWithProviders(<ActivityPane />);
+    expect(await screen.findByText('IDE daily active users')).toBeInTheDocument();
+  });
+
+  it('renders IDE weekly active users chart', async () => {
+    renderWithProviders(<ActivityPane />);
+    expect(await screen.findByText('IDE weekly active users')).toBeInTheDocument();
+  });
+
+  it('renders code completions chart', async () => {
+    renderWithProviders(<ActivityPane />);
+    expect(await screen.findByText('Code completions')).toBeInTheDocument();
+  });
+
+  it('renders acceptance rate chart', async () => {
+    renderWithProviders(<ActivityPane />);
+    expect(await screen.findByText('Code completions acceptance rate')).toBeInTheDocument();
+  });
+
+  it('renders chat requests per user chart', async () => {
+    renderWithProviders(<ActivityPane />);
+    expect(await screen.findByText('Average chat requests per active user')).toBeInTheDocument();
+  });
+
+  it('renders requests per mode chart', async () => {
+    renderWithProviders(<ActivityPane />);
+    expect(await screen.findByText('Requests per chat mode')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Copilot/ActivityPane.tsx
+++ b/frontend/src/pages/Copilot/ActivityPane.tsx
@@ -1,0 +1,155 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { LineAreaChart } from '../../components/charts/LineAreaChart';
+import { BarChart } from '../../components/charts/BarChart';
+import { StackedBarChart } from '../../components/charts/StackedBarChart';
+import { getCopilotActivity } from '../../api/copilotMetrics';
+import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
+import styles from './Copilot.module.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function ActivityPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['copilot', 'activity', orgParam],
+    queryFn: () => getCopilotActivity(orgParam),
+    staleTime: 30 * 60 * 1000,
+  });
+  const chartColors = useChartColors();
+
+  if (isLoading) return <Spinner />;
+  if (isError)
+    return <ErrorBanner message="Failed to load activity data" onRetry={() => void refetch()} />;
+  if (data?.error) return <ErrorBanner message={data.message ?? 'Activity data unavailable'} />;
+
+  const dates = (data?.dates ?? []).map(formatDate);
+  const modeData = data?.requests_per_mode;
+  const modeDates = (modeData?.dates ?? []).map(formatDate);
+
+  return (
+    <>
+      {/* DAU / WAU */}
+      <div className={styles.grid2}>
+        <Card>
+          <CardHeader>IDE daily active users</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'DAU',
+                  data: data?.ide_dau ?? [],
+                  color: chartColors.accent,
+                  areaOpacity: 0.15,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+        <Card>
+          <CardHeader>IDE weekly active users</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'WAU',
+                  data: data?.ide_wau ?? [],
+                  color: chartColors.success,
+                  areaOpacity: 0.15,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+      </div>
+
+      {/* Code completions + Acceptance rate */}
+      <div className={styles.grid2}>
+        <Card>
+          <CardHeader>Code completions</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'Suggestions',
+                  data: data?.completions_count ?? [],
+                  color: chartColors.accent,
+                },
+                {
+                  name: 'Accepted',
+                  data: data?.completions_accepted ?? [],
+                  color: chartColors.success,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+        <Card>
+          <CardHeader>Code completions acceptance rate</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <BarChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'Acceptance %',
+                  data: data?.acceptance_rate_pct ?? [],
+                  color: chartColors.success,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+      </div>
+
+      {/* Chat per user + Requests per mode */}
+      <div className={styles.grid2}>
+        <Card>
+          <CardHeader>Average chat requests per active user</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'Requests/user',
+                  data: data?.chat_requests_per_user ?? [],
+                  color: chartColors.attention,
+                  areaOpacity: 0.1,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+        <Card>
+          <CardHeader>Requests per chat mode</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <StackedBarChart
+              xAxisData={modeDates}
+              series={[
+                { name: 'Completions', data: modeData?.completions ?? [] },
+                { name: 'Chat', data: modeData?.chat ?? [] },
+                { name: 'Dotcom Chat', data: modeData?.dotcom_chat ?? [] },
+                { name: 'PR', data: modeData?.pr ?? [] },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Copilot/AdoptionPane.tsx
+++ b/frontend/src/pages/Copilot/AdoptionPane.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { SampleDataBanner } from '../../components/primitives/SampleDataBanner';
 import { getCopilotAdoption } from '../../api/copilotMetrics';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 type AdoptionModal = 'settings' | null;
@@ -27,13 +28,15 @@ interface UnifiedUser {
 }
 
 export function AdoptionPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const {
     data: adoption,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['copilot', 'adoption'],
-    queryFn: getCopilotAdoption,
+    queryKey: ['copilot', 'adoption', orgParam],
+    queryFn: () => getCopilotAdoption(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/AgentActivityPane.test.tsx
+++ b/frontend/src/pages/Copilot/AgentActivityPane.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { AgentActivityPane } from './AgentActivityPane';
+
+vi.mock('echarts-for-react', () => ({
+  default: () => null,
+}));
+
+const mockGetCopilotAgentActivity = vi.fn();
+
+vi.mock('../../api/copilotMetrics', () => ({
+  getCopilotAgentActivity: (...args: unknown[]) => mockGetCopilotAgentActivity(...args),
+}));
+
+describe('AgentActivityPane', () => {
+  beforeEach(() => {
+    mockGetCopilotAgentActivity.mockResolvedValue({
+      dates: ['2026-06-01', '2026-06-02', '2026-06-03'],
+      daily_lines_added: [5000, 5200, 5400],
+      daily_lines_accepted: [3000, 3200, 3400],
+      lines_by_mode: {
+        completions: [4000, 4100, 4200],
+        chat: [800, 850, 900],
+        pr: [200, 250, 300],
+      },
+      lines_by_model: [
+        { model: 'gpt-4o', lines_added: 25000, lines_accepted: 15000 },
+        { model: 'claude-3.5', lines_added: 18000, lines_accepted: 12000 },
+      ],
+      lines_by_language: [
+        { language: 'TypeScript', lines_added: 20000, lines_accepted: 12000 },
+        { language: 'Python', lines_added: 15000, lines_accepted: 9000 },
+      ],
+    });
+  });
+
+  it('renders summary stats', async () => {
+    renderWithProviders(<AgentActivityPane />);
+    expect(await screen.findByText('Lines Suggested (28d)')).toBeInTheDocument();
+    expect(screen.getByText('Lines Accepted (28d)')).toBeInTheDocument();
+    expect(screen.getByText('Line Acceptance Rate')).toBeInTheDocument();
+  });
+
+  it('renders daily lines chart', async () => {
+    renderWithProviders(<AgentActivityPane />);
+    expect(await screen.findByText('Daily lines suggested & accepted')).toBeInTheDocument();
+  });
+
+  it('renders code changes by mode chart', async () => {
+    renderWithProviders(<AgentActivityPane />);
+    expect(await screen.findByText('Code changes by mode')).toBeInTheDocument();
+  });
+
+  it('renders lines by model chart', async () => {
+    renderWithProviders(<AgentActivityPane />);
+    expect(await screen.findByText('Lines added by model')).toBeInTheDocument();
+  });
+
+  it('renders lines by language chart', async () => {
+    renderWithProviders(<AgentActivityPane />);
+    expect(await screen.findByText('Lines added by language')).toBeInTheDocument();
+  });
+
+  it('renders feature activity over time chart', async () => {
+    renderWithProviders(<AgentActivityPane />);
+    expect(await screen.findByText('Feature activity over time')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Copilot/AgentActivityPane.tsx
+++ b/frontend/src/pages/Copilot/AgentActivityPane.tsx
@@ -1,0 +1,187 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { LineAreaChart } from '../../components/charts/LineAreaChart';
+import { BarChart } from '../../components/charts/BarChart';
+import { StackedBarChart } from '../../components/charts/StackedBarChart';
+import { HorizontalBarChart } from '../../components/charts/HorizontalBarChart';
+import { getCopilotAgentActivity } from '../../api/copilotMetrics';
+import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
+import styles from './Copilot.module.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function AgentActivityPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['copilot', 'agent-activity', orgParam],
+    queryFn: () => getCopilotAgentActivity(orgParam),
+    staleTime: 30 * 60 * 1000,
+  });
+  const chartColors = useChartColors();
+
+  if (isLoading) return <Spinner />;
+  if (isError)
+    return <ErrorBanner message="Failed to load agent activity" onRetry={() => void refetch()} />;
+  if (data?.error)
+    return <ErrorBanner message={data.message ?? 'Agent activity data unavailable'} />;
+
+  const dates = (data?.dates ?? []).map(formatDate);
+  const linesByMode = data?.lines_by_mode ?? {};
+  const modeNames = Object.keys(linesByMode);
+  const linesByModel = data?.lines_by_model ?? [];
+  const linesByLang = data?.lines_by_language ?? [];
+
+  const totalAdded = (data?.daily_lines_added ?? []).reduce((a, b) => a + b, 0);
+  const totalAccepted = (data?.daily_lines_accepted ?? []).reduce((a, b) => a + b, 0);
+
+  const palette = [
+    chartColors.accent,
+    chartColors.success,
+    chartColors.attention,
+    chartColors.done,
+    chartColors.danger,
+    '#a371f7',
+    '#79c0ff',
+    '#d2a8ff',
+  ];
+
+  return (
+    <>
+      {/* Summary stats */}
+      <div className={styles.metricStrip}>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{totalAdded.toLocaleString()}</div>
+          <div className={styles.statLabel}>Lines Suggested (28d)</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue} style={{ color: 'var(--success)' }}>
+            {totalAccepted.toLocaleString()}
+          </div>
+          <div className={styles.statLabel}>Lines Accepted (28d)</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>
+            {totalAdded > 0 ? `${Math.round((totalAccepted / totalAdded) * 100)}%` : '—'}
+          </div>
+          <div className={styles.statLabel}>Line Acceptance Rate</div>
+        </div>
+      </div>
+
+      {/* Daily lines added & accepted */}
+      <Card style={{ marginBottom: 16 }}>
+        <CardHeader>Daily lines suggested &amp; accepted</CardHeader>
+        <div style={{ padding: '0 16px 16px' }}>
+          <BarChart
+            xAxisData={dates}
+            series={[
+              {
+                name: 'Suggested',
+                data: data?.daily_lines_added ?? [],
+                color: chartColors.accent,
+              },
+              {
+                name: 'Accepted',
+                data: data?.daily_lines_accepted ?? [],
+                color: chartColors.success,
+              },
+            ]}
+            height={220}
+          />
+        </div>
+      </Card>
+
+      {/* Lines by mode (stacked bar) */}
+      {modeNames.length > 0 && (
+        <Card style={{ marginBottom: 16 }}>
+          <CardHeader>Code changes by mode</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <StackedBarChart
+              xAxisData={dates}
+              series={modeNames.map((mode, idx) => ({
+                name: mode,
+                data: linesByMode[mode],
+                color: palette[idx % palette.length],
+              }))}
+              height={220}
+            />
+          </div>
+        </Card>
+      )}
+
+      {/* Lines by model + Lines by language (horizontal bars) */}
+      <div className={styles.grid2}>
+        {linesByModel.length > 0 && (
+          <Card>
+            <CardHeader>Lines added by model</CardHeader>
+            <div style={{ padding: '0 16px 16px' }}>
+              <HorizontalBarChart
+                categories={linesByModel.map((m) => m.model)}
+                series={[
+                  {
+                    name: 'Lines Added',
+                    data: linesByModel.map((m) => m.lines_added),
+                    color: chartColors.accent,
+                  },
+                  {
+                    name: 'Lines Accepted',
+                    data: linesByModel.map((m) => m.lines_accepted),
+                    color: chartColors.success,
+                  },
+                ]}
+                height={Math.max(160, linesByModel.length * 36)}
+              />
+            </div>
+          </Card>
+        )}
+        {linesByLang.length > 0 && (
+          <Card>
+            <CardHeader>Lines added by language</CardHeader>
+            <div style={{ padding: '0 16px 16px' }}>
+              <HorizontalBarChart
+                categories={linesByLang.map((l) => l.language)}
+                series={[
+                  {
+                    name: 'Lines Added',
+                    data: linesByLang.map((l) => l.lines_added),
+                    color: chartColors.accent,
+                  },
+                  {
+                    name: 'Lines Accepted',
+                    data: linesByLang.map((l) => l.lines_accepted),
+                    color: chartColors.success,
+                  },
+                ]}
+                height={Math.max(160, linesByLang.length * 36)}
+              />
+            </div>
+          </Card>
+        )}
+      </div>
+
+      {/* Feature activity breakdown as line chart */}
+      {modeNames.length > 0 && (
+        <Card style={{ marginTop: 16 }}>
+          <CardHeader>Feature activity over time</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={modeNames.map((mode, idx) => ({
+                name: mode,
+                data: linesByMode[mode],
+                color: palette[idx % palette.length],
+              }))}
+              height={200}
+            />
+          </div>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Copilot/AnomaliesPane.tsx
+++ b/frontend/src/pages/Copilot/AnomaliesPane.tsx
@@ -9,6 +9,7 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { SampleDataBanner } from '../../components/primitives/SampleDataBanner';
 import { getCopilotAnomalies } from '../../api/copilotMetrics';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 const SEVERITY_VARIANT = {
@@ -120,14 +121,16 @@ const detectionRuleColumns: ColumnDef<DetectionRule>[] = [
 ];
 
 export function AnomaliesPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const {
     data: anomalyData,
     isLoading,
     isError,
     refetch,
   } = useQuery({
-    queryKey: ['copilot', 'anomalies'],
-    queryFn: getCopilotAnomalies,
+    queryKey: ['copilot', 'anomalies', orgParam],
+    queryFn: () => getCopilotAnomalies(orgParam),
     staleTime: 30 * 60 * 1000,
   });
   const anomalies = anomalyData?.anomalies ?? [];

--- a/frontend/src/pages/Copilot/BillingPane.tsx
+++ b/frontend/src/pages/Copilot/BillingPane.tsx
@@ -13,6 +13,7 @@ import {
   getCopilotBillingTrends,
 } from '../../api/copilotMetrics';
 import type { CopilotUserBudget } from '../../api/copilotMetrics';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 const tabNums: React.CSSProperties = { fontVariantNumeric: 'tabular-nums' };
@@ -127,26 +128,28 @@ function UtilizationHistogram({ buckets }: { buckets: Record<string, number> }) 
 
 export function BillingPane() {
   const [searchTerm, setSearchTerm] = useState('');
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
 
   const {
     data: overview,
     isLoading: loadingOverview,
     isError: errorOverview,
   } = useQuery({
-    queryKey: ['copilot', 'billing-overview'],
-    queryFn: getCopilotBillingOverview,
+    queryKey: ['copilot', 'billing-overview', orgParam],
+    queryFn: () => getCopilotBillingOverview(orgParam),
     staleTime: 5 * 60 * 1000,
   });
 
   const { data: budgets, isLoading: loadingBudgets } = useQuery({
-    queryKey: ['copilot', 'user-budgets'],
-    queryFn: getCopilotUserBudgets,
+    queryKey: ['copilot', 'user-budgets', orgParam],
+    queryFn: () => getCopilotUserBudgets(orgParam),
     staleTime: 5 * 60 * 1000,
   });
 
   const { data: trends, isLoading: loadingTrends } = useQuery({
-    queryKey: ['copilot', 'billing-trends'],
-    queryFn: getCopilotBillingTrends,
+    queryKey: ['copilot', 'billing-trends', orgParam],
+    queryFn: () => getCopilotBillingTrends(orgParam),
     staleTime: 5 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/BlockersPane.tsx
+++ b/frontend/src/pages/Copilot/BlockersPane.tsx
@@ -4,6 +4,7 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { getCopilotBlockers } from '../../api/copilotMetrics';
 import type { CopilotBlocker } from '../../api/copilotMetrics';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 const SEVERITY_COLORS: Record<string, string> = {
@@ -20,9 +21,11 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 
 export function BlockersPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ['copilot', 'blockers'],
-    queryFn: getCopilotBlockers,
+    queryKey: ['copilot', 'blockers', orgParam],
+    queryFn: () => getCopilotBlockers(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/ChatMetricsPane.test.tsx
+++ b/frontend/src/pages/Copilot/ChatMetricsPane.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { ChatMetricsPane } from './ChatMetricsPane';
+
+vi.mock('echarts-for-react', () => ({
+  default: () => null,
+}));
+
+const mockGetCopilotChatMetrics = vi.fn();
+
+vi.mock('../../api/copilotMetrics', () => ({
+  getCopilotChatMetrics: (...args: unknown[]) => mockGetCopilotChatMetrics(...args),
+}));
+
+describe('ChatMetricsPane', () => {
+  beforeEach(() => {
+    mockGetCopilotChatMetrics.mockResolvedValue({
+      dates: ['2026-06-01', '2026-06-02', '2026-06-03'],
+      total_interactions: [800, 850, 900],
+      code_actions: [200, 210, 220],
+      active_chat_users: [95, 100, 105],
+      action_rate_pct: [25.0, 24.7, 24.4],
+    });
+  });
+
+  it('renders summary stats', async () => {
+    renderWithProviders(<ChatMetricsPane />);
+    expect(await screen.findByText('Total Interactions (28d)')).toBeInTheDocument();
+    expect(screen.getByText('Code Actions (28d)')).toBeInTheDocument();
+    expect(screen.getByText('Peak Active Chat Users')).toBeInTheDocument();
+  });
+
+  it('renders daily interactions chart', async () => {
+    renderWithProviders(<ChatMetricsPane />);
+    expect(await screen.findByText('Daily Chat Interactions & Code Actions')).toBeInTheDocument();
+  });
+
+  it('renders active chat users chart', async () => {
+    renderWithProviders(<ChatMetricsPane />);
+    expect(await screen.findByText('Daily active chat users')).toBeInTheDocument();
+  });
+
+  it('renders action rate chart', async () => {
+    renderWithProviders(<ChatMetricsPane />);
+    expect(await screen.findByText('Daily action rate')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Copilot/ChatMetricsPane.tsx
+++ b/frontend/src/pages/Copilot/ChatMetricsPane.tsx
@@ -1,0 +1,122 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { LineAreaChart } from '../../components/charts/LineAreaChart';
+import { BarChart } from '../../components/charts/BarChart';
+import { getCopilotChatMetrics } from '../../api/copilotMetrics';
+import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
+import styles from './Copilot.module.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function ChatMetricsPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['copilot', 'chat-metrics', orgParam],
+    queryFn: () => getCopilotChatMetrics(orgParam),
+    staleTime: 30 * 60 * 1000,
+  });
+  const chartColors = useChartColors();
+
+  if (isLoading) return <Spinner />;
+  if (isError)
+    return <ErrorBanner message="Failed to load chat metrics" onRetry={() => void refetch()} />;
+  if (data?.error) return <ErrorBanner message={data.message ?? 'Chat metrics unavailable'} />;
+
+  const dates = (data?.dates ?? []).map(formatDate);
+
+  return (
+    <>
+      {/* Summary stats */}
+      <div className={styles.metricStrip}>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>
+            {(data?.total_interactions ?? []).reduce((a, b) => a + b, 0).toLocaleString()}
+          </div>
+          <div className={styles.statLabel}>Total Interactions (28d)</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>
+            {(data?.code_actions ?? []).reduce((a, b) => a + b, 0).toLocaleString()}
+          </div>
+          <div className={styles.statLabel}>Code Actions (28d)</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{Math.max(...(data?.active_chat_users ?? [0]))}</div>
+          <div className={styles.statLabel}>Peak Active Chat Users</div>
+        </div>
+      </div>
+
+      {/* Daily interactions */}
+      <Card style={{ marginBottom: 16 }}>
+        <CardHeader>Daily Chat Interactions &amp; Code Actions</CardHeader>
+        <div style={{ padding: '0 16px 16px' }}>
+          <LineAreaChart
+            xAxisData={dates}
+            series={[
+              {
+                name: 'Interactions',
+                data: data?.total_interactions ?? [],
+                color: chartColors.accent,
+                areaOpacity: 0.12,
+              },
+              {
+                name: 'Code Actions',
+                data: data?.code_actions ?? [],
+                color: chartColors.success,
+                areaOpacity: 0.12,
+              },
+            ]}
+            height={220}
+          />
+        </div>
+      </Card>
+
+      <div className={styles.grid2}>
+        {/* Active chat users */}
+        <Card>
+          <CardHeader>Daily active chat users</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <BarChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'Active Users',
+                  data: data?.active_chat_users ?? [],
+                  color: chartColors.accent,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+
+        {/* Action rate */}
+        <Card>
+          <CardHeader>Daily action rate</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'Action Rate %',
+                  data: data?.action_rate_pct ?? [],
+                  color: chartColors.success,
+                  areaOpacity: 0.1,
+                },
+              ]}
+              height={200}
+              yAxisFormatter={(v) => `${v}%`}
+            />
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Copilot/CopilotPage.test.tsx
+++ b/frontend/src/pages/Copilot/CopilotPage.test.tsx
@@ -126,6 +126,52 @@ vi.mock('../../api/copilotMetrics', () => ({
   getCopilotTeams: vi.fn().mockResolvedValue({ teams: [], total_teams: 0, at_risk_count: 0 }),
   getCopilotPolicyChanges: vi.fn().mockResolvedValue({ timeline: [], total_changes: 0 }),
   getCopilotROI: vi.fn().mockResolvedValue({ summary: null, recommendations: [] }),
+  getCopilotActivity: vi.fn().mockResolvedValue({
+    dates: [],
+    ide_dau: [],
+    ide_wau: [],
+    completions_count: [],
+    completions_accepted: [],
+    acceptance_rate_pct: [],
+    chat_requests_per_user: [],
+    requests_per_mode: { dates: [], completions: [], chat: [], dotcom_chat: [], pr: [] },
+  }),
+  getCopilotChatMetrics: vi.fn().mockResolvedValue({
+    dates: [],
+    total_interactions: [],
+    code_actions: [],
+    active_chat_users: [],
+    action_rate_pct: [],
+  }),
+  getCopilotLanguageBreakdown: vi.fn().mockResolvedValue({
+    dates: [],
+    language_per_day: {},
+    language_distribution: [],
+    model_per_language: { labels: [], series: [] },
+    acceptance_by_editor: [],
+    top_by_generations: [],
+    top_by_lines: [],
+  }),
+  getCopilotPRMetrics: vi.fn().mockResolvedValue({
+    dates: [],
+    pr_activity: [],
+    pr_contributions: [],
+    review_suggestions: [],
+  }),
+  getCopilotAgentActivity: vi.fn().mockResolvedValue({
+    dates: [],
+    daily_lines_added: [],
+    daily_lines_accepted: [],
+    lines_by_mode: {},
+    lines_by_model: [],
+    lines_by_language: [],
+  }),
+}));
+
+vi.mock('../../api/copilotGovernance', () => ({
+  listCopilotPolicies: vi.fn().mockResolvedValue([]),
+  listCopilotViolations: vi.fn().mockResolvedValue({ violations: [], total: 0 }),
+  updateCopilotPolicy: vi.fn().mockResolvedValue({}),
 }));
 
 function renderPage(initialTab = 'overview') {
@@ -155,11 +201,11 @@ describe('CopilotPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the tab bar with 6 tabs', () => {
+  it('renders the tab bar with 16 tabs', () => {
     renderPage();
     const tablist = screen.getByRole('tablist');
     const tabs = within(tablist).getAllByRole('tab');
-    expect(tabs).toHaveLength(6);
+    expect(tabs).toHaveLength(16);
   });
 
   it('shows the anomaly badge with count 3', async () => {

--- a/frontend/src/pages/Copilot/CopilotPage.test.tsx
+++ b/frontend/src/pages/Copilot/CopilotPage.test.tsx
@@ -21,7 +21,6 @@ vi.mock('../../api/reports', () => ({
       },
     ],
   }),
-  getCopilotSeatsReport: vi.fn().mockResolvedValue({ data: [] }),
 }));
 
 vi.mock('../../api/features', () => ({
@@ -50,7 +49,15 @@ vi.mock('../../hooks/useFeatures', () => ({
 
 vi.mock('../../api/copilotMetrics', () => ({
   getCopilotOverview: vi.fn().mockResolvedValue({
-    acceptance_rate_days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    acceptance_rate_days: [
+      '2026-06-01',
+      '2026-06-02',
+      '2026-06-03',
+      '2026-06-04',
+      '2026-06-05',
+      '2026-06-06',
+      '2026-06-07',
+    ],
     acceptance_rate_values: [24, 26, 27, 25, 28, 31, 29],
     acceptance_threshold: 25,
     languages: [
@@ -59,6 +66,7 @@ vi.mock('../../api/copilotMetrics', () => ({
     ],
     total_active_users: 120,
     total_engaged_users: 98,
+    total_provisioned_seats: 186,
   }),
   getCopilotAnomalies: vi.fn().mockResolvedValue({
     anomalies: [
@@ -105,6 +113,10 @@ vi.mock('../../api/copilotMetrics', () => ({
     models: [{ model: 'GPT-4o', pct: 42, color: '#58a6ff' }],
     features: [{ feature: 'IDE completions', count: 142, color: '#58a6ff' }],
     editors: [{ name: 'VS Code', count: 112, pct: 79 }],
+  }),
+  getCopilotModelUsers: vi.fn().mockResolvedValue({
+    users: [],
+    total_users: 0,
   }),
   getCopilotBlockers: vi.fn().mockResolvedValue({
     blockers: [],

--- a/frontend/src/pages/Copilot/CopilotTabBar.test.tsx
+++ b/frontend/src/pages/Copilot/CopilotTabBar.test.tsx
@@ -10,17 +10,27 @@ describe('CopilotTabBar', () => {
     anomalyCount: 3,
   };
 
-  it('renders all 6 tabs', () => {
+  it('renders all 16 tabs', () => {
     render(<CopilotTabBar {...defaultProps} />);
     const tablist = screen.getByRole('tablist');
     const tabs = within(tablist).getAllByRole('tab');
-    expect(tabs).toHaveLength(6);
+    expect(tabs).toHaveLength(16);
     expect(tabs[0]).toHaveTextContent('Overview');
-    expect(tabs[1]).toHaveTextContent('Adoption');
-    expect(tabs[2]).toHaveTextContent('Models & Features');
-    expect(tabs[3]).toHaveTextContent('License Optimization');
-    expect(tabs[4]).toHaveTextContent('Billing & UBB');
-    expect(tabs[5]).toHaveTextContent(/Anomalies/);
+    expect(tabs[1]).toHaveTextContent('Activity');
+    expect(tabs[2]).toHaveTextContent('Adoption');
+    expect(tabs[3]).toHaveTextContent('Teams');
+    expect(tabs[4]).toHaveTextContent('Chat');
+    expect(tabs[5]).toHaveTextContent('Languages');
+    expect(tabs[6]).toHaveTextContent('Models & Features');
+    expect(tabs[7]).toHaveTextContent('Pull Requests');
+    expect(tabs[8]).toHaveTextContent('Agent');
+    expect(tabs[9]).toHaveTextContent('License Optimization');
+    expect(tabs[10]).toHaveTextContent('Billing & UBB');
+    expect(tabs[11]).toHaveTextContent('ROI');
+    expect(tabs[12]).toHaveTextContent('Blockers');
+    expect(tabs[13]).toHaveTextContent('Policy');
+    expect(tabs[14]).toHaveTextContent('Governance');
+    expect(tabs[15]).toHaveTextContent(/Anomalies/);
   });
 
   it('marks the active tab with aria-selected', () => {

--- a/frontend/src/pages/Copilot/CopilotTabBar.tsx
+++ b/frontend/src/pages/Copilot/CopilotTabBar.tsx
@@ -1,6 +1,22 @@
 import styles from './Copilot.module.css';
 
-export type CopilotTab = 'overview' | 'adoption' | 'models' | 'license' | 'billing' | 'anomalies';
+export type CopilotTab =
+  | 'overview'
+  | 'activity'
+  | 'adoption'
+  | 'teams'
+  | 'chat'
+  | 'languages'
+  | 'models'
+  | 'license'
+  | 'billing'
+  | 'roi'
+  | 'prs'
+  | 'agent'
+  | 'blockers'
+  | 'policy'
+  | 'governance'
+  | 'anomalies';
 
 interface CopilotTabBarProps {
   activeTab: CopilotTab;
@@ -10,10 +26,20 @@ interface CopilotTabBarProps {
 
 const TABS: { id: CopilotTab; label: string }[] = [
   { id: 'overview', label: 'Overview' },
+  { id: 'activity', label: 'Activity' },
   { id: 'adoption', label: 'Adoption' },
+  { id: 'teams', label: 'Teams' },
+  { id: 'chat', label: 'Chat' },
+  { id: 'languages', label: 'Languages' },
   { id: 'models', label: 'Models & Features' },
+  { id: 'prs', label: 'Pull Requests' },
+  { id: 'agent', label: 'Agent' },
   { id: 'license', label: 'License Optimization' },
   { id: 'billing', label: 'Billing & UBB' },
+  { id: 'roi', label: 'ROI' },
+  { id: 'blockers', label: 'Blockers' },
+  { id: 'policy', label: 'Policy' },
+  { id: 'governance', label: 'Governance' },
   { id: 'anomalies', label: 'Anomalies' },
 ];
 

--- a/frontend/src/pages/Copilot/GovernancePane.tsx
+++ b/frontend/src/pages/Copilot/GovernancePane.tsx
@@ -11,6 +11,7 @@ import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { Button } from '../../components/primitives/Button';
 import { Label } from '../../components/primitives/Label';
 import { formatRelativeShort } from '../../utils/dates';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 function PolicyCard({
@@ -72,6 +73,8 @@ function ViolationRow({ violation }: { violation: CopilotPolicyViolation }) {
 export function GovernancePane() {
   const queryClient = useQueryClient();
   const [sevFilter, setSevFilter] = useState('');
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
 
   const {
     data: policies,
@@ -79,8 +82,8 @@ export function GovernancePane() {
     isError: policyError,
     refetch: refetchPolicies,
   } = useQuery({
-    queryKey: ['copilot-governance', 'policies'],
-    queryFn: listCopilotPolicies,
+    queryKey: ['copilot-governance', 'policies', orgParam],
+    queryFn: () => listCopilotPolicies(orgParam),
   });
 
   const {
@@ -89,10 +92,11 @@ export function GovernancePane() {
     isError: violationError,
     refetch: refetchViolations,
   } = useQuery({
-    queryKey: ['copilot-governance', 'violations', sevFilter],
+    queryKey: ['copilot-governance', 'violations', sevFilter, orgParam],
     queryFn: () =>
       listCopilotViolations({
         severity: sevFilter || undefined,
+        org: orgParam,
         page_size: 50,
       }),
   });

--- a/frontend/src/pages/Copilot/LanguageBreakdownPane.test.tsx
+++ b/frontend/src/pages/Copilot/LanguageBreakdownPane.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { LanguageBreakdownPane } from './LanguageBreakdownPane';
+
+vi.mock('echarts-for-react', () => ({
+  default: () => null,
+}));
+
+const mockGetCopilotLanguageBreakdown = vi.fn();
+
+vi.mock('../../api/copilotMetrics', () => ({
+  getCopilotLanguageBreakdown: (...args: unknown[]) => mockGetCopilotLanguageBreakdown(...args),
+}));
+
+describe('LanguageBreakdownPane', () => {
+  beforeEach(() => {
+    mockGetCopilotLanguageBreakdown.mockResolvedValue({
+      dates: ['2026-06-01', '2026-06-02', '2026-06-03'],
+      language_per_day: {
+        TypeScript: [500, 520, 540],
+        Python: [400, 410, 420],
+      },
+      language_distribution: [
+        { name: 'TypeScript', value: 1560, color: '#3178c6' },
+        { name: 'Python', value: 1230, color: '#3572a5' },
+      ],
+      model_per_language: {
+        labels: ['TypeScript', 'Python'],
+        series: [
+          { name: 'gpt-4o', data: [500, 400] },
+          { name: 'claude-3.5', data: [300, 350] },
+        ],
+      },
+      acceptance_by_editor: [
+        { editor: 'VS Code', rate: 38.5 },
+        { editor: 'JetBrains', rate: 32.1 },
+      ],
+      top_by_generations: [
+        { language: 'TypeScript', count: 12000 },
+        { language: 'Python', count: 9500 },
+      ],
+      top_by_lines: [
+        { language: 'TypeScript', lines: 45000 },
+        { language: 'Python', lines: 32000 },
+      ],
+    });
+  });
+
+  it('renders language usage per day chart', async () => {
+    renderWithProviders(<LanguageBreakdownPane />);
+    expect(await screen.findByText('Language usage per day')).toBeInTheDocument();
+  });
+
+  it('renders language distribution donut', async () => {
+    renderWithProviders(<LanguageBreakdownPane />);
+    expect(await screen.findByText('Language distribution')).toBeInTheDocument();
+  });
+
+  it('renders model usage per language chart', async () => {
+    renderWithProviders(<LanguageBreakdownPane />);
+    expect(await screen.findByText('Model usage per language')).toBeInTheDocument();
+  });
+
+  it('renders acceptance rate by editor chart', async () => {
+    renderWithProviders(<LanguageBreakdownPane />);
+    expect(await screen.findByText('Acceptance rate by editor')).toBeInTheDocument();
+  });
+
+  it('renders top 5 by generations chart', async () => {
+    renderWithProviders(<LanguageBreakdownPane />);
+    expect(await screen.findByText('Top 5 languages by code generations')).toBeInTheDocument();
+  });
+
+  it('renders top 5 by lines chart', async () => {
+    renderWithProviders(<LanguageBreakdownPane />);
+    expect(await screen.findByText('Top 5 languages by lines added')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Copilot/LanguageBreakdownPane.tsx
+++ b/frontend/src/pages/Copilot/LanguageBreakdownPane.tsx
@@ -1,0 +1,166 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { LineAreaChart } from '../../components/charts/LineAreaChart';
+import { DonutChart } from '../../components/charts/DonutChart';
+import { BarChart } from '../../components/charts/BarChart';
+import { HorizontalBarChart } from '../../components/charts/HorizontalBarChart';
+import { getCopilotLanguageBreakdown } from '../../api/copilotMetrics';
+import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
+import styles from './Copilot.module.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function LanguageBreakdownPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['copilot', 'language-breakdown', orgParam],
+    queryFn: () => getCopilotLanguageBreakdown(orgParam),
+    staleTime: 30 * 60 * 1000,
+  });
+  const chartColors = useChartColors();
+
+  if (isLoading) return <Spinner />;
+  if (isError)
+    return <ErrorBanner message="Failed to load language data" onRetry={() => void refetch()} />;
+  if (data?.error) return <ErrorBanner message={data.message ?? 'Language data unavailable'} />;
+
+  const dates = (data?.dates ?? []).map(formatDate);
+  const langPerDay = data?.language_per_day ?? {};
+  const langNames = Object.keys(langPerDay);
+
+  // Build series for stacked area chart (language per day)
+  const palette = [
+    chartColors.accent,
+    chartColors.success,
+    chartColors.attention,
+    chartColors.done,
+    chartColors.danger,
+    '#a371f7',
+    '#79c0ff',
+    '#d2a8ff',
+  ];
+  const langSeries = langNames.map((lang, idx) => ({
+    name: lang,
+    data: langPerDay[lang],
+    color: palette[idx % palette.length],
+    areaOpacity: 0.3,
+  }));
+
+  // Model per language (grouped bar)
+  const modelPerLang = data?.model_per_language;
+
+  // Acceptance by editor (horizontal bar)
+  const editorData = data?.acceptance_by_editor ?? [];
+
+  // Top 5 charts
+  const topGens = data?.top_by_generations ?? [];
+  const topLines = data?.top_by_lines ?? [];
+
+  return (
+    <>
+      {/* Language usage per day (stacked area) */}
+      <Card style={{ marginBottom: 16 }}>
+        <CardHeader>Language usage per day</CardHeader>
+        <div style={{ padding: '0 16px 16px' }}>
+          <LineAreaChart xAxisData={dates} series={langSeries} height={240} />
+        </div>
+      </Card>
+
+      <div className={styles.grid2}>
+        {/* Language distribution donut */}
+        <Card>
+          <CardHeader>Language distribution</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <DonutChart data={data?.language_distribution ?? []} height={220} title="" />
+          </div>
+        </Card>
+
+        {/* Model usage per language (grouped bar) */}
+        {modelPerLang && modelPerLang.labels.length > 0 && (
+          <Card>
+            <CardHeader>Model usage per language</CardHeader>
+            <div style={{ padding: '0 16px 16px' }}>
+              <BarChart
+                xAxisData={modelPerLang.labels}
+                series={modelPerLang.series.map((s, idx) => ({
+                  name: s.name,
+                  data: s.data,
+                  color: palette[idx % palette.length],
+                }))}
+                height={220}
+              />
+            </div>
+          </Card>
+        )}
+      </div>
+
+      {/* Acceptance rate by editor */}
+      {editorData.length > 0 && (
+        <Card style={{ marginBottom: 16 }}>
+          <CardHeader>Acceptance rate by editor</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <HorizontalBarChart
+              categories={editorData.map((e) => e.editor)}
+              series={[
+                {
+                  name: 'Acceptance %',
+                  data: editorData.map((e) => Math.round(e.rate * 10) / 10),
+                  color: chartColors.success,
+                },
+              ]}
+              height={Math.max(120, editorData.length * 32)}
+              xAxisFormatter={(v) => `${v}%`}
+            />
+          </div>
+        </Card>
+      )}
+
+      {/* Top 5 by generations + Top 5 by lines */}
+      <div className={styles.grid2}>
+        {topGens.length > 0 && (
+          <Card>
+            <CardHeader>Top 5 languages by code generations</CardHeader>
+            <div style={{ padding: '0 16px 16px' }}>
+              <HorizontalBarChart
+                categories={topGens.map((l) => l.language)}
+                series={[
+                  {
+                    name: 'Generations',
+                    data: topGens.map((l) => l.count),
+                    color: chartColors.accent,
+                  },
+                ]}
+                height={180}
+              />
+            </div>
+          </Card>
+        )}
+        {topLines.length > 0 && (
+          <Card>
+            <CardHeader>Top 5 languages by lines added</CardHeader>
+            <div style={{ padding: '0 16px 16px' }}>
+              <HorizontalBarChart
+                categories={topLines.map((l) => l.language)}
+                series={[
+                  {
+                    name: 'Lines',
+                    data: topLines.map((l) => l.lines),
+                    color: chartColors.success,
+                  },
+                ]}
+                height={180}
+              />
+            </div>
+          </Card>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Copilot/LicensePane.tsx
+++ b/frontend/src/pages/Copilot/LicensePane.tsx
@@ -10,6 +10,7 @@ import { SampleDataBanner } from '../../components/primitives/SampleDataBanner';
 import { getCopilotROI } from '../../api/copilotMetrics';
 import type { CopilotGhostMember } from '../../api/copilotMetrics';
 import type { SeatUtilizationBucket } from '../../types/reports';
+import { useOrg } from '../../hooks/useOrg';
 import { useOrgConfig } from '../../hooks/useOrgConfig';
 import { formatBucketDate } from '../../utils/dates';
 import styles from './Copilot.module.css';
@@ -28,10 +29,12 @@ export function LicensePane({ seatBuckets }: LicensePaneProps) {
   const costSectionRef = useRef<HTMLDivElement>(null);
   const navigate = useNavigate();
   const { costPerSeat } = useOrgConfig();
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
 
   const { data: roiData } = useQuery({
-    queryKey: ['copilot', 'roi'],
-    queryFn: getCopilotROI,
+    queryKey: ['copilot', 'roi', orgParam],
+    queryFn: () => getCopilotROI(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/ModelsPane.test.tsx
+++ b/frontend/src/pages/Copilot/ModelsPane.test.tsx
@@ -52,6 +52,32 @@ vi.mock('../../api/copilotMetrics', () => ({
     ],
     total_active_users: 100,
     total_engaged_users: 80,
+    total_provisioned_seats: 120,
+  }),
+  getCopilotModelUsers: vi.fn().mockResolvedValue({
+    users: [
+      {
+        login: 'user1',
+        total_credits: 45.2,
+        completions_credits: 20.1,
+        chat_credits: 15.0,
+        pr_credits: 8.1,
+        other_credits: 2.0,
+        days_active: 22,
+        last_active: '2026-06-08',
+      },
+      {
+        login: 'user2',
+        total_credits: 32.5,
+        completions_credits: 18.0,
+        chat_credits: 10.5,
+        pr_credits: 3.0,
+        other_credits: 1.0,
+        days_active: 18,
+        last_active: '2026-06-07',
+      },
+    ],
+    total_users: 2,
   }),
 }));
 

--- a/frontend/src/pages/Copilot/ModelsPane.tsx
+++ b/frontend/src/pages/Copilot/ModelsPane.tsx
@@ -9,7 +9,12 @@ import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { SampleDataBanner } from '../../components/primitives/SampleDataBanner';
 import { DonutChart } from '../../components/charts/DonutChart';
 import { LineAreaChart } from '../../components/charts/LineAreaChart';
-import { getCopilotModels, getCopilotOverview } from '../../api/copilotMetrics';
+import {
+  getCopilotModels,
+  getCopilotOverview,
+  getCopilotModelUsers,
+} from '../../api/copilotMetrics';
+import type { CopilotModelUser } from '../../api/copilotMetrics';
 import styles from './Copilot.module.css';
 
 type MetricRow = { metric: string; value: string };
@@ -65,11 +70,18 @@ export function ModelsPane() {
     staleTime: 30 * 60 * 1000,
   });
 
+  const { data: modelUsers } = useQuery({
+    queryKey: ['copilot', 'model-users'],
+    queryFn: getCopilotModelUsers,
+    staleTime: 30 * 60 * 1000,
+  });
+
   const modelUsage = models?.models ?? [];
   const featureUsage = models?.features ?? [];
   const editors = models?.editors ?? [];
   const timeSeries = models?.time_series;
   const languages = overview?.languages ?? [];
+  const userUsageList = modelUsers?.users ?? [];
 
   const [modelsModal, setModelsModal] = useState<ModelsModal>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
@@ -318,6 +330,113 @@ export function ModelsPane() {
               ))}
             </div>
           )}
+
+          {/* ── Per-User Copilot Usage Table ── */}
+          <Card style={{ marginTop: 24 }}>
+            <CardHeader>Per-user Copilot usage (last 28 days)</CardHeader>
+            {userUsageList.length === 0 ? (
+              <div
+                style={{
+                  color: 'var(--fg-muted)',
+                  fontSize: 13,
+                  padding: '16px',
+                  textAlign: 'center',
+                }}
+              >
+                No per-user usage data available — sync Copilot usage reports to populate.
+              </div>
+            ) : (
+              <DataTable<CopilotModelUser>
+                columns={[
+                  {
+                    key: 'login',
+                    header: 'User',
+                    filterable: true,
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+                        <img
+                          src={`https://github.com/${u.login}.png?size=24`}
+                          alt={u.login}
+                          style={{ width: 20, height: 20, borderRadius: '50%' }}
+                        />
+                        <span style={{ fontWeight: 500 }}>{u.login}</span>
+                      </span>
+                    ),
+                    filterValue: (u) => u.login,
+                    sortValue: (u) => u.login,
+                  },
+                  {
+                    key: 'total_credits',
+                    header: 'Total Credits',
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>
+                        {u.total_credits.toFixed(1)}
+                      </span>
+                    ),
+                    sortValue: (u) => u.total_credits,
+                  },
+                  {
+                    key: 'completions_credits',
+                    header: 'Completions',
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                        {u.completions_credits.toFixed(1)}
+                      </span>
+                    ),
+                    sortValue: (u) => u.completions_credits,
+                  },
+                  {
+                    key: 'chat_credits',
+                    header: 'Chat',
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                        {u.chat_credits.toFixed(1)}
+                      </span>
+                    ),
+                    sortValue: (u) => u.chat_credits,
+                  },
+                  {
+                    key: 'pr_credits',
+                    header: 'PR Review',
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                        {u.pr_credits.toFixed(1)}
+                      </span>
+                    ),
+                    sortValue: (u) => u.pr_credits,
+                  },
+                  {
+                    key: 'days_active',
+                    header: 'Days Active',
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{u.days_active}d</span>
+                    ),
+                    sortValue: (u) => u.days_active,
+                  },
+                  {
+                    key: 'last_active',
+                    header: 'Last Active',
+                    sortable: true,
+                    render: (u) => (
+                      <span style={{ color: 'var(--fg-muted)', fontSize: 12 }}>
+                        {u.last_active ?? '—'}
+                      </span>
+                    ),
+                    sortValue: (u) => u.last_active ?? '',
+                  },
+                ]}
+                data={userUsageList}
+                rowKey={(u) => u.login}
+                pageSize={15}
+              />
+            )}
+          </Card>
 
           {/* ── Model Detail Modal ── */}
           <Modal

--- a/frontend/src/pages/Copilot/ModelsPane.tsx
+++ b/frontend/src/pages/Copilot/ModelsPane.tsx
@@ -15,6 +15,7 @@ import {
   getCopilotModelUsers,
 } from '../../api/copilotMetrics';
 import type { CopilotModelUser } from '../../api/copilotMetrics';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 type MetricRow = { metric: string; value: string };
@@ -54,25 +55,27 @@ const MODEL_LINE_COLORS = [
 const FEATURE_LINE_COLORS = ['#3fb950', '#58a6ff', '#bc8cff', '#db6d28', '#79c0ff'];
 
 export function ModelsPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const {
     data: models,
     isLoading,
     isError,
   } = useQuery({
-    queryKey: ['copilot', 'models'],
-    queryFn: getCopilotModels,
+    queryKey: ['copilot', 'models', orgParam],
+    queryFn: () => getCopilotModels(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 
   const { data: overview, isLoading: overviewLoading } = useQuery({
-    queryKey: ['copilot', 'overview'],
-    queryFn: getCopilotOverview,
+    queryKey: ['copilot', 'overview', orgParam],
+    queryFn: () => getCopilotOverview(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 
   const { data: modelUsers } = useQuery({
-    queryKey: ['copilot', 'model-users'],
-    queryFn: getCopilotModelUsers,
+    queryKey: ['copilot', 'model-users', orgParam],
+    queryFn: () => getCopilotModelUsers(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/OverviewPane.test.tsx
+++ b/frontend/src/pages/Copilot/OverviewPane.test.tsx
@@ -14,7 +14,15 @@ vi.mock('react-router-dom', () => ({
 
 vi.mock('../../api/copilotMetrics', () => ({
   getCopilotOverview: vi.fn().mockResolvedValue({
-    acceptance_rate_days: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    acceptance_rate_days: [
+      '2026-06-01',
+      '2026-06-02',
+      '2026-06-03',
+      '2026-06-04',
+      '2026-06-05',
+      '2026-06-06',
+      '2026-06-07',
+    ],
     acceptance_rate_values: [24, 26, 27, 25, 28, 31, 29],
     acceptance_threshold: 25,
     languages: [
@@ -27,6 +35,7 @@ vi.mock('../../api/copilotMetrics', () => ({
     ],
     total_active_users: 120,
     total_engaged_users: 98,
+    total_provisioned_seats: 180,
   }),
 }));
 
@@ -45,23 +54,6 @@ const mockSeatBuckets = [
   },
 ];
 
-const mockCopilotBuckets = [
-  {
-    bucket: '2024-01-14',
-    seats_assigned: 5,
-    seats_revoked: 1,
-    seats_net: 4,
-    policy_change_count: 0,
-  },
-  {
-    bucket: '2024-01-15',
-    seats_assigned: 3,
-    seats_revoked: 2,
-    seats_net: 1,
-    policy_change_count: 0,
-  },
-];
-
 function renderPane() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -70,7 +62,6 @@ function renderPane() {
     <QueryClientProvider client={queryClient}>
       <OverviewPane
         seatBuckets={mockSeatBuckets}
-        copilotBuckets={mockCopilotBuckets}
         isLoading={false}
         isError={false}
         onRetry={() => {}}

--- a/frontend/src/pages/Copilot/OverviewPane.tsx
+++ b/frontend/src/pages/Copilot/OverviewPane.tsx
@@ -9,30 +9,22 @@ import { SampleDataBanner } from '../../components/primitives/SampleDataBanner';
 import { Button } from '../../components/primitives/Button';
 import { DataTable } from '../../components/primitives/DataTable';
 import { LineAreaChart } from '../../components/charts/LineAreaChart';
-import type { SeatUtilizationBucket, CopilotSeatsBucket } from '../../types/reports';
+import type { SeatUtilizationBucket } from '../../types/reports';
 import { getCopilotOverview } from '../../api/copilotMetrics';
 import { useChartColors } from '../../hooks/useChartColors';
 import { useOrgConfig } from '../../hooks/useOrgConfig';
 import { formatBucketDate, formatWeekday, formatWeekdayDate } from '../../utils/dates';
 import styles from './Copilot.module.css';
-type DrillDownType = 'active-seats' | 'assigned' | 'revoked' | 'net' | null;
 type OverviewModal = 'seat-waste' | 'correlation-seats' | 'correlation-cycle' | null;
 
 interface OverviewPaneProps {
   seatBuckets: SeatUtilizationBucket[];
-  copilotBuckets: CopilotSeatsBucket[];
   isLoading: boolean;
   isError: boolean;
   onRetry: () => void;
 }
 
-export function OverviewPane({
-  seatBuckets,
-  copilotBuckets,
-  isLoading,
-  isError,
-  onRetry,
-}: OverviewPaneProps) {
+export function OverviewPane({ seatBuckets, isLoading, isError, onRetry }: OverviewPaneProps) {
   const { costPerSeat } = useOrgConfig();
   const { data: overview, isLoading: overviewLoading } = useQuery({
     queryKey: ['copilot', 'overview'],
@@ -47,7 +39,6 @@ export function OverviewPane({
     () => overview?.acceptance_threshold ?? 25,
   );
 
-  const [drillDown, setDrillDown] = useState<DrillDownType>(null);
   const [overviewModal, setOverviewModal] = useState<OverviewModal>(null);
   const seatTableRef = useRef<HTMLDivElement>(null);
   const chartColors = useChartColors();
@@ -60,14 +51,10 @@ export function OverviewPane({
         ).toFixed(1)
       : null;
 
-  const totalAssigned = copilotBuckets.reduce((s, b) => s + (b.seats_assigned ?? 0), 0);
-  const totalRevoked = copilotBuckets.reduce((s, b) => s + (b.seats_revoked ?? 0), 0);
-  const netSeats = copilotBuckets.reduce((s, b) => s + (b.seats_net ?? 0), 0);
-
   // Use Copilot Metrics API data (overview) for active/provisioned counts
-  // seatBuckets are event-based counts which may not match actual API seat data
   const activeSeats = overview?.total_active_users ?? latestSeatBucket?.active_seat_count;
-  const provisionedSeats = latestSeatBucket?.provisioned_seat_count;
+  const provisionedSeats =
+    overview?.total_provisioned_seats ?? latestSeatBucket?.provisioned_seat_count;
   const seatLabel =
     activeSeats != null && provisionedSeats != null ? `${activeSeats} / ${provisionedSeats}` : '—';
 
@@ -78,21 +65,6 @@ export function OverviewPane({
   function handleActiveSeatsClick() {
     if (seatTableRef.current) {
       seatTableRef.current.scrollIntoView({ behavior: 'smooth' });
-    }
-  }
-
-  function drillDownTitle(): string {
-    switch (drillDown) {
-      case 'active-seats':
-        return 'Active / total seats — all data';
-      case 'assigned':
-        return 'Seats assigned — 30-day history';
-      case 'revoked':
-        return 'Seats revoked — 30-day history';
-      case 'net':
-        return 'Net seat change — 30-day history';
-      default:
-        return '';
     }
   }
 
@@ -186,236 +158,13 @@ export function OverviewPane({
       <div className={styles.metricStrip}>
         <MetricCard
           value={seatLabel}
-          label="Active / total seats (latest)"
+          label="Active / total seats (28d)"
           delta={avgUtilPct != null ? `${avgUtilPct}% avg utilization` : '—'}
           deltaDir="neutral"
           onClick={handleActiveSeatsClick}
-          helpText="Currently active vs. total provisioned Copilot seats. Synced daily from the GitHub Copilot API. Click to scroll to the utilization table."
-        />
-        <MetricCard
-          value={totalAssigned > 0 ? String(totalAssigned) : '—'}
-          label="Seats assigned (30d)"
-          delta="cumulative"
-          deltaDir="up"
-          onClick={() => setDrillDown('assigned')}
-          helpText="Total Copilot seats assigned in the last 30 days. From daily seat-change sync. A rising trend indicates growing adoption."
-        />
-        <MetricCard
-          value={totalRevoked > 0 ? String(totalRevoked) : '—'}
-          label="Seats revoked (30d)"
-          delta="cumulative"
-          deltaDir={totalRevoked > 0 ? 'down' : 'neutral'}
-          onClick={() => setDrillDown('revoked')}
-          helpText="Total Copilot seats revoked in the last 30 days. From daily seat-change sync. Review revocations to ensure intentional offboarding."
-        />
-        <MetricCard
-          value={netSeats !== 0 ? `${netSeats > 0 ? '+' : ''}${netSeats}` : '—'}
-          label="Net seat change (30d)"
-          delta="assigned minus revoked"
-          deltaDir={netSeats > 0 ? 'up' : netSeats < 0 ? 'down' : 'neutral'}
-          onClick={() => setDrillDown('net')}
-          helpText="Net change in Copilot seats (assigned minus revoked) over 30 days. From daily sync data. Positive means fleet is growing."
+          helpText="Active users in the last 28 days vs. total provisioned Copilot seats. From the Copilot Metrics API. Click to scroll to the utilization table."
         />
       </div>
-
-      {/* Drill-down modal */}
-      <Modal
-        open={drillDown !== null}
-        onClose={() => setDrillDown(null)}
-        title={drillDownTitle()}
-        width={640}
-      >
-        {drillDown === 'active-seats' && (
-          <DataTable<SeatUtilizationBucket>
-            columns={[
-              {
-                key: 'date',
-                header: 'Date',
-                filterable: true,
-                helpText:
-                  'The date of this daily Copilot usage snapshot. Synced once per day from the GitHub Copilot API.',
-                render: (b) => (
-                  <span style={{ color: 'var(--fg-muted)' }}>{formatBucketDate(b.bucket)}</span>
-                ),
-                filterValue: (b) => formatBucketDate(b.bucket),
-              },
-              {
-                key: 'active',
-                header: 'Active',
-                sortable: true,
-                helpText:
-                  'Number of seats with recorded Copilot activity on this day. From daily usage sync.',
-                render: (b) => (
-                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-                    {b.active_seat_count ?? '—'}
-                  </span>
-                ),
-                sortValue: (b) => b.active_seat_count ?? 0,
-              },
-              {
-                key: 'provisioned',
-                header: 'Provisioned',
-                sortable: true,
-                helpText:
-                  'Total Copilot seats provisioned (assigned) on this day. From the GitHub Copilot seat management API.',
-                render: (b) => (
-                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-                    {b.provisioned_seat_count ?? '—'}
-                  </span>
-                ),
-                sortValue: (b) => b.provisioned_seat_count ?? 0,
-              },
-              {
-                key: 'utilization',
-                header: 'Utilization %',
-                sortable: true,
-                helpText:
-                  'Percentage of provisioned Copilot seats that were active. Synced daily from GitHub Copilot API. Target 70%+ utilization to maximize ROI.',
-                render: (b) => (
-                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-                    {b.utilization_pct != null ? `${Math.round(b.utilization_pct)}%` : '—'}
-                  </span>
-                ),
-                sortValue: (b) => b.utilization_pct ?? 0,
-              },
-            ]}
-            data={seatBuckets}
-            rowKey={(b) => b.bucket}
-          />
-        )}
-        {drillDown === 'assigned' && (
-          <DataTable<CopilotSeatsBucket>
-            columns={[
-              {
-                key: 'date',
-                header: 'Date',
-                filterable: true,
-                helpText:
-                  'The date of this daily Copilot seat-change snapshot. Synced once per day from the GitHub Copilot API.',
-                render: (b) => (
-                  <span style={{ color: 'var(--fg-muted)' }}>{formatBucketDate(b.bucket)}</span>
-                ),
-                filterValue: (b) => formatBucketDate(b.bucket),
-              },
-              {
-                key: 'assigned',
-                header: 'Assigned',
-                sortable: true,
-                helpText:
-                  'Number of new Copilot seats assigned on this day. From daily seat-change sync.',
-                render: (b) => (
-                  <span style={{ color: 'var(--success)', fontVariantNumeric: 'tabular-nums' }}>
-                    +{b.seats_assigned ?? 0}
-                  </span>
-                ),
-                sortValue: (b) => b.seats_assigned ?? 0,
-              },
-            ]}
-            data={copilotBuckets}
-            rowKey={(b) => b.bucket}
-          />
-        )}
-        {drillDown === 'revoked' && (
-          <DataTable<CopilotSeatsBucket>
-            columns={[
-              {
-                key: 'date',
-                header: 'Date',
-                filterable: true,
-                helpText:
-                  'The date of this daily Copilot seat-change snapshot. Synced once per day from the GitHub Copilot API.',
-                render: (b) => (
-                  <span style={{ color: 'var(--fg-muted)' }}>{formatBucketDate(b.bucket)}</span>
-                ),
-                filterValue: (b) => formatBucketDate(b.bucket),
-              },
-              {
-                key: 'revoked',
-                header: 'Revoked',
-                sortable: true,
-                helpText:
-                  'Number of Copilot seats revoked on this day. From daily seat-change sync. Spikes may indicate offboarding events.',
-                render: (b) => (
-                  <span
-                    style={{
-                      color: b.seats_revoked > 0 ? 'var(--danger)' : undefined,
-                      fontVariantNumeric: 'tabular-nums',
-                    }}
-                  >
-                    {b.seats_revoked > 0 ? `-${b.seats_revoked}` : '—'}
-                  </span>
-                ),
-                sortValue: (b) => b.seats_revoked ?? 0,
-              },
-            ]}
-            data={copilotBuckets}
-            rowKey={(b) => b.bucket}
-          />
-        )}
-        {drillDown === 'net' && (
-          <DataTable<CopilotSeatsBucket>
-            columns={[
-              {
-                key: 'date',
-                header: 'Date',
-                filterable: true,
-                helpText:
-                  'The date of this daily Copilot seat-change snapshot. Synced once per day from the GitHub Copilot API.',
-                render: (b) => (
-                  <span style={{ color: 'var(--fg-muted)' }}>{formatBucketDate(b.bucket)}</span>
-                ),
-                filterValue: (b) => formatBucketDate(b.bucket),
-              },
-              {
-                key: 'assigned',
-                header: 'Assigned',
-                sortable: true,
-                helpText:
-                  'Number of new Copilot seats assigned on this day. From daily seat-change sync.',
-                render: (b) => (
-                  <span style={{ color: 'var(--success)', fontVariantNumeric: 'tabular-nums' }}>
-                    +{b.seats_assigned ?? 0}
-                  </span>
-                ),
-                sortValue: (b) => b.seats_assigned ?? 0,
-              },
-              {
-                key: 'revoked',
-                header: 'Revoked',
-                sortable: true,
-                helpText:
-                  'Number of Copilot seats revoked on this day. From daily seat-change sync.',
-                render: (b) => (
-                  <span
-                    style={{
-                      color: b.seats_revoked > 0 ? 'var(--danger)' : undefined,
-                      fontVariantNumeric: 'tabular-nums',
-                    }}
-                  >
-                    {b.seats_revoked > 0 ? `-${b.seats_revoked}` : '—'}
-                  </span>
-                ),
-                sortValue: (b) => b.seats_revoked ?? 0,
-              },
-              {
-                key: 'net',
-                header: 'Net',
-                sortable: true,
-                helpText:
-                  'Net seat change (assigned minus revoked) for this day. Positive values indicate fleet growth.',
-                render: (b) => (
-                  <span style={{ fontVariantNumeric: 'tabular-nums' }}>
-                    {b.seats_net > 0 ? `+${b.seats_net}` : b.seats_net}
-                  </span>
-                ),
-                sortValue: (b) => b.seats_net ?? 0,
-              },
-            ]}
-            data={copilotBuckets}
-            rowKey={(b) => b.bucket}
-          />
-        )}
-      </Modal>
 
       {/* Charts row */}
       <div className={styles.grid2}>

--- a/frontend/src/pages/Copilot/OverviewPane.tsx
+++ b/frontend/src/pages/Copilot/OverviewPane.tsx
@@ -12,6 +12,7 @@ import { LineAreaChart } from '../../components/charts/LineAreaChart';
 import type { SeatUtilizationBucket } from '../../types/reports';
 import { getCopilotOverview } from '../../api/copilotMetrics';
 import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
 import { useOrgConfig } from '../../hooks/useOrgConfig';
 import { formatBucketDate, formatWeekday, formatWeekdayDate } from '../../utils/dates';
 import styles from './Copilot.module.css';
@@ -26,9 +27,11 @@ interface OverviewPaneProps {
 
 export function OverviewPane({ seatBuckets, isLoading, isError, onRetry }: OverviewPaneProps) {
   const { costPerSeat } = useOrgConfig();
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const { data: overview, isLoading: overviewLoading } = useQuery({
-    queryKey: ['copilot', 'overview'],
-    queryFn: getCopilotOverview,
+    queryKey: ['copilot', 'overview', orgParam],
+    queryFn: () => getCopilotOverview(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/PRMetricsPane.test.tsx
+++ b/frontend/src/pages/Copilot/PRMetricsPane.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import { PRMetricsPane } from './PRMetricsPane';
+
+vi.mock('echarts-for-react', () => ({
+  default: () => null,
+}));
+
+const mockGetCopilotPRMetrics = vi.fn();
+
+vi.mock('../../api/copilotMetrics', () => ({
+  getCopilotPRMetrics: (...args: unknown[]) => mockGetCopilotPRMetrics(...args),
+}));
+
+describe('PRMetricsPane', () => {
+  beforeEach(() => {
+    mockGetCopilotPRMetrics.mockResolvedValue({
+      dates: ['2026-06-01', '2026-06-02', '2026-06-03'],
+      pr_activity: [10, 12, 14],
+      pr_contributions: [50, 55, 60],
+      review_suggestions: [30, 35, 40],
+    });
+  });
+
+  it('renders summary stats', async () => {
+    renderWithProviders(<PRMetricsPane />);
+    expect(await screen.findByText('PR Active Users (28d)')).toBeInTheDocument();
+    expect(screen.getByText('PR Summaries Generated')).toBeInTheDocument();
+    expect(screen.getByText('Review Suggestions Accepted')).toBeInTheDocument();
+  });
+
+  it('renders PR activity chart', async () => {
+    renderWithProviders(<PRMetricsPane />);
+    expect(await screen.findByText('Pull Request Activity Over Time')).toBeInTheDocument();
+  });
+
+  it('renders PR contributions chart', async () => {
+    renderWithProviders(<PRMetricsPane />);
+    expect(await screen.findByText('Copilot PR contributions')).toBeInTheDocument();
+  });
+
+  it('renders review suggestions chart', async () => {
+    renderWithProviders(<PRMetricsPane />);
+    expect(await screen.findByText('Review suggestions')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Copilot/PRMetricsPane.tsx
+++ b/frontend/src/pages/Copilot/PRMetricsPane.tsx
@@ -1,0 +1,115 @@
+import { useQuery } from '@tanstack/react-query';
+import { Card, CardHeader } from '../../components/primitives/Card';
+import { Spinner } from '../../components/primitives/Spinner';
+import { ErrorBanner } from '../../components/primitives/ErrorBanner';
+import { LineAreaChart } from '../../components/charts/LineAreaChart';
+import { BarChart } from '../../components/charts/BarChart';
+import { getCopilotPRMetrics } from '../../api/copilotMetrics';
+import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
+import styles from './Copilot.module.css';
+
+function formatDate(iso: string): string {
+  const d = new Date(iso + 'T00:00:00');
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+export function PRMetricsPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: ['copilot', 'pr-metrics', orgParam],
+    queryFn: () => getCopilotPRMetrics(orgParam),
+    staleTime: 30 * 60 * 1000,
+  });
+  const chartColors = useChartColors();
+
+  if (isLoading) return <Spinner />;
+  if (isError)
+    return <ErrorBanner message="Failed to load PR metrics" onRetry={() => void refetch()} />;
+  if (data?.error) return <ErrorBanner message={data.message ?? 'PR metrics unavailable'} />;
+
+  const dates = (data?.dates ?? []).map(formatDate);
+
+  const totalPRActivity = (data?.pr_activity ?? []).reduce((a, b) => a + b, 0);
+  const totalContributions = (data?.pr_contributions ?? []).reduce((a, b) => a + b, 0);
+  const totalReviews = (data?.review_suggestions ?? []).reduce((a, b) => a + b, 0);
+
+  return (
+    <>
+      {/* Summary stats */}
+      <div className={styles.metricStrip}>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{totalPRActivity.toLocaleString()}</div>
+          <div className={styles.statLabel}>PR Active Users (28d)</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{totalContributions.toLocaleString()}</div>
+          <div className={styles.statLabel}>PR Summaries Generated</div>
+        </div>
+        <div className={styles.statCard}>
+          <div className={styles.statValue}>{totalReviews.toLocaleString()}</div>
+          <div className={styles.statLabel}>Review Suggestions Accepted</div>
+        </div>
+      </div>
+
+      {/* PR Activity Over Time */}
+      <Card style={{ marginBottom: 16 }}>
+        <CardHeader>Pull Request Activity Over Time</CardHeader>
+        <div style={{ padding: '0 16px 16px' }}>
+          <LineAreaChart
+            xAxisData={dates}
+            series={[
+              {
+                name: 'Active PR Users',
+                data: data?.pr_activity ?? [],
+                color: chartColors.accent,
+                areaOpacity: 0.12,
+              },
+            ]}
+            height={220}
+          />
+        </div>
+      </Card>
+
+      <div className={styles.grid2}>
+        {/* Copilot PR Contributions */}
+        <Card>
+          <CardHeader>Copilot PR contributions</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <BarChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'PR Summaries',
+                  data: data?.pr_contributions ?? [],
+                  color: chartColors.success,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+
+        {/* Review Suggestions */}
+        <Card>
+          <CardHeader>Review suggestions</CardHeader>
+          <div style={{ padding: '0 16px 16px' }}>
+            <LineAreaChart
+              xAxisData={dates}
+              series={[
+                {
+                  name: 'Suggestions Accepted',
+                  data: data?.review_suggestions ?? [],
+                  color: chartColors.attention,
+                  areaOpacity: 0.1,
+                },
+              ]}
+              height={200}
+            />
+          </div>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/pages/Copilot/PolicyPane.tsx
+++ b/frontend/src/pages/Copilot/PolicyPane.tsx
@@ -4,6 +4,7 @@ import { Spinner } from '../../components/primitives/Spinner';
 import { ErrorBanner } from '../../components/primitives/ErrorBanner';
 import { getCopilotPolicyChanges } from '../../api/copilotMetrics';
 import type { PolicyChange } from '../../api/copilotMetrics';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 function formatTimestamp(ts: string): string {
@@ -22,9 +23,11 @@ function formatTimestamp(ts: string): string {
 }
 
 export function PolicyPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ['copilot', 'policy-changes'],
-    queryFn: getCopilotPolicyChanges,
+    queryKey: ['copilot', 'policy-changes', orgParam],
+    queryFn: () => getCopilotPolicyChanges(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/ROIPane.tsx
+++ b/frontend/src/pages/Copilot/ROIPane.tsx
@@ -6,6 +6,7 @@ import { BarChart } from '../../components/charts/BarChart';
 import { getCopilotROI } from '../../api/copilotMetrics';
 import type { CopilotROISummary } from '../../api/copilotMetrics';
 import { useChartColors } from '../../hooks/useChartColors';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 function formatCurrency(value: number): string {
@@ -17,9 +18,11 @@ function formatPercent(value: number): string {
 }
 
 export function ROIPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const { data, isLoading, isError, refetch } = useQuery({
-    queryKey: ['copilot', 'roi'],
-    queryFn: getCopilotROI,
+    queryKey: ['copilot', 'roi', orgParam],
+    queryFn: () => getCopilotROI(orgParam),
     staleTime: 30 * 60 * 1000,
   });
   const chartColors = useChartColors();

--- a/frontend/src/pages/Copilot/TeamsPane.tsx
+++ b/frontend/src/pages/Copilot/TeamsPane.tsx
@@ -6,6 +6,7 @@ import { DataTable, type ColumnDef } from '../../components/primitives/DataTable
 import { getCopilotTeams } from '../../api/copilotMetrics';
 import type { CopilotTeam } from '../../api/copilotMetrics';
 import { ApiError } from '../../api/client';
+import { useOrg } from '../../hooks/useOrg';
 import styles from './Copilot.module.css';
 
 const teamColumns: ColumnDef<CopilotTeam>[] = [
@@ -154,9 +155,11 @@ const teamColumns: ColumnDef<CopilotTeam>[] = [
 ];
 
 export function TeamsPane() {
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['copilot', 'teams'],
-    queryFn: getCopilotTeams,
+    queryKey: ['copilot', 'teams', orgParam],
+    queryFn: () => getCopilotTeams(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 

--- a/frontend/src/pages/Copilot/index.tsx
+++ b/frontend/src/pages/Copilot/index.tsx
@@ -1,8 +1,8 @@
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { getSeatUtilizationReport, getCopilotSeatsReport } from '../../api/reports';
+import { getSeatUtilizationReport } from '../../api/reports';
 import { getCopilotAnomalies } from '../../api/copilotMetrics';
-import type { SeatUtilizationBucket, CopilotSeatsBucket } from '../../types/reports';
+import type { SeatUtilizationBucket } from '../../types/reports';
 import { useFeatures } from '../../hooks/useFeatures';
 import { CopilotTabBar } from './CopilotTabBar';
 import type { CopilotTab } from './CopilotTabBar';
@@ -43,11 +43,6 @@ export function CopilotPage() {
     queryFn: () => getSeatUtilizationReport({ window_days: 30 }),
   });
 
-  const { data: copilotData, isLoading: loadingCopilot } = useQuery({
-    queryKey: ['reports', 'copilot-seats'],
-    queryFn: () => getCopilotSeatsReport({ window_days: 30 }),
-  });
-
   const { data: anomalyData } = useQuery({
     queryKey: ['copilot', 'anomalies'],
     queryFn: getCopilotAnomalies,
@@ -70,7 +65,6 @@ export function CopilotPage() {
   }
 
   const seatBuckets = (seatUtilData?.data ?? []) as unknown as SeatUtilizationBucket[];
-  const copilotBuckets = (copilotData?.data ?? []) as unknown as CopilotSeatsBucket[];
 
   return (
     <div className={styles.page}>
@@ -89,8 +83,7 @@ export function CopilotPage() {
       {activeTab === 'overview' && (
         <OverviewPane
           seatBuckets={seatBuckets}
-          copilotBuckets={copilotBuckets}
-          isLoading={loadingSeatUtil || loadingCopilot}
+          isLoading={loadingSeatUtil}
           isError={seatUtilError}
           onRetry={() => void refetchSeatUtil()}
         />

--- a/frontend/src/pages/Copilot/index.tsx
+++ b/frontend/src/pages/Copilot/index.tsx
@@ -4,23 +4,44 @@ import { getSeatUtilizationReport } from '../../api/reports';
 import { getCopilotAnomalies } from '../../api/copilotMetrics';
 import type { SeatUtilizationBucket } from '../../types/reports';
 import { useFeatures } from '../../hooks/useFeatures';
+import { useOrg } from '../../hooks/useOrg';
 import { CopilotTabBar } from './CopilotTabBar';
 import type { CopilotTab } from './CopilotTabBar';
 import { PageHeader } from '../../components/common/PageHeader';
 import { OverviewPane } from './OverviewPane';
+import { ActivityPane } from './ActivityPane';
 import { AdoptionPane } from './AdoptionPane';
+import { TeamsPane } from './TeamsPane';
+import { ChatMetricsPane } from './ChatMetricsPane';
+import { LanguageBreakdownPane } from './LanguageBreakdownPane';
 import { ModelsPane } from './ModelsPane';
 import { LicensePane } from './LicensePane';
 import { BillingPane } from './BillingPane';
+import { ROIPane } from './ROIPane';
+import { PRMetricsPane } from './PRMetricsPane';
+import { AgentActivityPane } from './AgentActivityPane';
+import { BlockersPane } from './BlockersPane';
+import { PolicyPane } from './PolicyPane';
+import { GovernancePane } from './GovernancePane';
 import { AnomaliesPane } from './AnomaliesPane';
 import styles from './Copilot.module.css';
 
 const VALID_TABS: readonly CopilotTab[] = [
   'overview',
+  'activity',
   'adoption',
+  'teams',
+  'chat',
+  'languages',
   'models',
+  'prs',
+  'agent',
   'license',
   'billing',
+  'roi',
+  'blockers',
+  'policy',
+  'governance',
   'anomalies',
 ];
 
@@ -28,6 +49,8 @@ export function CopilotPage() {
   const { tab } = useParams<{ tab: string }>();
   const navigate = useNavigate();
   const { features } = useFeatures();
+  const { selectedOrg } = useOrg();
+  const orgParam = selectedOrg || undefined;
 
   const activeTab: CopilotTab = VALID_TABS.includes(tab as CopilotTab)
     ? (tab as CopilotTab)
@@ -39,13 +62,13 @@ export function CopilotPage() {
     refetch: refetchSeatUtil,
     data: seatUtilData,
   } = useQuery({
-    queryKey: ['reports', 'seat-util'],
-    queryFn: () => getSeatUtilizationReport({ window_days: 30 }),
+    queryKey: ['reports', 'seat-util', orgParam],
+    queryFn: () => getSeatUtilizationReport({ window_days: 30, org: orgParam }),
   });
 
   const { data: anomalyData } = useQuery({
-    queryKey: ['copilot', 'anomalies'],
-    queryFn: getCopilotAnomalies,
+    queryKey: ['copilot', 'anomalies', orgParam],
+    queryFn: () => getCopilotAnomalies(orgParam),
     staleTime: 30 * 60 * 1000,
   });
 
@@ -88,10 +111,20 @@ export function CopilotPage() {
           onRetry={() => void refetchSeatUtil()}
         />
       )}
+      {activeTab === 'activity' && <ActivityPane />}
       {activeTab === 'adoption' && <AdoptionPane />}
+      {activeTab === 'teams' && <TeamsPane />}
+      {activeTab === 'chat' && <ChatMetricsPane />}
+      {activeTab === 'languages' && <LanguageBreakdownPane />}
       {activeTab === 'models' && <ModelsPane />}
+      {activeTab === 'prs' && <PRMetricsPane />}
+      {activeTab === 'agent' && <AgentActivityPane />}
       {activeTab === 'license' && <LicensePane seatBuckets={seatBuckets} />}
       {activeTab === 'billing' && <BillingPane />}
+      {activeTab === 'roi' && <ROIPane />}
+      {activeTab === 'blockers' && <BlockersPane />}
+      {activeTab === 'policy' && <PolicyPane />}
+      {activeTab === 'governance' && <GovernancePane />}
       {activeTab === 'anomalies' && <AnomaliesPane />}
     </div>
   );


### PR DESCRIPTION
## Summary

Completes the Copilot Insights page overhaul:

### New Charts & Panes (from copilot-metrics-viewer)
- **Activity Pane**: DAU/WAU, completions, acceptance rate, chat/user, requests per mode
- **Chat Metrics Pane**: Interactions over time, active users, action rate
- **Language Breakdown Pane**: Stacked area, donut, model/lang, editor, top 5s
- **PR Metrics Pane**: PR activity, contributions, review suggestions
- **Agent Activity Pane**: LOC, by mode, by model, by language

### Organization Filter
All 17 Copilot panes now respect the org selector in the TopBar:
- Backend: All router endpoints accept `?org=` query param; service functions filter by `org_slug`
- Frontend: All API functions accept optional `org`; all panes use `useOrg()` hook with org in `queryKey`

### Tab Bar
Expanded from 6 → 16 tabs (Activity, Chat, Languages, Pull Requests, Agent, + previously unwired Teams/Policy/Blockers/Governance/ROI)

### Tests
- 1785 frontend tests pass ✅
- 22 new backend tests pass ✅
- TypeScript clean, ESLint clean, Prettier clean