### PR TITLE
fix: Docker build errors in test imports and widget queryFn

### DIFF
--- a/frontend/src/components/widgets/CopilotUsageWidget.tsx
+++ b/frontend/src/components/widgets/CopilotUsageWidget.tsx
@@ -10,7 +10,7 @@ export function CopilotUsageWidget() {
   const navigate = useNavigate();
   const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['widget', 'copilot-usage'],
-    queryFn: getCopilotAdoption,
+    queryFn: () => getCopilotAdoption(),
     staleTime: 60_000,
   });
 

--- a/frontend/src/pages/Copilot/ActivityPane.test.tsx
+++ b/frontend/src/pages/Copilot/ActivityPane.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import { ActivityPane } from './ActivityPane';

--- a/frontend/src/pages/Copilot/AgentActivityPane.test.tsx
+++ b/frontend/src/pages/Copilot/AgentActivityPane.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import { AgentActivityPane } from './AgentActivityPane';

--- a/frontend/src/pages/Copilot/ChatMetricsPane.test.tsx
+++ b/frontend/src/pages/Copilot/ChatMetricsPane.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import { ChatMetricsPane } from './ChatMetricsPane';

--- a/frontend/src/pages/Copilot/LanguageBreakdownPane.test.tsx
+++ b/frontend/src/pages/Copilot/LanguageBreakdownPane.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import { LanguageBreakdownPane } from './LanguageBreakdownPane';

--- a/frontend/src/pages/Copilot/PRMetricsPane.test.tsx
+++ b/frontend/src/pages/Copilot/PRMetricsPane.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import { PRMetricsPane } from './PRMetricsPane';


### PR DESCRIPTION
Fixes the Docker frontend build failure introduced in #347:

1. **Test imports**: Added missing `beforeEach` import from vitest in 5 new test files
2. **Widget queryFn**: Wrapped `getCopilotAdoption` in arrow function in CopilotUsageWidget to prevent React Query context object being passed as the `org` string parameter

Verified: `tsc -b` and `npm run build` both pass locally.