### PR TITLE
fix: include selfmanaged values and pull secret in multi-tenant deploy

### DIFF
--- a/.github/workflows/provision-customer.yml
+++ b/.github/workflows/provision-customer.yml
@@ -81,28 +81,39 @@ jobs:
 
           echo "✅ Labels and annotations applied"
 
-      - name: Apply NetworkPolicy (default deny)
+      - name: Copy image pull secret
+        run: |
+          # Copy ghcr-pull-secret from the octowatch namespace (source of truth)
+          if kubectl get secret ghcr-pull-secret -n octowatch >/dev/null 2>&1; then
+            kubectl get secret ghcr-pull-secret -n octowatch -o json | \
+              jq 'del(.metadata.namespace, .metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp)' | \
+              kubectl apply -n "$NAMESPACE" -f -
+            echo "✅ Image pull secret copied from octowatch namespace"
+          else
+            echo "::warning::ghcr-pull-secret not found in octowatch namespace. Pods won't be able to pull images until this is created."
+          fi
+
+      - name: Apply bootstrap NetworkPolicy (default deny until Helm deploys)
         run: |
           cat <<'EOF' | kubectl apply -n "$NAMESPACE" -f -
           apiVersion: networking.k8s.io/v1
           kind: NetworkPolicy
           metadata:
-            name: default-deny-all
+            name: bootstrap-default-deny
+            labels:
+              octowatch.dev/lifecycle: bootstrap
           spec:
             podSelector: {}
             policyTypes:
               - Ingress
               - Egress
-          EOF
-          echo "✅ Default-deny NetworkPolicy applied"
-
-      - name: Apply DNS egress policy
-        run: |
-          cat <<'EOF' | kubectl apply -n "$NAMESPACE" -f -
+          ---
           apiVersion: networking.k8s.io/v1
           kind: NetworkPolicy
           metadata:
-            name: allow-dns-egress
+            name: bootstrap-allow-dns
+            labels:
+              octowatch.dev/lifecycle: bootstrap
           spec:
             podSelector: {}
             policyTypes:
@@ -118,7 +129,7 @@ jobs:
                   - protocol: TCP
                     port: 53
           EOF
-          echo "✅ DNS egress policy applied"
+          echo "✅ Bootstrap NetworkPolicies applied (will be superseded by Helm)"
 
       - name: Verify namespace
         run: |

--- a/scripts/deploy-namespace.sh
+++ b/scripts/deploy-namespace.sh
@@ -57,13 +57,19 @@ if [ -n "${KV_NAME}" ] && [ -n "${WI_CLIENT_ID}" ]; then
   )
 fi
 
+# Include selfmanaged overlay (imagePullSecrets, registry, static replicas)
+VALUES_FILES=(
+  -f "${CHART}/values.yaml"
+  -f "${CHART}/values-selfmanaged.yaml"
+  -f "${CHART}/values-${SIZE}.yaml"
+)
+
 # Deploy
 helm upgrade --install "${NS}" "${CHART}" \
   -n "${NS}" \
-  -f "${CHART}/values.yaml" \
-  -f "${CHART}/values-${SIZE}.yaml" \
+  "${VALUES_FILES[@]}" \
   "${HELM_ARGS[@]}" \
-  --timeout 5m \
+  --timeout 8m \
   --wait
 
 echo "✓ ${NS} deployed (customer=${CUSTOMER}, size=${SIZE}, tag=${TAG})"


### PR DESCRIPTION
Fixes the `context deadline exceeded` failure when deploying to a new customer namespace.

**Root cause:** The multi-tenant deploy script wasn't including `values-selfmanaged.yaml`, which provides:
- `imagePullSecrets: [{name: ghcr-pull-secret}]` — required to pull from private GHCR
- `global.image.registry: ghcr.io/jmassardo` — correct registry
- Static worker replica counts (no KEDA on self-managed)

**Fixes:**
1. `deploy-namespace.sh` — adds `values-selfmanaged.yaml` to the values chain and bumps timeout to 8m
2. `provision-customer.yml` — copies `ghcr-pull-secret` from the existing `octowatch` namespace into the new customer namespace during provisioning