### PR TITLE
feat: add force_reinstall option to multi-tenant deploy

### DIFF
--- a/.github/workflows/deploy-multitenant.yml
+++ b/.github/workflows/deploy-multitenant.yml
@@ -36,6 +36,11 @@ on:
           - test
           - preview
           - prod
+      force_reinstall:
+        description: "Uninstall existing releases before deploying (use for broken StatefulSet upgrades)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: deploy-multitenant
@@ -44,6 +49,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}
+  FORCE_REINSTALL: ${{ github.event.inputs.force_reinstall || 'false' }}
 
 jobs:
   # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/deploy-namespace.sh
+++ b/scripts/deploy-namespace.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 NS="${1:?Usage: deploy-namespace.sh <namespace> <image-tag> <helm-chart-path>}"
 TAG="${2:?Usage: deploy-namespace.sh <namespace> <image-tag> <helm-chart-path>}"
 CHART="${3:?Usage: deploy-namespace.sh <namespace> <image-tag> <helm-chart-path>}"
+FORCE_REINSTALL="${FORCE_REINSTALL:-false}"
 
 echo "━━━ Deploying to ${NS} (tag=${TAG}) ━━━"
 
@@ -55,6 +56,16 @@ if [ -n "${KV_NAME}" ] && [ -n "${WI_CLIENT_ID}" ]; then
     --set "keyVault.name=${KV_NAME}"
     --set "keyVault.uri=${KV_URI}"
   )
+fi
+
+# Force reinstall if requested (purges broken releases with immutable field conflicts)
+if [ "${FORCE_REINSTALL}" = "true" ]; then
+  if helm status "${NS}" -n "${NS}" >/dev/null 2>&1; then
+    echo "⚠️  Force reinstall: uninstalling existing release ${NS}"
+    helm uninstall "${NS}" -n "${NS}" --wait
+    # Give K8s time to clean up resources
+    sleep 5
+  fi
 fi
 
 # Include selfmanaged overlay (imagePullSecrets, registry, static replicas)


### PR DESCRIPTION
Adds a `force_reinstall` boolean input to the Deploy (Multi-Tenant) workflow.

When enabled, each namespace's existing Helm release is uninstalled before re-deploying. This handles the case where immutable StatefulSet fields changed (e.g., adding `values-selfmanaged.yaml` changed volumeClaimTemplates).

**Usage:** Trigger workflow dispatch with `force_reinstall: true` and `ring: preview` to purge and redeploy octodemo.