### PR TITLE
fix: generate app secrets during customer provisioning

### DIFF
--- a/.github/workflows/provision-customer.yml
+++ b/.github/workflows/provision-customer.yml
@@ -93,6 +93,37 @@ jobs:
             echo "::warning::ghcr-pull-secret not found in octowatch namespace. Pods won't be able to pull images until this is created."
           fi
 
+      - name: Generate application secrets
+        run: |
+          RELEASE_NAME="$NAMESPACE"
+          DB_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
+          SECRET_KEY=$(openssl rand -base64 48 | tr -d '/+=' | head -c 48)
+          ENCRYPTION_KEY=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
+
+          # Database secret (used by TimescaleDB StatefulSet)
+          kubectl create secret generic octowatch-db-secret \
+            -n "$NAMESPACE" \
+            --from-literal=postgres-password="$DB_PASSWORD" \
+            --from-literal=app-password="$DB_PASSWORD" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          # Application secret (used by API/worker deployments)
+          DATABASE_URL="postgresql+asyncpg://app_rw:${DB_PASSWORD}@${RELEASE_NAME}-postgresql:5432/auditlogs?sslmode=disable"
+          VALKEY_URL="redis://${RELEASE_NAME}-valkey-primary:6379"
+
+          kubectl create secret generic "${RELEASE_NAME}-secrets" \
+            -n "$NAMESPACE" \
+            --from-literal=secret-key="$SECRET_KEY" \
+            --from-literal=encryption-key="$ENCRYPTION_KEY" \
+            --from-literal=database-url="$DATABASE_URL" \
+            --from-literal=valkey-url="$VALKEY_URL" \
+            --from-literal=github-client-id="" \
+            --from-literal=github-client-secret="" \
+            --from-literal=github-rules-token="" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
+          echo "✅ Application secrets generated (GitHub credentials left blank for setup wizard)"
+
       - name: Apply bootstrap NetworkPolicy (default deny until Helm deploys)
         run: |
           cat <<'EOF' | kubectl apply -n "$NAMESPACE" -f -

--- a/scripts/deploy-namespace.sh
+++ b/scripts/deploy-namespace.sh
@@ -45,6 +45,7 @@ HELM_ARGS=(
   --set "ingress.tls.enabled=true"
   --set "ingress.annotations.cert-manager\\.io/cluster-issuer="
   --set "networkPolicy.enabled=true"
+  --set "useExternalSecrets=true"
 )
 
 # Add workload identity / Key Vault if annotations are populated


### PR DESCRIPTION
Root cause of deployment timeout: pods can't start without valid DATABASE_URL and VALKEY_URL.

**Changes:**
- `provision-customer.yml`: Generates random DB password, SECRET_KEY, ENCRYPTION_KEY. Creates both `octowatch-db-secret` (for TimescaleDB) and `{release}-secrets` (for app) with proper internal URLs.
- `deploy-namespace.sh`: Sets `useExternalSecrets=true` so the Helm chart doesn't overwrite pre-provisioned secrets.

**Flow after this fix:**
1. Provision → creates namespace, labels, pull secret, app secrets, NetworkPolicies
2. Deploy → Helm installs with proper secrets already in place, pods start successfully
3. User accesses `{customer}.octowatch.dev` → setup wizard prompts for GitHub App credentials