### PR TITLE
fix: use --set-string for image tag and create Valkey auth secret

### DIFF
--- a/.github/workflows/provision-customer.yml
+++ b/.github/workflows/provision-customer.yml
@@ -107,9 +107,16 @@ jobs:
             --from-literal=app-password="$DB_PASSWORD" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+          # Valkey auth secret (used by Valkey subchart)
+          VALKEY_PASSWORD=$(openssl rand -base64 32 | tr -d '/+=' | head -c 32)
+          kubectl create secret generic octowatch-valkey-secret \
+            -n "$NAMESPACE" \
+            --from-literal=valkey-password="$VALKEY_PASSWORD" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
           # Application secret (used by API/worker deployments)
           DATABASE_URL="postgresql+asyncpg://app_rw:${DB_PASSWORD}@${RELEASE_NAME}-postgresql:5432/auditlogs?sslmode=disable"
-          VALKEY_URL="redis://${RELEASE_NAME}-valkey-primary:6379"
+          VALKEY_URL="redis://:${VALKEY_PASSWORD}@${RELEASE_NAME}-valkey-primary:6379"
 
           kubectl create secret generic "${RELEASE_NAME}-secrets" \
             -n "$NAMESPACE" \

--- a/scripts/deploy-namespace.sh
+++ b/scripts/deploy-namespace.sh
@@ -38,7 +38,7 @@ REGISTRY="${IMAGE_PREFIX:-ghcr.io/jmassardo}"
 
 # Build Helm set flags
 HELM_ARGS=(
-  --set "global.image.tag=${TAG}"
+  --set-string "global.image.tag=${TAG}"
   --set "global.image.registry=${REGISTRY}"
   --set "ingress.host=${CUSTOMER}.octowatch.dev"
   --set "ingress.tls.secretName=octowatch-wildcard-tls"


### PR DESCRIPTION
Fixes two issues blocking the octodemo deployment:

1. **InvalidImageName** — SHA-prefix tags like `9470587` were parsed as integers by Helm's `--set`, producing `%!s(int64=9470587)` in the image name. Fixed by using `--set-string`.

2. **Missing Valkey secret** — The Valkey subchart requires `octowatch-valkey-secret` with a `valkey-password` key. The provisioning workflow now generates this and also includes the password in the VALKEY_URL.