### PR TITLE
fix: correct DATABASE_URL hostname for TimescaleDB service

### DIFF
--- a/.github/workflows/provision-customer.yml
+++ b/.github/workflows/provision-customer.yml
@@ -115,7 +115,8 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
           # Application secret (used by API/worker deployments)
-          DATABASE_URL="postgresql+asyncpg://app_rw:${DB_PASSWORD}@${RELEASE_NAME}-postgresql:5432/auditlogs?sslmode=disable"
+          # Note: TimescaleDB service is hardcoded as 'octowatch-postgresql' in the template
+          DATABASE_URL="postgresql+asyncpg://app_rw:${DB_PASSWORD}@octowatch-postgresql:5432/auditlogs?sslmode=disable"
           VALKEY_URL="redis://:${VALKEY_PASSWORD}@${RELEASE_NAME}-valkey-primary:6379"
 
           kubectl create secret generic "${RELEASE_NAME}-secrets" \


### PR DESCRIPTION
The TimescaleDB StatefulSet template uses a hardcoded service name `octowatch-postgresql` (not release-name based). The provisioning was generating `DATABASE_URL` with `${RELEASE_NAME}-postgresql` = `octowatch-octodemo-postgresql` which doesn't resolve in DNS — causing API readiness probe 503s and worker-sync CrashLoopBackOff.

Fixed to use the actual service name: `octowatch-postgresql`.