### PR TITLE
fix: remove invalid sslmode param from DATABASE_URL and disable worker-sync

### DIFF
--- a/.github/workflows/provision-customer.yml
+++ b/.github/workflows/provision-customer.yml
@@ -116,7 +116,7 @@ jobs:
 
           # Application secret (used by API/worker deployments)
           # Note: TimescaleDB service is hardcoded as 'octowatch-postgresql' in the template
-          DATABASE_URL="postgresql+asyncpg://app_rw:${DB_PASSWORD}@octowatch-postgresql:5432/auditlogs?sslmode=disable"
+          DATABASE_URL="postgresql+asyncpg://app_rw:${DB_PASSWORD}@octowatch-postgresql:5432/auditlogs"
           VALKEY_URL="redis://:${VALKEY_PASSWORD}@${RELEASE_NAME}-valkey-primary:6379"
 
           kubectl create secret generic "${RELEASE_NAME}-secrets" \

--- a/helm/values-selfmanaged.yaml
+++ b/helm/values-selfmanaged.yaml
@@ -28,7 +28,7 @@ worker:
   baseline:
     replicaCount: 2
   sync:
-    replicaCount: 1
+    replicaCount: 0  # Requires GitHub App credentials; enable per-customer when configured
 
 beat:
   image:


### PR DESCRIPTION
## Root Cause

The API readiness probe returned 503 because the DATABASE_URL contained `?sslmode=disable` — but asyncpg (the async PostgreSQL driver) does not support `sslmode` as a query parameter. It threw `TypeError: connect() got an unexpected keyword argument 'sslmode'` on every connection attempt.

## Changes

1. **Remove `?sslmode=disable` from DATABASE_URL** in provisioning workflow — asyncpg defaults to no SSL when the param is absent
2. **Set worker-sync replicas to 0** in self-managed values — it crashes without GitHub App credentials (`GITHUB_APP_PRIVATE_KEY_PATH` file missing)

## Verification needed

After merge: re-provision the customer (to update the secret), then deploy with force_reinstall to get a fresh DB with the corrected URL.