### PR TITLE
feat: update ingress host to csa.octowatch.dev

### DIFF
--- a/helm/values-selfmanaged.yaml
+++ b/helm/values-selfmanaged.yaml
@@ -43,7 +43,7 @@ frontend:
 ingress:
   enabled: true
   className: nginx
-  host: octowatch.jmassardo.azure.csa-github.com
+  host: csa.octowatch.dev
   tls:
     enabled: true
     secretName: octowatch-tls


### PR DESCRIPTION
Switches the existing OctoWatch instance ingress from `octowatch.jmassardo.azure.csa-github.com` to `csa.octowatch.dev`.