### PR TITLE
fix(sync): skip installation token for installations entity

### DIFF
--- a/backend/app/workers/github_sync_worker.py
+++ b/backend/app/workers/github_sync_worker.py
@@ -875,9 +875,15 @@ async def _sync_entity_async(
         current_cursor = resume_cursor
         page_num = 0
         while True:
-            # Use enterprise PAT for audit_log, installation token otherwise
+            # Use enterprise PAT for audit_log, App JWT for installations
+            # (handled inside _fetch_page), installation token otherwise.
             if entity_type == "audit_log" and enterprise_pat:
                 token = enterprise_pat
+            elif entity_type == "installations":
+                # installations entity generates its own App JWT in _fetch_page;
+                # skip installation token acquisition which may fail if the
+                # passed installation_id is stale or from a different org.
+                token = ""
             else:
                 token = await token_manager.get_installation_token(installation_id)
             items, next_cursor = await _fetch_page(


### PR DESCRIPTION
## Problem

The `installations` sync entity uses an App JWT (generated inside `_fetch_page`) to call `GET /app/installations`. However, the pagination loop unconditionally called `get_installation_token(installation_id)` on every iteration, which could fail with a 404 if the configured `installation_id` is stale or belongs to an org that no longer has the app installed.

When this token fetch failed, the entire installations entity task crashed **before** `_fetch_page` was ever reached, preventing org installations from being discovered and promoted into `github_app_configs`.

## Fix

Added an `elif entity_type == "installations":` branch that sets `token = ""` (unused placeholder), bypassing the unnecessary `get_installation_token()` call for this entity type.

## Testing

- All 110 sync tests pass
- All 26 post-sync pipeline tests pass
- Linter clean