### PR TITLE
fix: phase 1 quick wins — dashboard widget fallback, page headers

### DIFF
--- a/frontend/src/pages/Dashboard/index.tsx
+++ b/frontend/src/pages/Dashboard/index.tsx
@@ -112,15 +112,25 @@ export function DashboardPage() {
   // Seed widget layout from backend config on initial load
   const backendSeeded = useRef(false);
   useEffect(() => {
-    if (!backendSeeded.current && configQuery.data && configQuery.data.layout.length > 0) {
-      backendSeeded.current = true;
+    if (backendSeeded.current) return;
+    if (!configQuery.isFetched) return;
+
+    backendSeeded.current = true;
+
+    if (configQuery.data && configQuery.data.layout.length > 0) {
       const seeded = configQuery.data.layout.map((item) => ({
         id: item.widget_id,
         size: (getWidgetDefinition(item.widget_id)?.defaultSize ?? 'md') as 'sm' | 'md' | 'lg',
       }));
-      setWidgetLayout(seeded);
+      setWidgetLayout(seeded); // eslint-disable-line react-hooks/set-state-in-effect -- one-time seed from async config
+    } else if (widgetLayout.length === 0 && !showOnboarding) {
+      // No saved layout and onboarding already complete — seed with default preset
+      const defaultPreset = PERSONA_WIDGET_PRESETS['platform-engineer'];
+      const fallback = createDashboardLayout([...defaultPreset]);
+      setWidgetLayout(fallback); // eslint-disable-line react-hooks/set-state-in-effect -- one-time seed
+      saveDashboardLayout(fallback);
     }
-  }, [configQuery.data]);
+  }, [configQuery.isFetched, configQuery.data, widgetLayout.length, showOnboarding]);
 
   // After mutation success, sync backend response back into local state
   // (keeps local state authoritative while staying in sync with persisted data)

--- a/frontend/src/pages/Packages/Packages.test.tsx
+++ b/frontend/src/pages/Packages/Packages.test.tsx
@@ -367,7 +367,7 @@ describe('PackagesPage', () => {
   it('renders PageHeader with correct title', () => {
     queryResults = loadedResults();
     renderPage();
-    expect(screen.getByText('Packages')).toBeDefined();
+    expect(screen.getByText('Packages Monitoring')).toBeDefined();
     expect(
       screen.getByText('Monitor package security posture, visibility, and container image health'),
     ).toBeDefined();

--- a/frontend/src/pages/Packages/index.tsx
+++ b/frontend/src/pages/Packages/index.tsx
@@ -335,8 +335,9 @@ export function PackagesPage() {
   return (
     <div className={styles.page}>
       <PageHeader
-        title="Packages"
+        title="Packages Monitoring"
         description="Monitor package security posture, visibility, and container image health"
+        breadcrumbs={[{ label: 'Security' }]}
         showHelp
       />
 

--- a/frontend/src/pages/SupplyChain/index.tsx
+++ b/frontend/src/pages/SupplyChain/index.tsx
@@ -422,6 +422,7 @@ export function SupplyChainPage() {
       <PageHeader
         title="Supply Chain Security"
         description="Monitor and analyse supply chain risks across your GitHub Actions workflows and dependencies"
+        breadcrumbs={[{ label: 'Security' }]}
         showHelp
       />
 


### PR DESCRIPTION
## Summary

Phase 1 quick wins addressing 4 issues:

### #282 — Streaming telemetry widget not showing
The IngestionStatusWidget was properly registered but never appeared for users with no saved dashboard config. Added a fallback: when both localStorage and backend config are empty (and onboarding is complete), seed the dashboard with the `platform-engineer` preset which includes the ingestion-status widget.

### #280 — Onboarding org/repo list pagination
Already implemented via `PaginatedOrgList` component with search, pagination (20/page), select-all, and bulk operations. Closing as resolved.

### #297 — Packages Monitoring header inconsistent
Renamed page title from "Packages" to "Packages Monitoring" to follow the descriptive naming convention used across the app (e.g., "Compliance Center", "Workflow Security Scanner").

### #298 — Supply Chain Security header inconsistent
Added `breadcrumbs={[{ label: 'Security' }]}` to both Supply Chain and Packages pages to match the section-based navigation pattern used by other pages like Sync Status.

## Testing
- `npx tsc --noEmit` ✓
- `npx eslint src/ --quiet` ✓
- `npx vitest run` — 1788 tests pass
- `npm run build` ✓

Closes #282, closes #280, closes #297, closes #298