### PR TITLE
fix(tests): handle FastAPI 0.137+ _IncludedRouter in route traversal

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,10 +9,8 @@ description = "GitHub Enterprise Cloud audit log ingestion, detection, and repor
 requires-python = ">=3.12"
 dependencies = [
     # Web framework
-    # Pinned to 0.136.1: FastAPI 0.137.0 wraps included routers in
-    # _IncludedRouter objects that break prometheus-fastapi-instrumentator
-    # (see https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370).
-    # Upgrade once the instrumentator releases a compatible fix.
+    # Note: FastAPI 0.137+ wraps include_router() calls in _IncludedRouter
+    # objects — route traversal tests must use include_context to resolve paths.
     "fastapi==0.138.1",
     "uvicorn[standard]==0.49.0",
     "python-multipart==0.0.32",

--- a/backend/tests/test_epic12_future_vision.py
+++ b/backend/tests/test_epic12_future_vision.py
@@ -670,34 +670,32 @@ class TestModelImports:
 class TestRouterRegistration:
     """Verify new routers are registered in the FastAPI app."""
 
-    def test_app_has_cross_org_routes(self):
+    @staticmethod
+    def _get_all_paths() -> list[str]:
+        """Collect all route paths, handling FastAPI 0.137+ _IncludedRouter."""
         from app.main import app
+        from tests.test_route_registration import _collect_paths
 
-        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        return list(_collect_paths(list(app.routes)))
+
+    def test_app_has_cross_org_routes(self):
+        paths = self._get_all_paths()
         assert any("/cross-org" in p for p in paths)
 
     def test_app_has_playbook_routes(self):
-        from app.main import app
-
-        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        paths = self._get_all_paths()
         assert any("/playbooks" in p for p in paths)
 
     def test_app_has_workflow_routes(self):
-        from app.main import app
-
-        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        paths = self._get_all_paths()
         assert any("/workflows" in p for p in paths)
 
     def test_app_has_copilot_governance_routes(self):
-        from app.main import app
-
-        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        paths = self._get_all_paths()
         assert any("/copilot/governance" in p for p in paths)
 
     def test_app_has_nl_query_endpoint(self):
-        from app.main import app
-
-        paths = [r.path for r in app.routes if hasattr(r, "path")]
+        paths = self._get_all_paths()
         assert any("/query/nl" in p for p in paths)
 
 

--- a/backend/tests/test_epic4_detection.py
+++ b/backend/tests/test_epic4_detection.py
@@ -956,9 +956,10 @@ class TestThreatIntelRouterRegistration:
 
     def test_router_registered_in_app(self):
         from app.main import create_app
+        from tests.test_route_registration import _collect_paths
 
         app = create_app()
-        routes = [route.path for route in app.routes if hasattr(route, "path")]
+        routes = list(_collect_paths(list(app.routes)))
         # Check that at least the indicator endpoints are registered
         assert any("/threat-intel" in r for r in routes)
 

--- a/backend/tests/test_route_registration.py
+++ b/backend/tests/test_route_registration.py
@@ -54,9 +54,23 @@ EXPECTED_ROUTE_PREFIXES = [
 
 
 def _collect_paths(routes: list) -> set[str]:
-    """Recursively collect route paths, handling nested routers."""
+    """Recursively collect route paths, handling nested routers.
+
+    FastAPI 0.137+ wraps include_router() calls in _IncludedRouter objects
+    that expose the router via include_context.included_router rather than
+    the traditional path/routes attributes.
+    """
     paths: set[str] = set()
     for route in routes:
+        # FastAPI 0.137+ _IncludedRouter: traverse via include_context
+        if hasattr(route, "include_context"):
+            ctx = route.include_context
+            prefix = getattr(ctx, "prefix", "")
+            sub_router = getattr(ctx, "included_router", None)
+            if sub_router and hasattr(sub_router, "routes"):
+                for sub_path in _collect_paths(list(sub_router.routes)):
+                    paths.add(prefix + sub_path)
+            continue
         if hasattr(route, "path"):
             paths.add(route.path)
         if hasattr(route, "routes"):


### PR DESCRIPTION
FastAPI 0.137+ wraps `include_router()` calls in `_IncludedRouter` objects that lack `path`/`routes` attributes. This broke all 82 route registration tests since the dependabot bump to FastAPI 0.138.1 (#391).

**Fix:** Updated `_collect_paths()` to traverse via `include_context.included_router` when encountering `_IncludedRouter` instances.

**Files changed:**
- `tests/test_route_registration.py` — updated `_collect_paths` helper
- `tests/test_epic12_future_vision.py` — use shared helper
- `tests/test_epic4_detection.py` — use shared helper
- `pyproject.toml` — updated stale comment about FastAPI pin