### PR TITLE
feat: standardize tab routing to path-based pattern

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import { AppShell } from './components/layout/AppShell';
 import { AuthGuard } from './components/auth/AuthGuard';
+import { LegacyTabRedirect } from './components/common/LegacyTabRedirect';
 import { RedirectAfterLogin } from './components/auth/RedirectAfterLogin';
 import { LoginPage } from './pages/LoginPage';
 import { SetupPage } from './pages/Setup';
@@ -33,6 +34,7 @@ import { SupplyChainPage } from './pages/SupplyChain';
 import { PackagesPage } from './pages/Packages';
 import { UserBehaviorPage } from './pages/UserBehavior';
 import { ThreatIntelPage } from './pages/ThreatIntel';
+import { ThreatIntelFeedDetailPage } from './pages/ThreatIntel/FeedDetailPage';
 import { SyncStatusPage } from './pages/SyncStatus';
 import { NotificationsPage } from './pages/Notifications';
 import AuthSettingsPage from './pages/admin/AuthSettings';
@@ -62,8 +64,30 @@ export const router = createBrowserRouter(
         { path: '/dashboard/custom', element: <Navigate to="/dashboard?view=widgets" replace /> },
         { path: '/threats', element: <Navigate to="/threats/open" replace /> },
         { path: '/threats/:tab', element: <ThreatsPage /> },
-        { path: '/threat-intel', element: <ThreatIntelPage /> },
-        { path: '/threat-intel/:feedId', element: <ThreatIntelPage /> },
+        {
+          path: '/threat-intel',
+          element: (
+            <LegacyTabRedirect
+              basePath="/threat-intel"
+              validTabs={['feeds', 'indicators', 'matches', 'analytics']}
+              defaultTab="feeds"
+            />
+          ),
+        },
+        {
+          path: '/workflows',
+          element: (
+            <LegacyTabRedirect
+              basePath="/workflows"
+              validTabs={['findings', 'scores', 'activity', 'rules']}
+              defaultTab="findings"
+            />
+          ),
+        },
+        { path: '/workflows/health', element: <WorkflowHealthPage /> },
+        { path: '/workflows/:tab', element: <WorkflowsPage /> },
+        { path: '/threat-intel/:tab', element: <ThreatIntelPage /> },
+        { path: '/threat-intel/feeds/:feedId', element: <ThreatIntelFeedDetailPage /> },
         { path: '/actors/:login', element: <ActorsPage /> },
         { path: '/posture', element: <PosturePage /> },
         { path: '/posture/:org', element: <PosturePage /> },
@@ -71,41 +95,114 @@ export const router = createBrowserRouter(
         { path: '/events', element: <EventsPage /> },
         { path: '/events/:id', element: <EventDetailPage /> },
         { path: '/crossorg', element: <CrossOrgPage /> },
-        { path: '/workflows', element: <WorkflowsPage /> },
-        { path: '/workflows/health', element: <WorkflowHealthPage /> },
         {
           path: '/advanced-security',
           element: <Navigate to="/advanced-security/overview" replace />,
         },
         { path: '/advanced-security/:tab', element: <AdvancedSecurityPage /> },
-        { path: '/supply-chain', element: <SupplyChainPage /> },
-        { path: '/packages', element: <PackagesPage /> },
+        {
+          path: '/supply-chain',
+          element: (
+            <LegacyTabRedirect
+              basePath="/supply-chain"
+              validTabs={['risks', 'rules', 'workflow']}
+              defaultTab="risks"
+            />
+          ),
+        },
+        { path: '/supply-chain/:tab', element: <SupplyChainPage /> },
+        {
+          path: '/packages',
+          element: (
+            <LegacyTabRedirect
+              basePath="/packages"
+              validTabs={['overview', 'inventory', 'alerts', 'container-health']}
+              defaultTab="overview"
+            />
+          ),
+        },
+        { path: '/packages/:tab', element: <PackagesPage /> },
         { path: '/playbooks', element: <PlaybooksPage /> },
         { path: '/velocity', element: <VelocityPage /> },
         { path: '/devactivity', element: <DevActivityPage /> },
-        { path: '/user-behavior', element: <UserBehaviorPage /> },
+        {
+          path: '/user-behavior',
+          element: (
+            <LegacyTabRedirect
+              basePath="/user-behavior"
+              validTabs={['risky-users', 'anomalies', 'permissions']}
+              defaultTab="risky-users"
+            />
+          ),
+        },
+        { path: '/user-behavior/:tab', element: <UserBehaviorPage /> },
         { path: '/copilot', element: <Navigate to="/copilot/overview" replace /> },
         { path: '/copilot/:tab', element: <CopilotPage /> },
         { path: '/health', element: <Navigate to="/health/repos" replace /> },
         { path: '/health/settings', element: <HealthSettingsPage /> },
         { path: '/health/:tab', element: <HealthPage /> },
-        { path: '/reports', element: <ReportsPage /> },
-        { path: '/compliance', element: <CompliancePage /> },
+        {
+          path: '/reports',
+          element: (
+            <LegacyTabRedirect
+              basePath="/reports"
+              validTabs={['templates', 'my-reports', 'shared', 'recent']}
+              defaultTab="templates"
+            />
+          ),
+        },
+        { path: '/reports/:tab', element: <ReportsPage /> },
+        {
+          path: '/compliance',
+          element: (
+            <LegacyTabRedirect
+              basePath="/compliance"
+              validTabs={['overview', 'soc2', 'iso27001', 'nist_csf', 'gdpr', 'policy']}
+              defaultTab="overview"
+            />
+          ),
+        },
+        { path: '/compliance/:tab', element: <CompliancePage /> },
         { path: '/query', element: <QueryPage /> },
         { path: '/rules', element: <RulesPage /> },
         { path: '/rules/:ruleId', element: <RulesPage /> },
-        { path: '/users', element: <UsersPage /> },
-        { path: '/notifications', element: <NotificationsPage /> },
+        {
+          path: '/users',
+          element: (
+            <LegacyTabRedirect
+              basePath="/users"
+              validTabs={['users', 'roles']}
+              defaultTab="users"
+            />
+          ),
+        },
+        { path: '/users/:tab', element: <UsersPage /> },
+        {
+          path: '/notifications',
+          element: <Navigate to="/notifications/alerts" replace />,
+        },
+        { path: '/notifications/:tab', element: <NotificationsPage /> },
         { path: '/integrations', element: <Navigate to="/settings/integrations" replace /> },
         { path: '/settings', element: <Navigate to="/settings/all" replace /> },
         { path: '/settings/:tab', element: <SettingsPage /> },
-        { path: '/monitoring/telemetry', element: <TelemetryPage /> },
+        {
+          path: '/monitoring/telemetry',
+          element: (
+            <LegacyTabRedirect
+              basePath="/monitoring/telemetry"
+              validTabs={['streams', 'workers', 'volume', 'errors']}
+              defaultTab="streams"
+            />
+          ),
+        },
+        { path: '/monitoring/telemetry/:tab', element: <TelemetryPage /> },
         { path: '/monitoring/platform-usage', element: <PlatformUsagePage /> },
         { path: '/monitoring/audit-trail', element: <AuditTrailPage /> },
         { path: '/telemetry', element: <Navigate to="/monitoring/telemetry" replace /> },
         { path: '/monitoring/sync-status', element: <SyncStatusPage /> },
         { path: '/admin/auth', element: <AuthSettingsPage /> },
-        { path: '/profile', element: <ProfilePage /> },
+        { path: '/profile', element: <Navigate to="/profile/preferences" replace /> },
+        { path: '/profile/:tab', element: <ProfilePage /> },
       ],
     },
   ],

--- a/frontend/src/components/common/LegacyTabRedirect.tsx
+++ b/frontend/src/components/common/LegacyTabRedirect.tsx
@@ -1,0 +1,35 @@
+import { Navigate, useLocation } from 'react-router-dom';
+
+/**
+ * Redirect from a legacy `?tab=X` URL to a path-based `/base/X` URL.
+ *
+ * Validates the tab value against allowed tabs. Preserves all other query params
+ * and removes the `tab` param from the resulting URL.
+ *
+ * Usage in route config:
+ * ```
+ * { path: '/reports', element: <LegacyTabRedirect basePath="/reports" validTabs={[...]} defaultTab="templates" /> }
+ * ```
+ */
+export function LegacyTabRedirect({
+  basePath,
+  validTabs,
+  defaultTab,
+}: {
+  basePath: string;
+  validTabs: readonly string[];
+  defaultTab: string;
+}) {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const tabFromQuery = searchParams.get('tab');
+
+  const resolvedTab = tabFromQuery && validTabs.includes(tabFromQuery) ? tabFromQuery : defaultTab;
+
+  // Remove the tab param, keep everything else
+  searchParams.delete('tab');
+  const remainingSearch = searchParams.toString();
+  const to = `${basePath}/${resolvedTab}${remainingSearch ? `?${remainingSearch}` : ''}`;
+
+  return <Navigate to={to} replace />;
+}

--- a/frontend/src/hooks/useTabParam.ts
+++ b/frontend/src/hooks/useTabParam.ts
@@ -1,0 +1,42 @@
+import { useCallback } from 'react';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
+
+/**
+ * Manage path-based tab routing with validation, fallback, and query-param preservation.
+ *
+ * The hook reads the `:tab` param from the current URL (e.g. `/reports/templates`),
+ * validates it against the allowed values, and provides a setter that navigates to
+ * the new tab while preserving existing query params.
+ *
+ * If the current URL segment is not a valid tab, the hook returns `defaultTab` and
+ * replaces the URL with the canonical path on the next render (via the component).
+ *
+ * @param basePath - Absolute path prefix without trailing slash (e.g. `/reports`)
+ * @param validTabs - Readonly array of allowed tab slugs
+ * @param defaultTab - Fallback tab when URL segment is missing or invalid
+ */
+export function useTabParam<T extends string>(
+  basePath: string,
+  validTabs: readonly T[],
+  defaultTab: T,
+): [T, (tab: T, options?: { replace?: boolean }) => void] {
+  const { tab } = useParams<{ tab: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const activeTab: T = (validTabs as readonly string[]).includes(tab ?? '')
+    ? (tab as T)
+    : defaultTab;
+
+  const setTab = useCallback(
+    (newTab: T, opts?: { replace?: boolean }) => {
+      navigate(
+        { pathname: `${basePath}/${newTab}`, search: location.search },
+        { replace: opts?.replace ?? true },
+      );
+    },
+    [basePath, navigate, location.search],
+  );
+
+  return [activeTab, setTab];
+}

--- a/frontend/src/pages/Compliance/Compliance.test.tsx
+++ b/frontend/src/pages/Compliance/Compliance.test.tsx
@@ -131,20 +131,27 @@ vi.mock('../../api/reports', () => ({
   exportReport: vi.fn(),
 }));
 
+function renderPage(route = '/compliance/overview') {
+  return renderWithProviders(<CompliancePage />, {
+    route,
+    routePath: '/compliance/:tab',
+  });
+}
+
 describe('CompliancePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('renders the page header', async () => {
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Compliance Center')).toBeInTheDocument();
     });
   });
 
   it('renders summary metric cards', async () => {
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Overall Score')).toBeInTheDocument();
     });
@@ -159,7 +166,7 @@ describe('CompliancePage', () => {
   });
 
   it('renders all tabs', async () => {
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
     });
@@ -171,7 +178,7 @@ describe('CompliancePage', () => {
   });
 
   it('shows framework cards on overview tab', async () => {
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('SOC 2 Type II')).toBeInTheDocument();
     });
@@ -182,7 +189,7 @@ describe('CompliancePage', () => {
   });
 
   it('shows Generate All Reports button in header', async () => {
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Generate All Reports')).toBeInTheDocument();
     });
@@ -190,7 +197,7 @@ describe('CompliancePage', () => {
 
   it('navigates to SOC 2 tab on click', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'SOC 2' })).toBeInTheDocument();
@@ -205,7 +212,7 @@ describe('CompliancePage', () => {
 
   it('navigates to framework tab from framework card click', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByText('SOC 2 Type II')).toBeInTheDocument();
@@ -221,7 +228,7 @@ describe('CompliancePage', () => {
 
   it('navigates to GDPR tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'GDPR' })).toBeInTheDocument();
@@ -236,7 +243,7 @@ describe('CompliancePage', () => {
 
   it('renders GDPR processing activities', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'GDPR' })).toBeInTheDocument();
@@ -251,7 +258,7 @@ describe('CompliancePage', () => {
 
   it('renders GDPR breach checklist', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'GDPR' })).toBeInTheDocument();
@@ -267,7 +274,7 @@ describe('CompliancePage', () => {
 
   it('navigates to Policy Checks tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Policy Checks' })).toBeInTheDocument();
@@ -282,7 +289,7 @@ describe('CompliancePage', () => {
 
   it('renders policy check data table', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Policy Checks' })).toBeInTheDocument();
@@ -298,7 +305,7 @@ describe('CompliancePage', () => {
 
   it('marks the active tab correctly', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<CompliancePage />, { route: '/compliance' });
+    renderPage();
 
     await waitFor(() => {
       expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();

--- a/frontend/src/pages/Compliance/index.tsx
+++ b/frontend/src/pages/Compliance/index.tsx
@@ -10,7 +10,7 @@ import { OverviewPane } from './OverviewPane';
 import { FrameworkPane } from './FrameworkPane';
 import { GDPRPane } from './GDPRPane';
 import { PolicyChecksPane } from './PolicyChecksPane';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import type { ComplianceTab } from '../../types/compliance';
 import styles from './Compliance.module.css';
 
@@ -26,7 +26,7 @@ const TABS: { key: ComplianceTab; label: string }[] = [
 ];
 
 export function CompliancePage() {
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'overview');
+  const [activeTab, setActiveTab] = useTabParam('/compliance', TAB_KEYS, 'overview');
   const [isGenerating, setIsGenerating] = useState(false);
   const queryClient = useQueryClient();
 

--- a/frontend/src/pages/Notifications/Notifications.test.tsx
+++ b/frontend/src/pages/Notifications/Notifications.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { renderWithProviders } from '../../test/utils';
 import { NotificationsPage } from './index';
 
 const mockListNotifications = vi.fn();
@@ -73,19 +72,11 @@ const mockPreferences = {
   updated_at: new Date().toISOString(),
 };
 
-function renderPage() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+function renderPage(route = '/notifications/alerts') {
+  return renderWithProviders(<NotificationsPage />, {
+    route,
+    routePath: '/notifications/:tab',
   });
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={['/notifications']}>
-        <Routes>
-          <Route path="/notifications" element={<NotificationsPage />} />
-        </Routes>
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
 }
 
 describe('NotificationsPage', () => {

--- a/frontend/src/pages/Notifications/index.tsx
+++ b/frontend/src/pages/Notifications/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTabParam } from '../../hooks/useTabParam';
 import { PageHeader } from '../../components/common/PageHeader';
 import { Button } from '../../components/primitives/Button';
 import {
@@ -42,12 +43,14 @@ function severityClass(severity: NotificationSeverity): string {
   }
 }
 
-type TabId = 'notifications' | 'preferences';
+type TabId = 'alerts' | 'preferences';
+
+const TAB_KEYS: readonly TabId[] = ['alerts', 'preferences'];
 
 export function NotificationsPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const [activeTab, setActiveTab] = useState<TabId>('notifications');
+  const [activeTab, setActiveTab] = useTabParam('/notifications', TAB_KEYS, 'alerts');
   const [page, setPage] = useState(1);
   const [severityFilter, setSeverityFilter] = useState<NotificationSeverity | ''>('');
   const [readFilter, setReadFilter] = useState<string>('');
@@ -98,7 +101,7 @@ export function NotificationsPage() {
           description="Manage your notification settings and preferences"
         />
         <div className={styles.tabs}>
-          <button className={`${styles.tab}`} onClick={() => setActiveTab('notifications')}>
+          <button className={`${styles.tab}`} onClick={() => setActiveTab('alerts')}>
             Notifications
           </button>
           <button
@@ -120,7 +123,7 @@ export function NotificationsPage() {
       <div className={styles.tabs}>
         <button
           className={`${styles.tab} ${styles.tabActive}`}
-          onClick={() => setActiveTab('notifications')}
+          onClick={() => setActiveTab('alerts')}
         >
           Notifications
           {data && data.unread_count > 0 && ` (${data.unread_count})`}

--- a/frontend/src/pages/Packages/Packages.test.tsx
+++ b/frontend/src/pages/Packages/Packages.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { screen, fireEvent } from '@testing-library/react';
 import { PackagesPage } from './index';
+import { renderWithProviders } from '../../test/utils';
 import type {
   PackageSummary,
   PackageAlertList,
@@ -131,17 +130,11 @@ vi.mock('@tanstack/react-query', async () => {
   };
 });
 
-function renderPage() {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+function renderPage(route = '/packages/overview') {
+  return renderWithProviders(<PackagesPage />, {
+    route,
+    routePath: '/packages/:tab',
   });
-  return render(
-    <MemoryRouter>
-      <QueryClientProvider client={client}>
-        <PackagesPage />
-      </QueryClientProvider>
-    </MemoryRouter>,
-  );
 }
 
 function loadedResults(): Record<string, MockQueryReturn<unknown>> {

--- a/frontend/src/pages/Packages/index.tsx
+++ b/frontend/src/pages/Packages/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import { PageHeader } from '../../components/common/PageHeader';
 import { EmptyState } from '../../components/common/EmptyState';
 import { MetricCard } from '../../components/primitives/MetricCard';
@@ -278,7 +278,7 @@ function ContainerHealthTab({ data }: { data: StaleImageList | undefined }) {
 /* ── Main page ──────────────────────────────────────────────────────────── */
 
 export function PackagesPage() {
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'overview');
+  const [activeTab, setActiveTab] = useTabParam('/packages', TAB_KEYS, 'overview');
 
   const summaryQuery = useQuery({
     queryKey: ['packages', 'summary'],

--- a/frontend/src/pages/Profile/Profile.test.tsx
+++ b/frontend/src/pages/Profile/Profile.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { renderWithProviders } from '../../test/utils';
 import { ProfilePage } from './index';
 
 /* ─── Mock API module ──────────────────────────────────────────────────────── */
@@ -72,18 +71,11 @@ const MOCK_SESSIONS = {
 
 /* ─── Helpers ──────────────────────────────────────────────────────────────── */
 
-function renderProfile() {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+function renderProfile(route = '/profile/profile') {
+  return renderWithProviders(<ProfilePage />, {
+    route,
+    routePath: '/profile/:tab',
   });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <MemoryRouter>
-        <ProfilePage />
-      </MemoryRouter>
-    </QueryClientProvider>,
-  );
 }
 
 /* ─── Tests ────────────────────────────────────────────────────────────────── */
@@ -107,9 +99,9 @@ describe('ProfilePage', () => {
 
     const tabs = screen.getAllByRole('tab');
     expect(tabs).toHaveLength(3);
-    expect(tabs[0]).toHaveTextContent('Profile');
-    expect(tabs[1]).toHaveTextContent('Preferences');
-    expect(tabs[2]).toHaveTextContent('Sessions');
+    expect(screen.getByRole('tab', { name: 'Profile' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Preferences' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Sessions' })).toBeInTheDocument();
   });
 
   it('displays user profile information on the Profile tab', async () => {

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTabParam } from '../../hooks/useTabParam';
 import { PageHeader } from '../../components/common/PageHeader';
 import { Card, CardHeader } from '../../components/primitives/Card';
 import { Avatar } from '../../components/primitives/Avatar';
@@ -14,11 +15,13 @@ import {
 import type { UserPreferences, SessionInfo } from '../../api/userProfile';
 import styles from './Profile.module.css';
 
-type TabKey = 'profile' | 'preferences' | 'sessions';
+type TabKey = 'preferences' | 'profile' | 'sessions';
+
+const TAB_KEYS: readonly TabKey[] = ['preferences', 'profile', 'sessions'];
 
 const TABS: { key: TabKey; label: string }[] = [
-  { key: 'profile', label: 'Profile' },
   { key: 'preferences', label: 'Preferences' },
+  { key: 'profile', label: 'Profile' },
   { key: 'sessions', label: 'Sessions' },
 ];
 
@@ -44,7 +47,7 @@ const ITEMS_PER_PAGE_OPTIONS = [25, 50, 100];
  * ProfilePage — User profile, preferences, and session management.
  */
 export function ProfilePage() {
-  const [activeTab, setActiveTab] = useState<TabKey>('profile');
+  const [activeTab, setActiveTab] = useTabParam('/profile', TAB_KEYS, 'preferences');
 
   return (
     <div className={styles.page}>

--- a/frontend/src/pages/Reports/Reports.test.tsx
+++ b/frontend/src/pages/Reports/Reports.test.tsx
@@ -141,6 +141,13 @@ vi.mock('../../api/reports', () => ({
   exportCustomReport: vi.fn(),
 }));
 
+function renderPage(route = '/reports/templates') {
+  return renderWithProviders(<ReportsPage />, {
+    route,
+    routePath: '/reports/:tab',
+  });
+}
+
 describe('ReportsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -148,13 +155,13 @@ describe('ReportsPage', () => {
   });
 
   it('renders page title and subtitle', () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(screen.getByText('Reports')).toBeInTheDocument();
     expect(screen.getByText('Organization activity and usage analytics')).toBeInTheDocument();
   });
 
   it('renders window selector with 30d, 60d, 90d buttons', () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(screen.getByText('Window:')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '30d' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '60d' })).toBeInTheDocument();
@@ -163,7 +170,7 @@ describe('ReportsPage', () => {
 
   it('updates window days when selector buttons are clicked', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     expect(screen.getByText(/last 30 days/)).toBeInTheDocument();
 
@@ -175,7 +182,7 @@ describe('ReportsPage', () => {
   });
 
   it('renders summary card with data bucket counts', async () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(screen.getByText(/Data summary/)).toBeInTheDocument();
     expect(screen.getByText('Total MAU buckets')).toBeInTheDocument();
     expect(screen.getByText('Actions buckets')).toBeInTheDocument();
@@ -184,7 +191,7 @@ describe('ReportsPage', () => {
   });
 
   it('renders summary cards for all 8 report types', async () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Repo creation buckets')).toBeInTheDocument();
     });
@@ -199,12 +206,12 @@ describe('ReportsPage', () => {
   });
 
   it('shows Platform seat util instead of Seat util for seat-utilization summary', () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(screen.getByText('Platform seat util buckets')).toBeInTheDocument();
   });
 
   it('summary values are clickable when numeric', async () => {
-    const { container } = renderWithProviders(<ReportsPage />);
+    const { container } = renderPage();
     await waitFor(() => {
       const grid = container.querySelector('.summaryGrid')!;
       const clickableValues = grid.querySelectorAll('.clickableValue');
@@ -219,7 +226,7 @@ describe('ReportsPage', () => {
 
   it('clicking bucket value opens the detail drawer', async () => {
     const user = userEvent.setup();
-    const { container } = renderWithProviders(<ReportsPage />);
+    const { container } = renderPage();
     await waitFor(() => {
       expect(container.querySelector('.clickableValue')).not.toBeNull();
     });
@@ -230,7 +237,7 @@ describe('ReportsPage', () => {
   });
 
   it('renders data source labels on summary cards', async () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       const sources = screen.getAllByText(/Source: Audit Events/);
       expect(sources.length).toBeGreaterThanOrEqual(3);
@@ -239,7 +246,7 @@ describe('ReportsPage', () => {
 
   it('renders data source in drawer when report is opened', async () => {
     const user = userEvent.setup();
-    const { container } = renderWithProviders(<ReportsPage />);
+    const { container } = renderPage();
     await waitFor(() => {
       expect(container.querySelector('.clickableValue')).not.toBeNull();
     });
@@ -252,7 +259,7 @@ describe('ReportsPage', () => {
   // ── Tab navigation tests ──────────────────────────────────────────────
 
   it('renders tab navigation with Templates, My Reports, Shared with Me, and Recent tabs', () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(screen.getByRole('tab', { name: /Templates/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /My Reports/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Shared with Me/i })).toBeInTheDocument();
@@ -260,13 +267,13 @@ describe('ReportsPage', () => {
   });
 
   it('Templates tab is active by default', () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     const templatesTab = screen.getByRole('tab', { name: /Templates/i });
     expect(templatesTab.getAttribute('aria-selected')).toBe('true');
   });
 
   it('renders 8 pre-built report template rows in Templates tab table', async () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });
@@ -280,7 +287,7 @@ describe('ReportsPage', () => {
   });
 
   it('templates are displayed in a DataTable', async () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });
@@ -294,7 +301,7 @@ describe('ReportsPage', () => {
 
   it('clicking a template row opens the detail drawer with config panel', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('User Activity Report')).toBeInTheDocument();
     });
@@ -308,7 +315,7 @@ describe('ReportsPage', () => {
 
   it('clicking a template row opens drawer with export buttons', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });
@@ -322,7 +329,7 @@ describe('ReportsPage', () => {
   it('calls exportReport when Export CSV is clicked in drawer', async () => {
     const { exportReport } = await import('../../api/reports');
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });
@@ -336,7 +343,7 @@ describe('ReportsPage', () => {
   it('calls exportReport when Export PDF is clicked in drawer', async () => {
     const { exportReport } = await import('../../api/reports');
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });
@@ -368,7 +375,7 @@ describe('ReportsPage', () => {
       },
     ]);
 
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     expect(await screen.findByText('Custom Security Report')).toBeInTheDocument();
     expect(screen.getByText('DORA Metrics Report')).toBeInTheDocument();
@@ -385,7 +392,7 @@ describe('ReportsPage', () => {
         status: 'available',
       } as import('../../types/reports').ReportCatalogEntry,
     ]);
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(await screen.findByText('Report Without Tags')).toBeInTheDocument();
   });
 
@@ -401,7 +408,7 @@ describe('ReportsPage', () => {
         tags: ['custom-tag-unique'],
       },
     ]);
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(await screen.findByText('Report With Null Date')).toBeInTheDocument();
   });
 
@@ -418,7 +425,7 @@ describe('ReportsPage', () => {
         tags: [],
       },
     ]);
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await screen.findByText('MAU With Description');
     expect(screen.getByText('Unique actors per time bucket.')).toBeInTheDocument();
   });
@@ -436,7 +443,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('MAU Report');
     await user.click(title);
@@ -461,7 +468,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('MAU Report');
     await user.click(title);
@@ -481,7 +488,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('Unknown Report');
     await user.click(title);
@@ -502,7 +509,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('Repo Creation Rate Report');
     await user.click(title);
@@ -523,7 +530,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('PAT Counts Report');
     await user.click(title);
@@ -544,7 +551,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('Webhook Counts Report');
     await user.click(title);
@@ -565,7 +572,7 @@ describe('ReportsPage', () => {
       },
     ]);
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     const title = await screen.findByText('Codespace Hours Report');
     await user.click(title);
@@ -577,7 +584,7 @@ describe('ReportsPage', () => {
 
   it('switching to My Reports tab shows empty state when no custom reports', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('tab', { name: /My Reports/i }));
 
@@ -586,7 +593,7 @@ describe('ReportsPage', () => {
 
   it('switching to Shared tab shows empty state when no shared reports', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('tab', { name: /Shared with Me/i }));
 
@@ -595,7 +602,7 @@ describe('ReportsPage', () => {
 
   it('switching to Recent tab shows empty state when no recent reports', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('tab', { name: /Recent/i }));
 
@@ -603,13 +610,13 @@ describe('ReportsPage', () => {
   });
 
   it('renders "New Custom Report" button', () => {
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     expect(screen.getByRole('button', { name: /New Custom Report/i })).toBeInTheDocument();
   });
 
   it('clicking "New Custom Report" opens the report builder modal', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('button', { name: /New Custom Report/i }));
 
@@ -639,7 +646,7 @@ describe('ReportsPage', () => {
     ]);
 
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('tab', { name: /My Reports/i }));
 
@@ -669,7 +676,7 @@ describe('ReportsPage', () => {
     ]);
 
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('tab', { name: /My Reports/i }));
     await screen.findByText('My Report');
@@ -703,7 +710,7 @@ describe('ReportsPage', () => {
     ]);
 
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await user.click(screen.getByRole('tab', { name: /Shared with Me/i }));
     await screen.findByText('Shared Detection Report');
@@ -748,7 +755,7 @@ describe('ReportsPage', () => {
       },
     ]);
 
-    renderWithProviders(<ReportsPage />);
+    renderPage();
 
     await waitFor(() => {
       const myReportsTab = screen.getByRole('tab', { name: /My Reports/i });
@@ -759,7 +766,7 @@ describe('ReportsPage', () => {
   // ── Deep-linking tests ──────────────────────────────────────────────
 
   it('opening page with report query param auto-opens the drawer', async () => {
-    renderWithProviders(<ReportsPage />, { route: '/?report=tmpl-user-activity' });
+    renderPage('/reports/templates?report=tmpl-user-activity');
 
     await waitFor(() => {
       expect(screen.getByTestId('report-detail-tray')).toBeInTheDocument();
@@ -771,7 +778,7 @@ describe('ReportsPage', () => {
   it('drawer shows organization when selectedOrg is set', async () => {
     mockUseOrg.mockReturnValue({ selectedOrg: 'my-org', setSelectedOrg: vi.fn() });
     const user = userEvent.setup();
-    renderWithProviders(<ReportsPage />);
+    renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });
@@ -782,7 +789,7 @@ describe('ReportsPage', () => {
   });
 
   it('table has clickable row styling on report names', async () => {
-    const { container } = renderWithProviders(<ReportsPage />);
+    const { container } = renderPage();
     await waitFor(() => {
       expect(screen.getByText('Security Posture Report')).toBeInTheDocument();
     });

--- a/frontend/src/pages/Reports/index.tsx
+++ b/frontend/src/pages/Reports/index.tsx
@@ -39,7 +39,8 @@ import type {
   ReportTemplate,
 } from '../../types/reports';
 import { formatDateOnly } from '../../utils/dates';
-import { useEnumQueryParam, useQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
+import { useQueryParam } from '../../hooks/useQueryParam';
 import styles from './Reports.module.css';
 
 /**
@@ -157,8 +158,8 @@ export function ReportsPage() {
   const { selectedOrg } = useOrg();
   const { showToast } = useToast();
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useEnumQueryParam(
-    'tab',
+  const [activeTab, setActiveTab] = useTabParam(
+    '/reports',
     ['templates', 'my-reports', 'shared', 'recent'] as const,
     'templates',
   );

--- a/frontend/src/pages/SupplyChain/SupplyChain.test.tsx
+++ b/frontend/src/pages/SupplyChain/SupplyChain.test.tsx
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { screen, fireEvent } from '@testing-library/react';
 import { SupplyChainPage } from './index';
+import { renderWithProviders } from '../../test/utils';
 import type { SupplyChainPosture, RiskSummary, RulesListResponse } from '../../api/supplyChain';
 
 vi.mock('../../hooks/useHelp', () => ({
@@ -95,17 +94,11 @@ vi.mock('@tanstack/react-query', async () => {
   };
 });
 
-function renderPage() {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+function renderPage(route = '/supply-chain/risks') {
+  return renderWithProviders(<SupplyChainPage />, {
+    route,
+    routePath: '/supply-chain/:tab',
   });
-  return render(
-    <MemoryRouter>
-      <QueryClientProvider client={client}>
-        <SupplyChainPage />
-      </QueryClientProvider>
-    </MemoryRouter>,
-  );
 }
 
 describe('SupplyChainPage', () => {

--- a/frontend/src/pages/SupplyChain/index.tsx
+++ b/frontend/src/pages/SupplyChain/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import { PageHeader } from '../../components/common/PageHeader';
 import { MetricCard } from '../../components/primitives/MetricCard';
 import { Spinner } from '../../components/primitives/Spinner';
@@ -374,7 +374,7 @@ function RuleEditor({
 /* ── Main page ──────────────────────────────────────────────────────────── */
 
 export function SupplyChainPage() {
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'risks');
+  const [activeTab, setActiveTab] = useTabParam('/supply-chain', TAB_KEYS, 'risks');
   const [selectedRisk, setSelectedRisk] = useState<SupplyChainRisk | null>(null);
   const [selectedRule, setSelectedRule] = useState<SupplyChainRule | null>(null);
   const [creatingRule, setCreatingRule] = useState(false);

--- a/frontend/src/pages/Telemetry/Telemetry.test.tsx
+++ b/frontend/src/pages/Telemetry/Telemetry.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { TelemetryPage } from './index';
 
 vi.mock('echarts-for-react', () => ({
@@ -18,13 +18,20 @@ vi.mock('../../api/telemetry', () => ({
 
 import * as telemetryApi from '../../api/telemetry';
 
-function renderPage() {
+function renderPage(route = '/monitoring/telemetry/streams') {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
-    <MemoryRouter>
-      <QueryClientProvider client={qc}>
-        <TelemetryPage />
-      </QueryClientProvider>
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route
+          path="/monitoring/telemetry/:tab"
+          element={
+            <QueryClientProvider client={qc}>
+              <TelemetryPage />
+            </QueryClientProvider>
+          }
+        />
+      </Routes>
     </MemoryRouter>,
   );
 }

--- a/frontend/src/pages/Telemetry/index.tsx
+++ b/frontend/src/pages/Telemetry/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import { getTelemetrySummary } from '../../api/telemetry';
 import { PageHeader } from '../../components/common/PageHeader';
 import { MetricCard } from '../../components/primitives/MetricCard';
@@ -30,7 +30,7 @@ function isStale(iso: string | null): boolean {
 }
 
 export function TelemetryPage() {
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'streams');
+  const [activeTab, setActiveTab] = useTabParam('/monitoring/telemetry', TAB_KEYS, 'streams');
 
   const {
     data: summary,

--- a/frontend/src/pages/ThreatIntel/FeedDetailPage.tsx
+++ b/frontend/src/pages/ThreatIntel/FeedDetailPage.tsx
@@ -1,0 +1,19 @@
+import { PageHeader } from '../../components/common/PageHeader';
+import { FeedsTab } from './FeedsTab';
+import styles from './ThreatIntel.module.css';
+
+/**
+ * Feed detail page rendered at /threat-intel/feeds/:feedId.
+ * Reuses FeedsTab which reads feedId from useParams.
+ */
+export function ThreatIntelFeedDetailPage() {
+  return (
+    <div className={styles.page}>
+      <PageHeader
+        title="Threat Intelligence"
+        description="Manage threat intelligence feeds, indicators, and view detection matches"
+      />
+      <FeedsTab />
+    </div>
+  );
+}

--- a/frontend/src/pages/ThreatIntel/FeedsTab.tsx
+++ b/frontend/src/pages/ThreatIntel/FeedsTab.tsx
@@ -136,13 +136,13 @@ export function FeedsTab() {
 
   const openFeedDetail = useCallback(
     (feed: ThreatIntelFeed) => {
-      navigate(`/threat-intel/${feed.id}`, { replace: true });
+      navigate(`/threat-intel/feeds/${feed.id}`, { replace: true });
     },
     [navigate],
   );
 
   const closeFeedDetail = useCallback(() => {
-    navigate('/threat-intel', { replace: true });
+    navigate('/threat-intel/feeds', { replace: true });
   }, [navigate]);
 
   if (isLoading) {

--- a/frontend/src/pages/ThreatIntel/ThreatIntel.test.tsx
+++ b/frontend/src/pages/ThreatIntel/ThreatIntel.test.tsx
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { Route, Routes } from 'react-router-dom';
 import { renderWithProviders } from '../../test/utils';
 import { ThreatIntelPage } from './index';
+import { ThreatIntelFeedDetailPage } from './FeedDetailPage';
 
 vi.mock('echarts-for-react', () => ({
   default: () => null,
@@ -125,16 +127,27 @@ vi.mock('../../api/threatIntel', () => ({
   bulkCreateIndicators: vi.fn().mockResolvedValue({ created: 5, duplicates: 1, errors: 0 }),
 }));
 
+function renderThreatIntel(route = '/threat-intel/feeds') {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/threat-intel/:tab" element={<ThreatIntelPage />} />
+      <Route path="/threat-intel/feeds/:feedId" element={<ThreatIntelFeedDetailPage />} />
+    </Routes>,
+    { route },
+  );
+}
+
+function renderFeedDetail(route = '/threat-intel/feeds/1') {
+  return renderThreatIntel(route);
+}
+
 describe('ThreatIntelPage', () => {
   /* ---------------------------------------------------------------- */
   /*  Tab rendering                                                     */
   /* ---------------------------------------------------------------- */
 
   it('renders page header and all tabs', () => {
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     expect(screen.getByText('Threat Intelligence')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Feeds' })).toBeInTheDocument();
@@ -144,30 +157,21 @@ describe('ThreatIntelPage', () => {
   });
 
   it('shows Feeds tab as active by default', () => {
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     const feedsTab = screen.getByRole('tab', { name: 'Feeds' });
     expect(feedsTab).toHaveAttribute('aria-selected', 'true');
   });
 
   it('renders feed data in the Feeds tab', async () => {
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     expect(await screen.findByText('AlienVault OTX')).toBeInTheDocument();
     expect(screen.getByText('Blocklist.de')).toBeInTheDocument();
   });
 
   it('shows Add Feed button on Feeds tab', async () => {
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await screen.findByText('AlienVault OTX');
     expect(screen.getByText('+ Add Feed')).toBeInTheDocument();
@@ -179,10 +183,7 @@ describe('ThreatIntelPage', () => {
 
   it('switches to Indicators tab on click', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Indicators' }));
 
@@ -192,10 +193,7 @@ describe('ThreatIntelPage', () => {
 
   it('switches to Matches tab and shows metric cards', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Matches' }));
 
@@ -206,10 +204,7 @@ describe('ThreatIntelPage', () => {
 
   it('switches to Analytics tab and shows metric cards', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Analytics' }));
 
@@ -225,10 +220,7 @@ describe('ThreatIntelPage', () => {
 
   it('opens Add Feed modal when clicking the button', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await screen.findByText('AlienVault OTX');
     await user.click(screen.getByText('+ Add Feed'));
@@ -238,10 +230,7 @@ describe('ThreatIntelPage', () => {
   });
 
   it('shows feed status badges', async () => {
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     expect(await screen.findByText('Active')).toBeInTheDocument();
     expect(screen.getByText('Paused')).toBeInTheDocument();
@@ -253,10 +242,7 @@ describe('ThreatIntelPage', () => {
 
   it('opens detail drawer when clicking a feed row', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await screen.findByText('AlienVault OTX');
     const row = screen.getByRole('button', { name: 'View details for AlienVault OTX' });
@@ -276,10 +262,7 @@ describe('ThreatIntelPage', () => {
 
   it('closes detail drawer when clicking close button', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel/1',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderFeedDetail('/threat-intel/feeds/1');
 
     // Wait for feed data and drawer to render
     await waitFor(() => {
@@ -294,10 +277,7 @@ describe('ThreatIntelPage', () => {
   });
 
   it('opens feed detail via deep link URL', async () => {
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel/1',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderFeedDetail('/threat-intel/feeds/1');
 
     await waitFor(() => {
       expect(screen.getByTestId('drawer-panel')).toBeInTheDocument();
@@ -311,10 +291,7 @@ describe('ThreatIntelPage', () => {
 
   it('shows search input on Indicators tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Indicators' }));
 
@@ -323,10 +300,7 @@ describe('ThreatIntelPage', () => {
 
   it('shows Add Indicator button on Indicators tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Indicators' }));
 
@@ -336,10 +310,7 @@ describe('ThreatIntelPage', () => {
 
   it('shows Import CSV and Export buttons on Indicators tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Indicators' }));
 
@@ -350,10 +321,7 @@ describe('ThreatIntelPage', () => {
 
   it('opens indicator detail drawer when clicking a row', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel?tab=indicators',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel('/threat-intel/indicators');
 
     await screen.findByText('malicious.example.com');
     const row = screen.getByRole('button', { name: 'View details for malicious.example.com' });
@@ -374,10 +342,7 @@ describe('ThreatIntelPage', () => {
 
   it('shows match details with detection link', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Matches' }));
 
@@ -391,10 +356,7 @@ describe('ThreatIntelPage', () => {
 
   it('shows analytics metric values', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<ThreatIntelPage />, {
-      route: '/threat-intel',
-      routePath: '/threat-intel/:feedId?',
-    });
+    renderThreatIntel();
 
     await user.click(screen.getByRole('tab', { name: 'Analytics' }));
 

--- a/frontend/src/pages/ThreatIntel/index.tsx
+++ b/frontend/src/pages/ThreatIntel/index.tsx
@@ -3,7 +3,7 @@ import { FeedsTab } from './FeedsTab';
 import { IndicatorsTab } from './IndicatorsTab';
 import { MatchesTab } from './MatchesTab';
 import { AnalyticsTab } from './AnalyticsTab';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import styles from './ThreatIntel.module.css';
 
 type TabId = 'feeds' | 'indicators' | 'matches' | 'analytics';
@@ -18,7 +18,7 @@ const TABS: { id: TabId; label: string }[] = [
 ];
 
 export function ThreatIntelPage() {
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'feeds');
+  const [activeTab, setActiveTab] = useTabParam('/threat-intel', TAB_KEYS, 'feeds');
 
   return (
     <div className={styles.page}>

--- a/frontend/src/pages/UserBehavior/UserBehavior.test.tsx
+++ b/frontend/src/pages/UserBehavior/UserBehavior.test.tsx
@@ -137,21 +137,28 @@ vi.mock('../../hooks/useHelp', () => ({
 // Tests
 // ---------------------------------------------------------------------------
 
+function renderPage(route = '/user-behavior/risky-users') {
+  return renderWithProviders(<UserBehaviorPage />, {
+    route,
+    routePath: '/user-behavior/:tab',
+  });
+}
+
 describe('UserBehaviorPage', () => {
   it('renders page title and security-focused description', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText('User Behavior')).toBeInTheDocument();
     expect(screen.getByText(/Security-focused behavioral analysis/)).toBeInTheDocument();
   });
 
   it('shows context banner explaining the page purpose', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText(/What this page shows:/)).toBeInTheDocument();
     expect(screen.getByText(/different from Developer Activity/)).toBeInTheDocument();
   });
 
   it('displays risk summary metrics after loading', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByTestId('users-with-signals')).toHaveTextContent('12');
     expect(screen.getByTestId('high-risk-count')).toHaveTextContent('2');
     expect(screen.getByTestId('medium-risk-count')).toHaveTextContent('4');
@@ -160,7 +167,7 @@ describe('UserBehaviorPage', () => {
   });
 
   it('shows risk categories breakdown', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText('Top Risk Categories')).toBeInTheDocument();
     expect(screen.getByText('Security Bypasses')).toBeInTheDocument();
     expect(screen.getByText('Permission Changes')).toBeInTheDocument();
@@ -168,38 +175,38 @@ describe('UserBehaviorPage', () => {
   });
 
   it('shows helpful context for metric thresholds', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText(/Score ≥ 15 — investigate promptly/)).toBeInTheDocument();
     expect(screen.getByText(/Score 7–14 — worth monitoring/)).toBeInTheDocument();
   });
 
   it('renders risky users table with data', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText('risky-admin')).toBeInTheDocument();
     expect(screen.getByText('moderate-user')).toBeInTheDocument();
   });
 
   it('shows risk level labels in user table', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText('high')).toBeInTheDocument();
     expect(screen.getByText('medium')).toBeInTheDocument();
   });
 
   it('shows signal tags in risky users table', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByText(/Branch protection removed/)).toBeInTheDocument();
     expect(screen.getByText(/PAT created/)).toBeInTheDocument();
   });
 
   it('has time range filter', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     const select = await screen.findByLabelText(/Time range/i);
     expect(select).toBeInTheDocument();
     expect(select).toHaveValue('30');
   });
 
   it('has risk level filter on risky users tab', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     const select = await screen.findByLabelText(/Risk level/i);
     expect(select).toBeInTheDocument();
     expect(select).toHaveValue('');
@@ -207,7 +214,7 @@ describe('UserBehaviorPage', () => {
 
   it('switches to anomaly detection tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const anomalyTab = await screen.findByRole('tab', { name: /Anomaly Detection/i });
     await user.click(anomalyTab);
@@ -221,7 +228,7 @@ describe('UserBehaviorPage', () => {
 
   it('switches to permission drift tab', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const permTab = await screen.findByRole('tab', { name: /Permission Drift/i });
     await user.click(permTab);
@@ -234,7 +241,7 @@ describe('UserBehaviorPage', () => {
   });
 
   it('renders tab descriptions explaining what each tab shows', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(
       await screen.findByText(/Users ranked by risk score based on security-sensitive actions/),
     ).toBeInTheDocument();
@@ -242,7 +249,7 @@ describe('UserBehaviorPage', () => {
 
   it('time range filter updates the lookback period', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const select = await screen.findByLabelText(/Time range/i);
     await user.selectOptions(select, '7');
@@ -250,7 +257,7 @@ describe('UserBehaviorPage', () => {
   });
 
   it('shows three navigation tabs', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
     expect(await screen.findByRole('tab', { name: /Risky Users/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Anomaly Detection/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /Permission Drift/i })).toBeInTheDocument();
@@ -260,7 +267,7 @@ describe('UserBehaviorPage', () => {
 
   it('clicking high risk chip filters to high risk and shows filter banner', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     // Wait for metrics to load
     await screen.findByTestId('high-risk-count');
@@ -280,7 +287,7 @@ describe('UserBehaviorPage', () => {
 
   it('clicking a risk chip again deselects it and clears filter', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     await screen.findByTestId('high-risk-count');
 
@@ -295,7 +302,7 @@ describe('UserBehaviorPage', () => {
 
   it('clear filter button removes chip filter', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     await screen.findByTestId('high-risk-count');
 
@@ -310,7 +317,7 @@ describe('UserBehaviorPage', () => {
 
   it('clicking a category card shows filter banner with category name', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     await screen.findByText('Security Bypasses');
 
@@ -324,7 +331,7 @@ describe('UserBehaviorPage', () => {
   // ─── Column Filters ─────────────────────────────────────────────────────────
 
   it('risky users table has filterable Level and Orgs columns', async () => {
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     await screen.findByText('risky-admin');
 
@@ -339,7 +346,7 @@ describe('UserBehaviorPage', () => {
 
   it('anomaly table has filterable Activity Multiplier column', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const anomalyTab = await screen.findByRole('tab', { name: /Anomaly Detection/i });
     await user.click(anomalyTab);
@@ -354,7 +361,7 @@ describe('UserBehaviorPage', () => {
 
   it('permission drift table has filterable Status and Admin % columns', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const permTab = await screen.findByRole('tab', { name: /Permission Drift/i });
     await user.click(permTab);
@@ -371,7 +378,7 @@ describe('UserBehaviorPage', () => {
 
   it('clicking a risky user row opens the detail drawer', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const row = await screen.findByText('risky-admin');
     await user.click(row);
@@ -389,7 +396,7 @@ describe('UserBehaviorPage', () => {
 
   it('clicking an anomaly row opens the detail drawer with activity comparison', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const anomalyTab = await screen.findByRole('tab', { name: /Anomaly Detection/i });
     await user.click(anomalyTab);
@@ -406,7 +413,7 @@ describe('UserBehaviorPage', () => {
 
   it('clicking a permission drift row opens the detail drawer with status', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const permTab = await screen.findByRole('tab', { name: /Permission Drift/i });
     await user.click(permTab);
@@ -422,7 +429,7 @@ describe('UserBehaviorPage', () => {
 
   it('drawer can be closed by clicking the close button', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const row = await screen.findByText('risky-admin');
     await user.click(row);
@@ -440,7 +447,7 @@ describe('UserBehaviorPage', () => {
 
   it('drawer shows GitHub link with correct URL', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UserBehaviorPage />);
+    renderPage();
 
     const row = await screen.findByText('risky-admin');
     await user.click(row);

--- a/frontend/src/pages/UserBehavior/index.tsx
+++ b/frontend/src/pages/UserBehavior/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import {
   getRiskSummary,
   getRiskyUsers,
@@ -51,7 +51,7 @@ const PAGE_SIZE = 50;
 export function UserBehaviorPage() {
   const [lookbackDays, setLookbackDays] = useState(30);
   const [riskFilter, setRiskFilter] = useState<string>('');
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'risky-users');
+  const [activeTab, setActiveTab] = useTabParam('/user-behavior', TAB_KEYS, 'risky-users');
   const [page, setPage] = useState(1);
   const [selectedRow, setSelectedRow] = useState<SelectedRow | null>(null);
   const [activeChip, setActiveChip] = useState<string | null>(null);

--- a/frontend/src/pages/Users/Users.test.tsx
+++ b/frontend/src/pages/Users/Users.test.tsx
@@ -113,9 +113,16 @@ vi.mock('../../api/roles', () => ({
   }),
 }));
 
+function renderPage(route = '/users/users') {
+  return renderWithProviders(<UsersPage />, {
+    route,
+    routePath: '/users/:tab',
+  });
+}
+
 describe('UsersPage', () => {
   it('renders page title and guidance banner', () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     expect(screen.getByRole('heading', { level: 1, name: /users & roles/i })).toBeInTheDocument();
     expect(
@@ -127,7 +134,7 @@ describe('UsersPage', () => {
   });
 
   it('renders Members and Roles tabs but not Teams', () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     expect(screen.getByRole('button', { name: 'Members' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Roles' })).toBeInTheDocument();
@@ -135,7 +142,7 @@ describe('UsersPage', () => {
   });
 
   it('renders team mappings section', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     expect(screen.getByRole('heading', { level: 2, name: /team mappings/i })).toBeInTheDocument();
 
@@ -144,7 +151,7 @@ describe('UsersPage', () => {
   });
 
   it('renders active users section from API data', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     expect(screen.getByRole('heading', { level: 2, name: /active users/i })).toBeInTheDocument();
 
@@ -158,7 +165,7 @@ describe('UsersPage', () => {
   });
 
   it('displays correct role labels for active sessions', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for sessions to load
     await screen.findByText('@mwestphal');
@@ -175,7 +182,7 @@ describe('UsersPage', () => {
   });
 
   it('team mapping shows correct role name from backend', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for team mapping data to load - the role_name "sys_admin" maps to "Sys Admin"
     await screen.findByText('@security-team');
@@ -188,7 +195,7 @@ describe('UsersPage', () => {
   });
 
   it('active user logins are clickable with clickableMention class', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for sessions to load (use unique login to avoid multi-match)
     await screen.findByText('@mwestphal');
@@ -202,7 +209,7 @@ describe('UsersPage', () => {
   });
 
   it('session counts are clickable with clickableSession class', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for sessions to load
     await screen.findByText('@mwestphal');
@@ -213,7 +220,7 @@ describe('UsersPage', () => {
 
   it('clicking session count opens session detail modal', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for sessions to load
     await screen.findByText('@mwestphal');
@@ -226,7 +233,7 @@ describe('UsersPage', () => {
 
   it('session modal shows user info and note about API integration', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for sessions to load
     await screen.findByText('@mwestphal');
@@ -245,7 +252,7 @@ describe('UsersPage', () => {
 
   it('session modal shows correct role display name', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for sessions to load
     await screen.findByText('@mwestphal');
@@ -261,7 +268,7 @@ describe('UsersPage', () => {
   });
 
   it('granted-by mentions are clickable with clickableMention class', async () => {
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Wait for the team mapping data to load
     await screen.findByText('@security-team');
@@ -279,7 +286,7 @@ describe('UsersPage', () => {
     const { getActiveSessions } = await import('../../api/admin');
     vi.mocked(getActiveSessions).mockResolvedValueOnce([]);
 
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     expect(await screen.findByText('No active sessions in the last 24 hours')).toBeInTheDocument();
   });
@@ -302,7 +309,7 @@ describe('UsersPage', () => {
       },
     ]);
 
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Should show @individual-user, not @org/individual-user
     expect(await screen.findByText('@individual-user')).toBeInTheDocument();
@@ -310,7 +317,7 @@ describe('UsersPage', () => {
 
   it('roles tab shows permission picker when creating a role', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     // Switch to Roles tab
     await user.click(screen.getByRole('button', { name: 'Roles' }));
@@ -328,7 +335,7 @@ describe('UsersPage', () => {
 
   it('permission picker allows selecting individual permissions', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     await user.click(screen.getByRole('button', { name: 'Roles' }));
     await user.click(await screen.findByRole('button', { name: 'Create role' }));
@@ -347,7 +354,7 @@ describe('UsersPage', () => {
 
   it('permission picker filter narrows displayed permissions', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<UsersPage />);
+    renderPage();
 
     await user.click(screen.getByRole('button', { name: 'Roles' }));
     await user.click(await screen.findByRole('button', { name: 'Create role' }));

--- a/frontend/src/pages/Users/index.tsx
+++ b/frontend/src/pages/Users/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEnumQueryParam } from '../../hooks/useQueryParam';
+import { useTabParam } from '../../hooks/useTabParam';
 import {
   listRoleAssignments,
   createRoleAssignment,
@@ -832,7 +832,7 @@ export function UsersPage() {
   const qc = useQueryClient();
   const navigate = useNavigate();
   const { showToast } = useToast();
-  const [activeTab, setActiveTab] = useEnumQueryParam('tab', TAB_KEYS, 'users');
+  const [activeTab, setActiveTab] = useTabParam('/users', TAB_KEYS, 'users');
   const [showAdd, setShowAdd] = useState(false);
   const [editTarget, setEditTarget] = useState<RoleAssignment | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<RoleAssignment | null>(null);

--- a/frontend/src/pages/Workflows/Workflows.test.tsx
+++ b/frontend/src/pages/Workflows/Workflows.test.tsx
@@ -91,6 +91,13 @@ const SCAN_STATUS_RESPONSE = {
 
 /* ── Tests ─────────────────────────────────────────────────────────── */
 
+function renderPage(route = '/workflows/findings') {
+  return renderWithProviders(<WorkflowsPage />, {
+    route,
+    routePath: '/workflows/:tab',
+  });
+}
+
 describe('WorkflowsPage — Findings Tab', () => {
   beforeEach(() => {
     mockListFindings.mockClear();
@@ -102,41 +109,41 @@ describe('WorkflowsPage — Findings Tab', () => {
   });
 
   it('renders page title', async () => {
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText('Workflow Security Scanner')).toBeInTheDocument();
   });
 
   it('renders finding titles', async () => {
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText('Unpinned third-party action')).toBeInTheDocument();
     expect(await screen.findByText('Script injection risk')).toBeInTheDocument();
   });
 
   it('shows severity labels', async () => {
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText('high')).toBeInTheDocument();
     expect(await screen.findByText('critical')).toBeInTheDocument();
   });
 
   it('shows repo paths', async () => {
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText('myorg/myrepo')).toBeInTheDocument();
     expect(await screen.findByText('myorg/other-repo')).toBeInTheDocument();
   });
 
   it('renders empty state when no findings', async () => {
     mockListFindings.mockResolvedValue({ findings: [], total: 0 });
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText('No workflow findings yet')).toBeInTheDocument();
   });
 
   it('renders severity filter dropdown', async () => {
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByDisplayValue('All severities')).toBeInTheDocument();
   });
 
   it('renders status filter dropdown', async () => {
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByDisplayValue('All statuses')).toBeInTheDocument();
   });
 });
@@ -153,7 +160,7 @@ describe('WorkflowsPage — Scores Tab', () => {
 
   it('switches to scores tab and shows repo scores', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     const scoresTab = await screen.findByRole('button', { name: 'Repo Scores' });
     await user.click(scoresTab);
     expect(await screen.findByText('myorg/myrepo')).toBeInTheDocument();
@@ -162,7 +169,7 @@ describe('WorkflowsPage — Scores Tab', () => {
 
   it('shows score values', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     await user.click(await screen.findByRole('button', { name: 'Repo Scores' }));
     expect(await screen.findByText('65')).toBeInTheDocument();
     expect(await screen.findByText('95')).toBeInTheDocument();
@@ -170,7 +177,7 @@ describe('WorkflowsPage — Scores Tab', () => {
 
   it('shows finding counts on score cards', async () => {
     const user = userEvent.setup();
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     await user.click(await screen.findByRole('button', { name: 'Repo Scores' }));
     expect(await screen.findByText('3 findings')).toBeInTheDocument();
     expect(await screen.findByText('0 findings')).toBeInTheDocument();
@@ -187,7 +194,7 @@ describe('WorkflowsPage — Error Handling', () => {
 
   it('shows error banner on findings failure', async () => {
     mockListFindings.mockRejectedValue(new Error('Network error'));
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText('Failed to load findings')).toBeInTheDocument();
   });
 });
@@ -203,7 +210,7 @@ describe('WorkflowsPage — Scan Status', () => {
 
   it('displays scan status with last scan time', async () => {
     mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText(/3 repos/)).toBeInTheDocument();
     expect(await screen.findByText(/5 findings/)).toBeInTheDocument();
   });
@@ -214,7 +221,7 @@ describe('WorkflowsPage — Scan Status', () => {
       last_scan_at: null,
       last_scan_status: null,
     });
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(
       await screen.findByText('Awaiting first scan — data will appear automatically'),
     ).toBeInTheDocument();
@@ -222,7 +229,7 @@ describe('WorkflowsPage — Scan Status', () => {
 
   it('renders guidance box with automated scanning description', async () => {
     mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
-    renderWithProviders(<WorkflowsPage />);
+    renderPage();
     expect(await screen.findByText(/Fully automated/)).toBeInTheDocument();
     expect(await screen.findByText(/every 6 hours/)).toBeInTheDocument();
   });
@@ -230,7 +237,7 @@ describe('WorkflowsPage — Scan Status', () => {
   it('deep links to scores tab via ?tab=scores query param', async () => {
     mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
     mockGetScores.mockResolvedValue(SCORES_RESPONSE);
-    renderWithProviders(<WorkflowsPage />, { route: '/workflows?tab=scores' });
+    renderPage('/workflows/scores');
 
     expect(await screen.findByText('myorg/myrepo')).toBeInTheDocument();
   });
@@ -238,7 +245,7 @@ describe('WorkflowsPage — Scan Status', () => {
   it('deep links to a specific finding via ?finding= query param', async () => {
     mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
     mockListFindings.mockResolvedValue(FINDINGS_RESPONSE);
-    renderWithProviders(<WorkflowsPage />, { route: '/workflows?finding=1' });
+    renderPage('/workflows/findings?finding=1');
 
     // The detail panel should show the finding details (title appears in both table and panel)
     const titles = await screen.findAllByText('Unpinned third-party action');
@@ -249,7 +256,7 @@ describe('WorkflowsPage — Scan Status', () => {
   it('applies severity filter from URL query param', async () => {
     mockGetScanStatus.mockResolvedValue(SCAN_STATUS_RESPONSE);
     mockListFindings.mockResolvedValue(FINDINGS_RESPONSE);
-    renderWithProviders(<WorkflowsPage />, { route: '/workflows?severity=high' });
+    renderPage('/workflows/findings?severity=high');
 
     await screen.findByText('Unpinned third-party action');
     // The severity filter select should have the value from URL

--- a/frontend/src/pages/Workflows/index.tsx
+++ b/frontend/src/pages/Workflows/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useParams, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   listWorkflowFindings,
   getRepoSecurityScores,
@@ -111,13 +111,13 @@ function FindingDetailContent({ finding }: { finding: WorkflowFinding }) {
 }
 
 export function WorkflowsPage() {
+  const { tab: tabParam } = useParams<{ tab: string }>();
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Sync tab, severity, status, page, and selected finding with URL
-  const tabParam = searchParams.get('tab') ?? 'findings';
-  const tab: Tab = (['findings', 'scores', 'activity', 'rules'] as Tab[]).includes(tabParam as Tab)
-    ? (tabParam as Tab)
-    : 'findings';
+  // Tab from path param, remaining filters from query params
+  const TAB_VALUES: Tab[] = ['findings', 'scores', 'activity', 'rules'];
+  const tab: Tab = TAB_VALUES.includes(tabParam as Tab) ? (tabParam as Tab) : 'findings';
   const sevFilter = searchParams.get('severity') ?? '';
   const statusFilter = searchParams.get('status') ?? '';
   const findingIdParam = searchParams.get('finding');
@@ -127,22 +127,8 @@ export function WorkflowsPage() {
   const [selectedFinding, setSelectedFinding] = useState<WorkflowFinding | null>(null);
 
   function setTab(newTab: Tab) {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        if (newTab === 'findings') {
-          next.delete('tab');
-        } else {
-          next.set('tab', newTab);
-        }
-        // Clear finding selection and pagination when switching tabs
-        next.delete('finding');
-        next.delete('page');
-        next.delete('spage');
-        return next;
-      },
-      { replace: true },
-    );
+    // Navigate to new tab path, clear pagination and finding selection
+    navigate(`/workflows/${newTab}`, { replace: true });
     setSelectedFinding(null);
   }
 


### PR DESCRIPTION
## Summary

Standardizes all tabbed pages to use path-based routing (`/page/:tab`) instead of the previous mix of query-param (`?tab=X`) and local-state patterns. This enables proper deep-linking, browser back/forward navigation, and establishes a single consistent pattern across the app.

## Changes

### New utilities
- **`useTabParam` hook** — Validates path-based tab params, preserves query params during navigation, accepts absolute base path for reliability
- **`LegacyTabRedirect` component** — Handles backward-compatible redirects from old `?tab=X` URLs to new path-based URLs

### Pages migrated (11 total)
| Page | Old Pattern | New URL |
|------|-------------|---------|
| Reports | `?tab=templates` | `/reports/templates` |
| Compliance | `?tab=overview` | `/compliance/overview` |
| Users | `?tab=users` | `/users/users` |
| Packages | `?tab=overview` | `/packages/overview` |
| SupplyChain | `?tab=risks` | `/supply-chain/risks` |
| UserBehavior | `?tab=risky-users` | `/user-behavior/risky-users` |
| ThreatIntel | `?tab=feeds` | `/threat-intel/feeds` |
| Telemetry | `?tab=streams` | `/monitoring/telemetry/streams` |
| Workflows | `?tab=findings` | `/workflows/findings` |
| Notifications | local state | `/notifications/alerts` |
| Profile | local state | `/profile/preferences` |

### ThreatIntel route restructure
- Old: `/threat-intel/:feedId` (conflicted with potential `:tab` param)
- New: `/threat-intel/:tab` for tabs + `/threat-intel/feeds/:feedId` for feed detail

### All tests updated
- 27 files changed, 139 test files pass
- ESLint, TypeScript, and full build all pass

Closes #309