### PR TITLE
fix: replace hardcoded colors with theme-aware CSS variables

### DIFF
--- a/frontend/src/pages/Copilot/AdoptionPane.tsx
+++ b/frontend/src/pages/Copilot/AdoptionPane.tsx
@@ -158,7 +158,7 @@ export function AdoptionPane() {
             fontSize: 11,
             fontWeight: 600,
             background: u.tier_color,
-            color: '#fff',
+            color: 'var(--fg-on-emphasis)',
           }}
         >
           {u.tier}
@@ -394,7 +394,7 @@ export function AdoptionPane() {
                         fontSize: 11,
                         fontWeight: 600,
                         background: drawerUser.tier_color,
-                        color: '#fff',
+                        color: 'var(--fg-on-emphasis)',
                         marginTop: 4,
                       }}
                     >

--- a/frontend/src/pages/Settings/Settings.module.css
+++ b/frontend/src/pages/Settings/Settings.module.css
@@ -886,7 +886,7 @@
 
 .syncWizardStepActive {
   background: var(--accent);
-  color: #fff;
+  color: var(--fg-on-emphasis);
 }
 
 .syncWizardStepDone {
@@ -918,7 +918,7 @@
 
 .syncWizardStepDone .syncWizardStepNumber {
   background: var(--accent);
-  color: #fff;
+  color: var(--fg-on-emphasis);
 }
 
 .syncWizardStepLabel {


### PR DESCRIPTION
Replace hardcoded white (`#fff`) color values with `var(--fg-on-emphasis)` to ensure proper contrast in both light and dark themes.

**Changes:**
- `Settings.module.css`: sync wizard step badges (lines 889, 921)
- `Copilot/AdoptionPane.tsx`: tier badges in table and drawer (lines 161, 397)

These were the only non-adaptive color literals found in the UI components (chart data-series colors are intentionally branded and excluded).

Closes #288