### PR TITLE
feat: optimize GitHub sync with concurrent fetches and streaming

### DIFF
--- a/backend/app/workers/github_sync_worker.py
+++ b/backend/app/workers/github_sync_worker.py
@@ -2149,12 +2149,14 @@ async def _fetch_page(
 
         # Filter repos eligible for protection check
         eligible_repos = []
+        hit_delta_cutoff = False
         for repo in repos:
             if repo.get("archived"):
                 continue
             if delta_since is not None:
                 pushed_at = repo.get("pushed_at") or ""
                 if pushed_at < delta_since.isoformat():
+                    hit_delta_cutoff = True
                     break
             eligible_repos.append(repo)
 
@@ -2162,7 +2164,11 @@ async def _fetch_page(
         results = await asyncio.gather(*[_fetch_protection(r) for r in eligible_repos])
         items = [r for r in results if r is not None]
 
-        next_cursor = str(page + 1) if _has_next_page(resp.headers) else None
+        # Don't paginate if we hit the delta cutoff — remaining pages are older
+        if hit_delta_cutoff:
+            next_cursor = None
+        else:
+            next_cursor = str(page + 1) if _has_next_page(resp.headers) else None
         return items, next_cursor
 
     # ── Repo commits (iterate repos, fetch recent commits per repo) ───────

--- a/backend/app/workers/github_sync_worker.py
+++ b/backend/app/workers/github_sync_worker.py
@@ -683,31 +683,40 @@ async def _run_post_sync_pipeline_async(run_id: str) -> dict[str, object]:
                     f"Promoted {new_count} new org installation(s) into app configs",
                 )
 
-        # Query event IDs from the last 30 days
+        # Stream event IDs in chunks to avoid loading all into memory
         cutoff = datetime.now(UTC) - timedelta(days=30)
-        async with sf() as session:
-            result = await session.execute(
-                select(AuditEvent.id).where(AuditEvent.created_at >= cutoff).order_by(AuditEvent.id)
-            )
-            event_ids: list[int] = [row[0] for row in result.fetchall()]
-
-        # Batch event IDs and dispatch detection pipeline tasks
         from app.workers.detection_worker import run_detection_pipeline_task
 
         batch_size = 500
         detection_batches = 0
-        for i in range(0, len(event_ids), batch_size):
-            batch = event_ids[i : i + batch_size]
-            run_detection_pipeline_task.apply_async(
-                args=[batch],
-                queue="detection",
+        total_events = 0
+        async with sf() as session:
+            result = await session.stream(
+                select(AuditEvent.id).where(AuditEvent.created_at >= cutoff).order_by(AuditEvent.id)
             )
-            detection_batches += 1
+            batch: list[int] = []
+            async for row in result:
+                batch.append(row[0])
+                if len(batch) >= batch_size:
+                    run_detection_pipeline_task.apply_async(
+                        args=[batch],
+                        queue="detection",
+                    )
+                    detection_batches += 1
+                    total_events += len(batch)
+                    batch = []
+            if batch:
+                run_detection_pipeline_task.apply_async(
+                    args=[batch],
+                    queue="detection",
+                )
+                detection_batches += 1
+                total_events += len(batch)
 
         await _write_sync_log(
             sf,
             run_id,
-            f"Dispatched {detection_batches} detection batches for {len(event_ids)} events",
+            f"Dispatched {detection_batches} detection batches for {total_events} events",
         )
 
         # Dispatch rolling baseline computation
@@ -743,7 +752,7 @@ async def _run_post_sync_pipeline_async(run_id: str) -> dict[str, object]:
         logger.info(
             "github_sync.post_sync_pipeline_completed",
             run_id=run_id,
-            event_count=len(event_ids),
+            event_count=total_events,
             detection_batches=detection_batches,
         )
         await _write_sync_log(
@@ -754,7 +763,7 @@ async def _run_post_sync_pipeline_async(run_id: str) -> dict[str, object]:
 
         return {
             "status": "completed",
-            "event_count": len(event_ids),
+            "event_count": total_events,
             "detection_batches": detection_batches,
             "posture_findings": posture_count,
         }
@@ -2099,33 +2108,29 @@ async def _fetch_page(
             return [], None
 
         items = []
-        for repo in repos:
-            if repo.get("archived"):
-                continue
-            # Delta optimisation: skip repos not pushed since the cutoff
-            if delta_since is not None:
-                pushed_at = repo.get("pushed_at") or ""
-                if pushed_at < delta_since.isoformat():
-                    # All remaining repos are older — stop early
-                    return items, None
-            branch = repo.get("default_branch") or "main"
-            prot_url = f"{_GITHUB_API_BASE}/repos/{org}/{repo['name']}/branches/{branch}/protection"
-            prot_resp = await _github_get(
-                prot_url,
-                headers,
-                {},
-                rate_limiter,
-                etag_cache=etag_cache,
-                api_counter=api_counter,
-                entity_type=entity_type,
-            )
-            if prot_resp.status_code == 200:
-                prot = prot_resp.json()
-                pr_reviews = prot.get("required_pull_request_reviews") or {}
-                status_checks = prot.get("required_status_checks")
-                enforce = prot.get("enforce_admins") or {}
-                items.append(
-                    {
+        sem = asyncio.Semaphore(10)
+
+        async def _fetch_protection(repo: dict) -> dict | None:
+            async with sem:
+                branch = repo.get("default_branch") or "main"
+                prot_url = (
+                    f"{_GITHUB_API_BASE}/repos/{org}/{repo['name']}/branches/{branch}/protection"
+                )
+                prot_resp = await _github_get(
+                    prot_url,
+                    headers,
+                    {},
+                    rate_limiter,
+                    etag_cache=etag_cache,
+                    api_counter=api_counter,
+                    entity_type=entity_type,
+                )
+                if prot_resp.status_code == 200:
+                    prot = prot_resp.json()
+                    pr_reviews = prot.get("required_pull_request_reviews") or {}
+                    status_checks = prot.get("required_status_checks")
+                    enforce = prot.get("enforce_admins") or {}
+                    return {
                         "_repo_name": repo["name"],
                         "_branch": branch,
                         "required_reviews": pr_reviews.get("required_approving_review_count", 0),
@@ -2139,13 +2144,23 @@ async def _fetch_page(
                         ),
                         "enforce_admins": enforce.get("enabled", False),
                     }
-                )
-            elif prot_resp.status_code == 404:
-                # No branch protection — don't create a record.
-                # The posture rule "missing_protection" detects repos
-                # that have no corresponding row in repo_branch_protections.
-                pass
-            # 403 (no permission) — skip silently
+                # 404 (no protection) or 403 (no permission) — skip
+                return None
+
+        # Filter repos eligible for protection check
+        eligible_repos = []
+        for repo in repos:
+            if repo.get("archived"):
+                continue
+            if delta_since is not None:
+                pushed_at = repo.get("pushed_at") or ""
+                if pushed_at < delta_since.isoformat():
+                    break
+            eligible_repos.append(repo)
+
+        # Fetch protections concurrently (bounded by semaphore)
+        results = await asyncio.gather(*[_fetch_protection(r) for r in eligible_repos])
+        items = [r for r in results if r is not None]
 
         next_cursor = str(page + 1) if _has_next_page(resp.headers) else None
         return items, next_cursor

--- a/backend/tests/test_post_sync_pipeline.py
+++ b/backend/tests/test_post_sync_pipeline.py
@@ -272,22 +272,25 @@ class TestRunPostSyncPipeline:
         # Mock session
         mock_session = AsyncMock()
 
-        # First call: update status to running (execute + commit)
-        # Second call: query events (execute returns rows)
-        # Third call: update status to completed (execute + commit)
+        # Events returned by streaming query
         event_rows = [(i,) for i in range(1, 1201)]  # 1200 events
-        call_count = 0
 
-        async def mock_execute(*args: object, **kwargs: object) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            result = MagicMock()
-            if call_count == 3:
-                # Event query (after status update + _write_sync_log)
-                result.fetchall.return_value = event_rows
-            return result
+        # Mock session.stream() to return an async iterator over event rows
+        class _AsyncRowIter:
+            def __init__(self, rows: list[tuple[int]]) -> None:
+                self._iter = iter(rows)
 
-        mock_session.execute = AsyncMock(side_effect=mock_execute)
+            def __aiter__(self) -> _AsyncRowIter:
+                return self
+
+            async def __anext__(self) -> tuple[int]:
+                try:
+                    return next(self._iter)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+
+        mock_session.stream = AsyncMock(return_value=_AsyncRowIter(event_rows))
+        mock_session.execute = AsyncMock(return_value=MagicMock())
         mock_session.commit = AsyncMock()
 
         # Make session factory return our mock
@@ -434,17 +437,22 @@ class TestRunPostSyncPipeline:
 
         mock_session = AsyncMock()
         event_rows = [(i,) for i in range(1, 501)]  # Exactly 500 events
-        call_count = 0
 
-        async def mock_execute(*args: object, **kwargs: object) -> MagicMock:
-            nonlocal call_count
-            call_count += 1
-            result = MagicMock()
-            if call_count == 3:
-                result.fetchall.return_value = event_rows
-            return result
+        class _AsyncRowIter:
+            def __init__(self, rows: list[tuple[int]]) -> None:
+                self._iter = iter(rows)
 
-        mock_session.execute = AsyncMock(side_effect=mock_execute)
+            def __aiter__(self) -> _AsyncRowIter:
+                return self
+
+            async def __anext__(self) -> tuple[int]:
+                try:
+                    return next(self._iter)
+                except StopIteration:
+                    raise StopAsyncIteration from None
+
+        mock_session.stream = AsyncMock(return_value=_AsyncRowIter(event_rows))
+        mock_session.execute = AsyncMock(return_value=MagicMock())
         mock_session.commit = AsyncMock()
 
         mock_ctx = AsyncMock()


### PR DESCRIPTION
Two key performance improvements to the sync pipeline:

### 1. Parallel branch protection fetches
Previously, branch protection checks were sequential (one API call per repo). Now uses `asyncio.gather` with a semaphore (max 10 concurrent requests) to parallelize these calls.

**Impact:** For orgs with 100+ repos, branch protection sync time reduces by ~10x.

### 2. Streaming event dispatch in post-sync pipeline
Previously loaded ALL event IDs from the last 30 days into memory before dispatching detection batches. Now uses `session.stream()` to process rows as they arrive, dispatching batches incrementally.

**Impact:** Reduces peak memory usage proportional to event volume. Critical for large deployments (30-70K users, 200K+ events per month, 12-18 months retention).

### What was already good (unchanged)
- Incremental sync via `delta_since` timestamps ✓
- ETag/Last-Modified caching via Valkey ✓
- Rate limit handling with backoff ✓
- Cursor-based pagination ✓

Closes #319