### PR TITLE
fix: color scheme fixes for posture gauge and supply chain badges

### DIFF
--- a/frontend/src/components/charts/RadialGauge.tsx
+++ b/frontend/src/components/charts/RadialGauge.tsx
@@ -28,9 +28,9 @@ export function RadialGauge({ value, label, color, size = 140 }: RadialGaugeProp
     color ??
     (clampedValue < 50
       ? 'var(--danger)'
-      : clampedValue < 75
+      : clampedValue < 80
         ? 'var(--attention)'
-        : 'var(--accent)');
+        : 'var(--success)');
 
   const cx = size / 2;
   const cy = size / 2;

--- a/frontend/src/pages/SupplyChain/SupplyChain.module.css
+++ b/frontend/src/pages/SupplyChain/SupplyChain.module.css
@@ -101,27 +101,27 @@
 }
 
 .critical {
-  background: var(--danger-subtle, #2d0d10);
-  color: var(--danger-fg, #f85149);
+  background: var(--danger-subtle);
+  color: var(--danger-fg);
 }
 
 .high {
-  background: var(--attention-subtle, #2d1d00);
-  color: var(--attention-fg, #d29922);
+  background: var(--attention-subtle);
+  color: var(--attention-fg);
 }
 
 .medium {
-  background: var(--accent-subtle, #0d1d2d);
+  background: var(--accent-subtle);
   color: var(--accent);
 }
 
 .low {
-  background: var(--success-subtle, #0d2d1d);
-  color: var(--success-fg, #3fb950);
+  background: var(--success-subtle);
+  color: var(--success-fg);
 }
 
 .none {
-  background: var(--neutral-subtle, #1d1d1d);
+  background: var(--neutral-subtle);
   color: var(--fg-muted);
 }
 
@@ -244,7 +244,7 @@
 }
 
 .clickableRow:hover {
-  background-color: var(--bg-hover, rgba(0, 0, 0, 0.04));
+  background-color: var(--bg-hover);
 }
 
 .clickableRow:focus-visible {


### PR DESCRIPTION
## Changes

- **RadialGauge** (#283): Use `--success` (green) for scores >= 80 instead of `--accent` (blue), matching the `scoreColor()` threshold pattern used elsewhere on the Posture page
- **SupplyChain severity badges** (#287): Remove dark-mode-only fallback hex values from CSS, rely on theme CSS variables directly
- Remove hardcoded `rgba(0,0,0,0.04)` hover fallback in supply chain clickable rows

Closes #283
Closes #287