### PR TITLE
feat: Feed Parser Registry with STIX 2.1, OpenSSF, and Custom JSON parsers

### DIFF
--- a/backend/app/routers/threat_intel.py
+++ b/backend/app/routers/threat_intel.py
@@ -144,6 +144,10 @@ async def create_feed(
         feed_type=body.feed_type,
         refresh_interval_minutes=body.refresh_interval_minutes,
         created_by=user.github_login,
+        parser_type=body.parser_type,
+        parser_config=body.parser_config,
+        auto_rule_generation=body.auto_rule_generation,
+        default_campaign_id=body.default_campaign_id,
     )
     return result
 

--- a/backend/app/schemas/threat_intel.py
+++ b/backend/app/schemas/threat_intel.py
@@ -82,7 +82,7 @@ class FeedCreate(BaseModel):
     )
     parser_type: str = Field(
         default="plaintext",
-        pattern=r"^(plaintext|custom_json|stix21|openssf_package_analysis|github_advisory|osv)$",
+        pattern=r"^(plaintext|custom_json|stix21|openssf_package_analysis)$",
         description="Feed parser format",
     )
     parser_config: dict[str, Any] | None = Field(
@@ -134,6 +134,13 @@ class FeedUpdate(BaseModel):
     feed_type: str | None = Field(default=None, pattern=r"^(domain|ip)$")
     refresh_interval_minutes: int | None = Field(default=None, ge=15, le=43200)
     enabled: bool | None = None
+    parser_type: str | None = Field(
+        default=None,
+        pattern=r"^(plaintext|custom_json|stix21|openssf_package_analysis)$",
+    )
+    parser_config: dict[str, Any] | None = None
+    auto_rule_generation: bool | None = None
+    default_campaign_id: int | None = None
 
 
 class BulkIndicatorItem(BaseModel):

--- a/backend/app/services/feed_parsers/__init__.py
+++ b/backend/app/services/feed_parsers/__init__.py
@@ -1,0 +1,8 @@
+"""Feed parser registry for structured threat intelligence formats."""
+
+from __future__ import annotations
+
+from app.services.feed_parsers.base import NormalizedIndicator, ParseResult
+from app.services.feed_parsers.registry import get_parser
+
+__all__ = ["NormalizedIndicator", "ParseResult", "get_parser"]

--- a/backend/app/services/feed_parsers/base.py
+++ b/backend/app/services/feed_parsers/base.py
@@ -1,0 +1,44 @@
+"""Base types and protocol for feed parsers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Protocol
+
+
+@dataclass
+class NormalizedIndicator:
+    """Common shape for all parsed threat intelligence indicators."""
+
+    indicator_type: str
+    value: str
+    confidence: float = 0.7
+    severity: str = "medium"
+    campaign_name: str | None = None
+    campaign_description: str | None = None
+    source_reference: str | None = None
+    expires_at: datetime | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    suggested_action_filters: list[str] = field(default_factory=list)
+    external_id: str | None = None
+
+
+@dataclass
+class ParseResult:
+    """Result of parsing a feed, including warnings and skip counts."""
+
+    indicators: list[NormalizedIndicator] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    skipped_count: int = 0
+    campaign_name: str | None = None
+    campaign_description: str | None = None
+    campaign_severity: str | None = None
+    campaign_references: list[str] = field(default_factory=list)
+    campaign_mitre_attack: list[str] = field(default_factory=list)
+
+
+class FeedParser(Protocol):
+    """Protocol for all feed parsers."""
+
+    def parse(self, content: str, config: dict[str, Any]) -> ParseResult: ...

--- a/backend/app/services/feed_parsers/custom_json.py
+++ b/backend/app/services/feed_parsers/custom_json.py
@@ -1,0 +1,147 @@
+"""OctoWatch-native JSON feed parser with campaign and indicator support."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import structlog
+from pydantic import BaseModel, Field, ValidationError
+
+from app.services.feed_parsers.base import NormalizedIndicator, ParseResult
+
+logger = structlog.get_logger(__name__)
+
+
+# ─── Pydantic validation models for the custom JSON schema ────────────────────
+
+
+class CampaignInfo(BaseModel):
+    """Campaign metadata in a custom JSON feed."""
+
+    name: str = Field(..., min_length=1, max_length=255)
+    description: str | None = None
+    severity: str = Field(default="critical", pattern=r"^(critical|high|medium|low)$")
+    references: list[str] = Field(default_factory=list)
+    mitre_attack: list[str] = Field(default_factory=list)
+
+
+class IndicatorGroup(BaseModel):
+    """A group of indicators sharing the same type and context."""
+
+    type: str = Field(..., min_length=1)
+    values: list[str] = Field(..., min_length=1)
+    context: str | None = None
+    confidence: float = Field(default=0.80, ge=0.0, le=1.0)
+    severity: str = Field(default="medium", pattern=r"^(critical|high|medium|low)$")
+    expires_at: str | None = None
+
+
+class SuggestedRule(BaseModel):
+    """Rule suggestion embedded in a custom JSON feed."""
+
+    name: str
+    action_filters: list[str] = Field(default_factory=list)
+    match_field: str | None = None
+    indicator_types: list[str] = Field(default_factory=list)
+    severity: str = "critical"
+
+
+class CustomJSONFeed(BaseModel):
+    """Top-level schema for OctoWatch-native threat intel feeds."""
+
+    schema_version: str = "1.0"
+    campaign: CampaignInfo | None = None
+    indicators: list[IndicatorGroup]
+    suggested_rules: list[SuggestedRule] = Field(default_factory=list)
+
+
+# ─── Parser implementation ────────────────────────────────────────────────────
+
+
+class CustomJSONParser:
+    """Parse OctoWatch-native JSON threat intel feeds."""
+
+    def parse(self, content: str, config: dict[str, Any]) -> ParseResult:
+        import json
+
+        result = ParseResult()
+
+        try:
+            raw = json.loads(content)
+        except json.JSONDecodeError as exc:
+            result.warnings.append(f"Invalid JSON: {exc}")
+            return result
+
+        try:
+            feed = CustomJSONFeed.model_validate(raw)
+        except ValidationError as exc:
+            result.warnings.append(f"Schema validation failed: {exc.error_count()} errors")
+            for err in exc.errors()[:5]:
+                result.warnings.append(f"  {'.'.join(str(p) for p in err['loc'])}: {err['msg']}")
+            return result
+
+        # Extract campaign info
+        if feed.campaign:
+            result.campaign_name = feed.campaign.name
+            result.campaign_description = feed.campaign.description
+            result.campaign_severity = feed.campaign.severity
+            result.campaign_references = feed.campaign.references
+            result.campaign_mitre_attack = feed.campaign.mitre_attack
+
+        # Extract indicators
+        for group in feed.indicators:
+            expires_at = _parse_datetime(group.expires_at) if group.expires_at else None
+            action_filters = _action_filters_for_type(group.type, feed.suggested_rules)
+
+            for value in group.values:
+                value = value.strip()
+                if not value:
+                    result.skipped_count += 1
+                    continue
+
+                metadata: dict[str, Any] = {}
+                if group.context:
+                    metadata["context"] = group.context
+                if feed.campaign and feed.campaign.mitre_attack:
+                    metadata["mitre_attack"] = feed.campaign.mitre_attack
+
+                result.indicators.append(
+                    NormalizedIndicator(
+                        indicator_type=group.type,
+                        value=value,
+                        confidence=group.confidence,
+                        severity=group.severity,
+                        campaign_name=feed.campaign.name if feed.campaign else None,
+                        source_reference=(
+                            feed.campaign.references[0]
+                            if feed.campaign and feed.campaign.references
+                            else None
+                        ),
+                        expires_at=expires_at,
+                        metadata=metadata,
+                        suggested_action_filters=action_filters,
+                    )
+                )
+
+        return result
+
+
+def _parse_datetime(value: str) -> datetime | None:
+    """Try to parse an ISO 8601 datetime string."""
+    try:
+        dt = datetime.fromisoformat(value)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+    except (ValueError, TypeError):
+        return None
+
+
+def _action_filters_for_type(indicator_type: str, rules: list[SuggestedRule]) -> list[str]:
+    """Find action filters from suggested rules that match this indicator type."""
+    filters: list[str] = []
+    for rule in rules:
+        if indicator_type in rule.indicator_types:
+            filters.extend(rule.action_filters)
+    return list(dict.fromkeys(filters))  # dedupe preserving order

--- a/backend/app/services/feed_parsers/openssf.py
+++ b/backend/app/services/feed_parsers/openssf.py
@@ -1,0 +1,147 @@
+"""OpenSSF Package Analysis JSON output parser."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import structlog
+
+from app.services.feed_parsers.base import NormalizedIndicator, ParseResult
+
+logger = structlog.get_logger(__name__)
+
+# Map OpenSSF ecosystem names to canonical prefixes
+_ECOSYSTEM_MAP: dict[str, str] = {
+    "npm": "npm",
+    "pypi": "pypi",
+    "rubygems": "rubygems",
+    "crates.io": "crates",
+    "packagist": "packagist",
+    "nuget": "nuget",
+    "pub": "pub",
+}
+
+
+class OpenSSFParser:
+    """Parse OpenSSF Package Analysis JSON output.
+
+    Supports both single-result objects and arrays of results.
+    Each result should contain package info and analysis verdicts.
+    """
+
+    def parse(self, content: str, config: dict[str, Any]) -> ParseResult:
+        result = ParseResult()
+
+        try:
+            raw = json.loads(content)
+        except json.JSONDecodeError as exc:
+            result.warnings.append(f"Invalid JSON: {exc}")
+            return result
+
+        # Support both single object and array
+        items = raw if isinstance(raw, list) else [raw]
+
+        for item in items:
+            if not isinstance(item, dict):
+                result.skipped_count += 1
+                continue
+
+            try:
+                self._parse_item(item, result)
+            except Exception as exc:
+                result.skipped_count += 1
+                result.warnings.append(f"Failed to parse item: {exc}")
+
+        return result
+
+    def _parse_item(self, item: dict[str, Any], result: ParseResult) -> None:
+        """Parse a single Package Analysis result."""
+        package = item.get("package", {})
+        if not isinstance(package, dict):
+            result.skipped_count += 1
+            return
+
+        name = package.get("name", "")
+        ecosystem = package.get("ecosystem", "").lower()
+        version = package.get("version", "")
+
+        if not name:
+            result.skipped_count += 1
+            return
+
+        # Canonical package identifier: ecosystem:name
+        eco_prefix = _ECOSYSTEM_MAP.get(ecosystem, ecosystem)
+        canonical_value = f"{eco_prefix}:{name}" if eco_prefix else name
+
+        # Extract verdict / analysis results
+        analysis = item.get("analysis", item.get("result", {}))
+        if not isinstance(analysis, dict):
+            analysis = {}
+
+        verdict = analysis.get("verdict", item.get("verdict", ""))
+        is_malicious = _is_malicious_verdict(verdict, analysis)
+
+        if not is_malicious:
+            result.skipped_count += 1
+            return
+
+        # Build metadata
+        metadata: dict[str, Any] = {"ecosystem": ecosystem}
+        if version:
+            metadata["version"] = version
+        behaviors = analysis.get("behaviors", [])
+        if behaviors:
+            metadata["behaviors"] = behaviors[:20]
+        source_url = item.get("source_url") or item.get("url")
+        if source_url:
+            metadata["source_url"] = source_url
+
+        # Extract maintainer info as a separate indicator
+        maintainers = package.get("maintainers", [])
+        for maint in maintainers:
+            if isinstance(maint, dict):
+                email = maint.get("email")
+                if email:
+                    result.indicators.append(
+                        NormalizedIndicator(
+                            indicator_type="commit_author_email",
+                            value=email,
+                            confidence=0.5,
+                            severity="medium",
+                            metadata={
+                                "context": f"Maintainer of malicious package {canonical_value}",
+                            },
+                        )
+                    )
+
+        result.indicators.append(
+            NormalizedIndicator(
+                indicator_type="package_name",
+                value=canonical_value,
+                confidence=0.90,
+                severity="high",
+                source_reference=metadata.get("source_url"),
+                metadata=metadata,
+                suggested_action_filters=["packages.package_created", "packages.package_published"],
+                external_id=f"{canonical_value}@{version}" if version else None,
+            )
+        )
+
+
+def _is_malicious_verdict(
+    verdict: str | Any,
+    analysis: dict[str, Any],
+) -> bool:
+    """Determine if the analysis verdict indicates a malicious package."""
+    if isinstance(verdict, str) and verdict:
+        return verdict.lower() in ("malicious", "suspicious", "harmful")
+
+    # Some formats use boolean verdicts
+    if isinstance(verdict, bool):
+        return verdict
+
+    # Fallback: check for specific malicious behavior flags
+    behaviors = analysis.get("behaviors", [])
+    malicious_behaviors = {"exfiltration", "code_execution", "network_access", "file_system_access"}
+    return bool(set(behaviors) & malicious_behaviors)

--- a/backend/app/services/feed_parsers/plaintext.py
+++ b/backend/app/services/feed_parsers/plaintext.py
@@ -1,0 +1,38 @@
+"""Plaintext line-based feed parser (backwards-compatible default)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.feed_parsers.base import NormalizedIndicator, ParseResult
+
+
+class PlaintextParser:
+    """Parse one-indicator-per-line feeds (domains, IPs, etc.)."""
+
+    def parse(self, content: str, config: dict[str, Any]) -> ParseResult:
+        result = ParseResult()
+        indicator_type = config.get("indicator_type", "domain")
+        confidence = config.get("confidence", 0.70)
+
+        for line in content.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or line.startswith("//"):
+                continue
+
+            # Support CSV: take first column
+            value = line.split(",")[0].strip() if "," in line else line
+            if not value:
+                result.skipped_count += 1
+                continue
+
+            result.indicators.append(
+                NormalizedIndicator(
+                    indicator_type=indicator_type,
+                    value=value,
+                    confidence=confidence,
+                    severity="medium",
+                )
+            )
+
+        return result

--- a/backend/app/services/feed_parsers/registry.py
+++ b/backend/app/services/feed_parsers/registry.py
@@ -1,0 +1,25 @@
+"""Parser registry — maps parser_type strings to parser implementations."""
+
+from __future__ import annotations
+
+from app.services.feed_parsers.base import FeedParser
+from app.services.feed_parsers.custom_json import CustomJSONParser
+from app.services.feed_parsers.openssf import OpenSSFParser
+from app.services.feed_parsers.plaintext import PlaintextParser
+from app.services.feed_parsers.stix21 import STIX21Parser
+
+PARSER_REGISTRY: dict[str, type[FeedParser]] = {
+    "plaintext": PlaintextParser,  # type: ignore[dict-item]
+    "custom_json": CustomJSONParser,  # type: ignore[dict-item]
+    "stix21": STIX21Parser,  # type: ignore[dict-item]
+    "openssf_package_analysis": OpenSSFParser,  # type: ignore[dict-item]
+}
+
+
+def get_parser(parser_type: str) -> FeedParser:
+    """Instantiate a parser for the given type. Raises ValueError for unknown types."""
+    cls = PARSER_REGISTRY.get(parser_type)
+    if cls is None:
+        supported = ", ".join(sorted(PARSER_REGISTRY.keys()))
+        raise ValueError(f"Unknown parser type: {parser_type!r}. Supported: {supported}")
+    return cls()  # type: ignore[return-value]

--- a/backend/app/services/feed_parsers/stix21.py
+++ b/backend/app/services/feed_parsers/stix21.py
@@ -1,0 +1,175 @@
+"""STIX 2.1 JSON bundle parser — extracts indicators from simple equality patterns."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import structlog
+
+from app.services.feed_parsers.base import NormalizedIndicator, ParseResult
+
+logger = structlog.get_logger(__name__)
+
+# Map STIX indicator pattern object types to our indicator types
+_STIX_TYPE_MAP: dict[str, str] = {
+    "domain-name": "domain",
+    "ipv4-addr": "ip",
+    "ipv6-addr": "ip",
+    "email-addr": "commit_author_email",
+    "user-account": "github_username",
+    "software": "package_name",
+    "url": "domain",
+}
+
+# Regex for simple STIX equality patterns: [type:property = 'value']
+_SIMPLE_PATTERN_RE = re.compile(r"\[\s*([a-z0-9\-]+):(\S+)\s*=\s*'([^']+)'\s*\]")
+
+
+class STIX21Parser:
+    """Parse STIX 2.1 JSON bundles, extracting indicators from simple equality patterns.
+
+    Only supports simple single-comparison patterns like:
+        [domain-name:value = 'evil.com']
+    Complex patterns with AND/OR/MATCHES are logged as skipped.
+    """
+
+    def parse(self, content: str, config: dict[str, Any]) -> ParseResult:
+        result = ParseResult()
+
+        try:
+            bundle = json.loads(content)
+        except json.JSONDecodeError as exc:
+            result.warnings.append(f"Invalid JSON: {exc}")
+            return result
+
+        if not isinstance(bundle, dict):
+            result.warnings.append("STIX bundle must be a JSON object")
+            return result
+
+        objects = bundle.get("objects", [])
+        if not isinstance(objects, list):
+            result.warnings.append("STIX bundle 'objects' must be an array")
+            return result
+
+        # Index campaigns and relationships for attribution
+        campaigns = _index_campaigns(objects)
+        relationships = _index_relationships(objects)
+
+        # Extract campaign info from first campaign SDO
+        if campaigns:
+            first_campaign = next(iter(campaigns.values()))
+            result.campaign_name = first_campaign.get("name")
+            result.campaign_description = first_campaign.get("description")
+            result.campaign_severity = _stix_severity(first_campaign.get("confidence"))
+
+        for obj in objects:
+            if not isinstance(obj, dict) or obj.get("type") != "indicator":
+                continue
+
+            pattern = obj.get("pattern", "")
+            stix_id = obj.get("id", "")
+            stix_confidence = obj.get("confidence")
+
+            # Only handle simple single-comparison patterns
+            match = _SIMPLE_PATTERN_RE.search(pattern)
+            if not match:
+                result.skipped_count += 1
+                result.warnings.append(f"Unsupported STIX pattern (skipped): {pattern[:120]}")
+                continue
+
+            stix_type = match.group(1)
+            value = match.group(3)
+
+            indicator_type = _STIX_TYPE_MAP.get(stix_type)
+            if not indicator_type:
+                result.skipped_count += 1
+                result.warnings.append(f"Unknown STIX object type '{stix_type}' (skipped)")
+                continue
+
+            # Resolve campaign attribution via relationships
+            campaign_name = _resolve_campaign(stix_id, relationships, campaigns)
+
+            metadata: dict[str, Any] = {"stix_id": stix_id}
+            labels = obj.get("labels", [])
+            if labels:
+                metadata["labels"] = labels
+            kill_chain = obj.get("kill_chain_phases", [])
+            if kill_chain:
+                metadata["kill_chain_phases"] = kill_chain
+
+            result.indicators.append(
+                NormalizedIndicator(
+                    indicator_type=indicator_type,
+                    value=value,
+                    confidence=_normalize_confidence(stix_confidence),
+                    severity=_stix_severity(stix_confidence),
+                    campaign_name=campaign_name or result.campaign_name,
+                    source_reference=obj.get("external_references", [{}])[0].get("url")
+                    if obj.get("external_references")
+                    else None,
+                    metadata=metadata,
+                    external_id=stix_id,
+                )
+            )
+
+        return result
+
+
+def _index_campaigns(objects: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Build a lookup of STIX campaign SDOs by id."""
+    return {
+        obj["id"]: obj for obj in objects if isinstance(obj, dict) and obj.get("type") == "campaign"
+    }
+
+
+def _index_relationships(
+    objects: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    """Build indicator_id → [campaign_id, ...] mapping from relationship SDOs."""
+    rels: dict[str, list[str]] = {}
+    for obj in objects:
+        if not isinstance(obj, dict) or obj.get("type") != "relationship":
+            continue
+        if obj.get("relationship_type") != "indicates":
+            continue
+        source = obj.get("source_ref", "")
+        target = obj.get("target_ref", "")
+        if source.startswith("indicator--") and target.startswith("campaign--"):
+            rels.setdefault(source, []).append(target)
+    return rels
+
+
+def _resolve_campaign(
+    indicator_id: str,
+    relationships: dict[str, list[str]],
+    campaigns: dict[str, dict[str, Any]],
+) -> str | None:
+    """Resolve campaign name for an indicator via relationship SDOs."""
+    campaign_ids = relationships.get(indicator_id, [])
+    for cid in campaign_ids:
+        campaign = campaigns.get(cid)
+        if campaign:
+            return campaign.get("name")
+    return None
+
+
+def _normalize_confidence(stix_confidence: int | None) -> float:
+    """Convert STIX confidence (0-100) to our scale (0.0-1.0)."""
+    if stix_confidence is None:
+        return 0.7
+    return max(0.0, min(1.0, stix_confidence / 100.0))
+
+
+def _stix_severity(stix_confidence: int | None) -> str:
+    """Map STIX confidence to severity level."""
+    if stix_confidence is None:
+        return "medium"
+    if stix_confidence >= 85:
+        return "critical"
+    if stix_confidence >= 65:
+        return "high"
+    if stix_confidence >= 40:
+        return "medium"
+    return "low"

--- a/backend/app/services/threat_intel_service.py
+++ b/backend/app/services/threat_intel_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 from fnmatch import fnmatch
 from typing import Any
 from urllib.parse import urlparse
@@ -297,7 +298,8 @@ async def get_feeds(
         text("""
             SELECT id, name, url, feed_type, enabled, refresh_interval_minutes,
                    last_fetched_at, last_fetch_status, last_indicator_count,
-                   created_by, created_at, updated_at, is_default
+                   created_by, created_at, updated_at, is_default,
+                   parser_type, parser_config, auto_rule_generation, default_campaign_id
             FROM threat_intel_feeds
             ORDER BY created_at DESC
         """)
@@ -313,17 +315,24 @@ async def create_feed(
     feed_type: str = "domain",
     refresh_interval_minutes: int = 1440,
     created_by: str,
+    parser_type: str = "plaintext",
+    parser_config: dict[str, Any] | None = None,
+    auto_rule_generation: bool = True,
+    default_campaign_id: int | None = None,
 ) -> dict[str, Any]:
     """Create a new threat intel feed configuration."""
     result = await session.execute(
         text("""
             INSERT INTO threat_intel_feeds
-                (name, url, feed_type, refresh_interval_minutes, created_by)
+                (name, url, feed_type, refresh_interval_minutes, created_by,
+                 parser_type, parser_config, auto_rule_generation, default_campaign_id)
             VALUES
-                (:name, :url, :feed_type, :refresh_interval_minutes, :created_by)
+                (:name, :url, :feed_type, :refresh_interval_minutes, :created_by,
+                 :parser_type, :parser_config, :auto_rule_generation, :default_campaign_id)
             RETURNING id, name, url, feed_type, enabled, refresh_interval_minutes,
                       last_fetched_at, last_fetch_status, last_indicator_count,
-                      created_by, created_at, updated_at, is_default
+                      created_by, created_at, updated_at, is_default,
+                      parser_type, parser_config, auto_rule_generation, default_campaign_id
         """),
         {
             "name": name,
@@ -331,6 +340,10 @@ async def create_feed(
             "feed_type": feed_type,
             "refresh_interval_minutes": refresh_interval_minutes,
             "created_by": created_by,
+            "parser_type": parser_type,
+            "parser_config": json.dumps(parser_config) if parser_config else None,
+            "auto_rule_generation": auto_rule_generation,
+            "default_campaign_id": default_campaign_id,
         },
     )
     row = result.mappings().fetchone()
@@ -344,56 +357,164 @@ async def fetch_feed_indicators(
     content: str,
     feed_type: str,
     added_by: str,
+    *,
+    parser_type: str = "plaintext",
+    parser_config: dict[str, Any] | None = None,
+    default_campaign_id: int | None = None,
 ) -> int:
-    """Parse feed content and upsert indicators. Returns count of indicators processed."""
-    lines = [ln.strip() for ln in content.splitlines() if ln.strip() and not ln.startswith("#")]
+    """Parse feed content using the appropriate parser and upsert indicators."""
+    from app.services.feed_parsers import get_parser
+
+    config = dict(parser_config or {})
+    # Plaintext parser needs indicator_type from feed_type
+    if parser_type == "plaintext" and "indicator_type" not in config:
+        config["indicator_type"] = feed_type if feed_type in ("domain", "ip") else "domain"
+
+    parser = get_parser(parser_type)
+    parse_result = parser.parse(content, config)
+
+    for warning in parse_result.warnings:
+        logger.warning("threat_intel.parse_warning", feed_id=feed_id, warning=warning)
+
+    # Upsert campaign if the parser extracted one
+    campaign_id = default_campaign_id
+    if parse_result.campaign_name:
+        campaign_id = await _upsert_campaign(
+            session,
+            feed_id=feed_id,
+            name=parse_result.campaign_name,
+            description=parse_result.campaign_description,
+            severity=parse_result.campaign_severity or "critical",
+            references=parse_result.campaign_references,
+            mitre_attack=parse_result.campaign_mitre_attack,
+        )
+
     count = 0
+    for ind in parse_result.indicators:
+        ind_campaign_id = campaign_id
+        # If the indicator specifies a different campaign, resolve it
+        if ind.campaign_name and ind.campaign_name != parse_result.campaign_name:
+            ind_campaign_id = await _upsert_campaign(
+                session,
+                feed_id=feed_id,
+                name=ind.campaign_name,
+            )
 
-    for line in lines:
-        # Skip comments and empty lines
-        if not line or line.startswith("//"):
-            continue
-
-        indicator_type = feed_type if feed_type in ("domain", "ip") else "domain"
-        value = line.split(",")[0].strip() if "," in line else line.strip()
-
-        if not value:
-            continue
+        metadata = ind.metadata or {}
+        if ind.suggested_action_filters:
+            metadata["suggested_action_filters"] = ind.suggested_action_filters
 
         await session.execute(
             text("""
                 INSERT INTO threat_intel_indicators
-                    (indicator_type, value, source, confidence, added_by, feed_id)
+                    (indicator_type, value, source, confidence, added_by,
+                     feed_id, campaign_id, expires_at, notes, metadata_json)
                 VALUES
-                    (:indicator_type, :value, :source, 0.70, :added_by, :feed_id)
+                    (:indicator_type, :value, :source, :confidence, :added_by,
+                     :feed_id, :campaign_id, :expires_at, :notes, :metadata_json)
                 ON CONFLICT (indicator_type, value) DO UPDATE SET
                     active = TRUE,
-                    feed_id = EXCLUDED.feed_id
+                    confidence = GREATEST(
+                        threat_intel_indicators.confidence,
+                        EXCLUDED.confidence
+                    ),
+                    feed_id = EXCLUDED.feed_id,
+                    campaign_id = COALESCE(
+                        EXCLUDED.campaign_id,
+                        threat_intel_indicators.campaign_id
+                    ),
+                    expires_at = EXCLUDED.expires_at,
+                    metadata_json = COALESCE(
+                        EXCLUDED.metadata_json,
+                        threat_intel_indicators.metadata_json
+                    )
             """),
             {
-                "indicator_type": indicator_type,
-                "value": value,
+                "indicator_type": ind.indicator_type,
+                "value": ind.value,
                 "source": f"feed:{feed_id}",
+                "confidence": ind.confidence,
                 "added_by": added_by,
                 "feed_id": feed_id,
+                "campaign_id": ind_campaign_id,
+                "expires_at": ind.expires_at,
+                "notes": ind.source_reference,
+                "metadata_json": json.dumps(metadata) if metadata else None,
             },
         )
         count += 1
 
-    # Update feed status
+    # Determine feed status
+    status = "success"
+    if parse_result.warnings and count == 0:
+        status = "failed"
+    elif parse_result.warnings:
+        status = f"partial ({parse_result.skipped_count} skipped)"
+
     await session.execute(
         text("""
             UPDATE threat_intel_feeds
             SET last_fetched_at = NOW(),
-                last_fetch_status = 'success',
+                last_fetch_status = :status,
                 last_indicator_count = :count,
                 updated_at = NOW()
             WHERE id = :feed_id
         """),
-        {"feed_id": feed_id, "count": count},
+        {"feed_id": feed_id, "count": count, "status": status},
     )
     await session.commit()
     return count
+
+
+async def _upsert_campaign(
+    session: AsyncSession,
+    *,
+    feed_id: int,
+    name: str,
+    description: str | None = None,
+    severity: str = "critical",
+    references: list[str] | None = None,
+    mitre_attack: list[str] | None = None,
+) -> int:
+    """Insert or update a campaign, returning its ID."""
+    import re as _re
+
+    slug = _re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    metadata: dict[str, Any] = {}
+    if references:
+        metadata["references"] = references
+    if mitre_attack:
+        metadata["mitre_attack"] = mitre_attack
+
+    result = await session.execute(
+        text("""
+            INSERT INTO threat_intel_campaigns
+                (name, slug, description, severity, source_feed_id, metadata_json)
+            VALUES
+                (:name, :slug, :description, :severity, :source_feed_id, :metadata_json)
+            ON CONFLICT (name) DO UPDATE SET
+                last_updated = NOW(),
+                description = COALESCE(
+                    EXCLUDED.description,
+                    threat_intel_campaigns.description
+                ),
+                metadata_json = COALESCE(
+                    EXCLUDED.metadata_json,
+                    threat_intel_campaigns.metadata_json
+                )
+            RETURNING id
+        """),
+        {
+            "name": name,
+            "slug": slug,
+            "description": description,
+            "severity": severity,
+            "source_feed_id": feed_id,
+            "metadata_json": json.dumps(metadata) if metadata else None,
+        },
+    )
+    row = result.fetchone()
+    return row[0]  # type: ignore[index]
 
 
 async def update_feed(
@@ -406,11 +527,23 @@ async def update_feed(
     set_clauses = []
     params: dict[str, Any] = {"id": feed_id}
 
-    allowed_fields = {"name", "url", "feed_type", "refresh_interval_minutes", "enabled"}
+    allowed_fields = {
+        "name",
+        "url",
+        "feed_type",
+        "refresh_interval_minutes",
+        "enabled",
+        "parser_type",
+        "auto_rule_generation",
+        "default_campaign_id",
+    }
     for field_name, field_value in updates.items():
         if field_name in allowed_fields:
             set_clauses.append(f"{field_name} = :{field_name}")
             params[field_name] = field_value
+        elif field_name == "parser_config":
+            set_clauses.append("parser_config = :parser_config")
+            params["parser_config"] = json.dumps(field_value) if field_value else None
 
     if not set_clauses:
         return None
@@ -424,7 +557,8 @@ async def update_feed(
             WHERE id = :id
             RETURNING id, name, url, feed_type, enabled, refresh_interval_minutes,
                       last_fetched_at, last_fetch_status, last_indicator_count,
-                      created_by, created_at, updated_at, is_default
+                      created_by, created_at, updated_at, is_default,
+                      parser_type, parser_config, auto_rule_generation, default_campaign_id
         """),
         params,
     )

--- a/backend/app/workers/threat_intel_worker.py
+++ b/backend/app/workers/threat_intel_worker.py
@@ -45,7 +45,8 @@ async def _refresh_feeds() -> dict[str, object]:
         try:
             result = await session.execute(
                 text("""
-                    SELECT id, url, feed_type, name
+                    SELECT id, url, feed_type, name,
+                           parser_type, parser_config, default_campaign_id
                     FROM threat_intel_feeds
                     WHERE enabled = TRUE
                       AND (
@@ -70,6 +71,9 @@ async def _refresh_feeds() -> dict[str, object]:
                             content=content,
                             feed_type=feed.feed_type,
                             added_by="system:feed_refresh",
+                            parser_type=feed.parser_type,
+                            parser_config=feed.parser_config,
+                            default_campaign_id=feed.default_campaign_id,
                         )
                         feeds_processed += 1
                         indicators_total += count

--- a/backend/tests/test_feed_parsers.py
+++ b/backend/tests/test_feed_parsers.py
@@ -1,0 +1,391 @@
+"""Unit tests for feed parser registry and individual parsers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.services.feed_parsers import get_parser
+from app.services.feed_parsers.base import ParseResult
+from app.services.feed_parsers.custom_json import CustomJSONParser
+from app.services.feed_parsers.openssf import OpenSSFParser
+from app.services.feed_parsers.plaintext import PlaintextParser
+from app.services.feed_parsers.stix21 import STIX21Parser
+
+# ─── Registry tests ──────────────────────────────────────────────────────────
+
+
+class TestRegistry:
+    def test_get_plaintext_parser(self) -> None:
+        parser = get_parser("plaintext")
+        assert isinstance(parser, PlaintextParser)
+
+    def test_get_custom_json_parser(self) -> None:
+        parser = get_parser("custom_json")
+        assert isinstance(parser, CustomJSONParser)
+
+    def test_get_stix21_parser(self) -> None:
+        parser = get_parser("stix21")
+        assert isinstance(parser, STIX21Parser)
+
+    def test_get_openssf_parser(self) -> None:
+        parser = get_parser("openssf_package_analysis")
+        assert isinstance(parser, OpenSSFParser)
+
+    def test_unknown_parser_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown parser type"):
+            get_parser("nonexistent")
+
+
+# ─── Plaintext parser tests ──────────────────────────────────────────────────
+
+
+class TestPlaintextParser:
+    def test_basic_domain_list(self) -> None:
+        content = "evil.com\nbad.org\nmalware.net"
+        result = PlaintextParser().parse(content, {})
+        assert len(result.indicators) == 3
+        assert result.indicators[0].value == "evil.com"
+        assert result.indicators[0].indicator_type == "domain"
+        assert result.indicators[0].confidence == 0.70
+
+    def test_comments_and_blanks_skipped(self) -> None:
+        content = "# header\nevil.com\n\n// another comment\nbad.org\n   \n"
+        result = PlaintextParser().parse(content, {})
+        assert len(result.indicators) == 2
+
+    def test_csv_first_column(self) -> None:
+        content = "evil.com,malware,2024-01-01\nbad.org,phishing,2024-02-01"
+        result = PlaintextParser().parse(content, {})
+        assert result.indicators[0].value == "evil.com"
+        assert result.indicators[1].value == "bad.org"
+
+    def test_custom_indicator_type_via_config(self) -> None:
+        content = "192.168.1.1\n10.0.0.1"
+        result = PlaintextParser().parse(content, {"indicator_type": "ip"})
+        assert all(i.indicator_type == "ip" for i in result.indicators)
+
+    def test_custom_confidence_via_config(self) -> None:
+        content = "evil.com"
+        result = PlaintextParser().parse(content, {"confidence": 0.95})
+        assert result.indicators[0].confidence == 0.95
+
+    def test_empty_content(self) -> None:
+        result = PlaintextParser().parse("", {})
+        assert len(result.indicators) == 0
+        assert not result.warnings
+
+
+# ─── Custom JSON parser tests ────────────────────────────────────────────────
+
+
+_SAMPLE_CUSTOM_JSON = json.dumps(
+    {
+        "schema_version": "1.0",
+        "campaign": {
+            "name": "Miasma",
+            "description": "npm supply chain worm targeting CI/CD secrets",
+            "severity": "critical",
+            "references": ["https://example.com/advisory-123"],
+            "mitre_attack": ["T1195.002", "T1528"],
+        },
+        "indicators": [
+            {
+                "type": "github_username",
+                "values": ["asteroiddao", "liuende501"],
+                "context": "Exfiltration accounts",
+                "confidence": 0.95,
+                "severity": "critical",
+            },
+            {
+                "type": "package_name",
+                "values": ["npm:evil-package"],
+                "confidence": 0.90,
+                "severity": "high",
+            },
+        ],
+        "suggested_rules": [
+            {
+                "name": "Miasma Actor Push",
+                "action_filters": ["git.push"],
+                "match_field": "actor",
+                "indicator_types": ["github_username"],
+                "severity": "critical",
+            }
+        ],
+    }
+)
+
+
+class TestCustomJSONParser:
+    def test_full_feed(self) -> None:
+        result = CustomJSONParser().parse(_SAMPLE_CUSTOM_JSON, {})
+        assert len(result.indicators) == 3
+        assert result.campaign_name == "Miasma"
+        assert result.campaign_severity == "critical"
+        assert result.campaign_mitre_attack == ["T1195.002", "T1528"]
+
+    def test_campaign_attribution(self) -> None:
+        result = CustomJSONParser().parse(_SAMPLE_CUSTOM_JSON, {})
+        for ind in result.indicators:
+            if ind.indicator_type == "github_username":
+                assert ind.campaign_name == "Miasma"
+                assert ind.confidence == 0.95
+                assert ind.severity == "critical"
+
+    def test_action_filters_wired(self) -> None:
+        result = CustomJSONParser().parse(_SAMPLE_CUSTOM_JSON, {})
+        username_inds = [i for i in result.indicators if i.indicator_type == "github_username"]
+        assert username_inds[0].suggested_action_filters == ["git.push"]
+
+    def test_mitre_in_metadata(self) -> None:
+        result = CustomJSONParser().parse(_SAMPLE_CUSTOM_JSON, {})
+        assert result.indicators[0].metadata.get("mitre_attack") == ["T1195.002", "T1528"]
+
+    def test_invalid_json(self) -> None:
+        result = CustomJSONParser().parse("not json", {})
+        assert len(result.indicators) == 0
+        assert any("Invalid JSON" in w for w in result.warnings)
+
+    def test_schema_validation_failure(self) -> None:
+        result = CustomJSONParser().parse(json.dumps({"bad": "data"}), {})
+        assert len(result.indicators) == 0
+        assert any("Schema validation failed" in w for w in result.warnings)
+
+    def test_no_campaign(self) -> None:
+        content = json.dumps(
+            {
+                "schema_version": "1.0",
+                "indicators": [{"type": "domain", "values": ["evil.com"]}],
+            }
+        )
+        result = CustomJSONParser().parse(content, {})
+        assert len(result.indicators) == 1
+        assert result.campaign_name is None
+        assert result.indicators[0].campaign_name is None
+
+    def test_empty_values_skipped(self) -> None:
+        content = json.dumps(
+            {
+                "schema_version": "1.0",
+                "indicators": [{"type": "domain", "values": ["evil.com", "", "  "]}],
+            }
+        )
+        result = CustomJSONParser().parse(content, {})
+        assert len(result.indicators) == 1
+        assert result.skipped_count == 2
+
+
+# ─── STIX 2.1 parser tests ───────────────────────────────────────────────────
+
+
+_SAMPLE_STIX_BUNDLE = json.dumps(
+    {
+        "type": "bundle",
+        "id": "bundle--001",
+        "objects": [
+            {
+                "type": "campaign",
+                "id": "campaign--abc",
+                "name": "APT-X",
+                "description": "Advanced persistent threat",
+                "confidence": 90,
+            },
+            {
+                "type": "indicator",
+                "id": "indicator--001",
+                "pattern": "[domain-name:value = 'evil.example.com']",
+                "pattern_type": "stix",
+                "confidence": 85,
+                "labels": ["malicious-activity"],
+                "external_references": [{"url": "https://example.com/advisory"}],
+            },
+            {
+                "type": "indicator",
+                "id": "indicator--002",
+                "pattern": "[ipv4-addr:value = '10.0.0.1']",
+                "pattern_type": "stix",
+                "confidence": 60,
+            },
+            {
+                "type": "indicator",
+                "id": "indicator--003",
+                "pattern": "[file:hashes.'SHA-256' = 'abc123']",
+                "pattern_type": "stix",
+            },
+            {
+                "type": "relationship",
+                "id": "relationship--001",
+                "relationship_type": "indicates",
+                "source_ref": "indicator--001",
+                "target_ref": "campaign--abc",
+            },
+        ],
+    }
+)
+
+
+class TestSTIX21Parser:
+    def test_simple_indicators(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        assert len(result.indicators) == 2
+        assert result.skipped_count == 1  # file hash unsupported
+
+    def test_domain_extracted(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        domain_ind = [i for i in result.indicators if i.indicator_type == "domain"]
+        assert len(domain_ind) == 1
+        assert domain_ind[0].value == "evil.example.com"
+        assert domain_ind[0].confidence == 0.85
+
+    def test_ip_extracted(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        ip_ind = [i for i in result.indicators if i.indicator_type == "ip"]
+        assert len(ip_ind) == 1
+        assert ip_ind[0].value == "10.0.0.1"
+
+    def test_campaign_attribution_via_relationship(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        domain_ind = [i for i in result.indicators if i.indicator_type == "domain"][0]
+        assert domain_ind.campaign_name == "APT-X"
+
+    def test_stix_id_in_metadata(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        assert result.indicators[0].metadata.get("stix_id") == "indicator--001"
+
+    def test_external_reference_as_source(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        domain_ind = [i for i in result.indicators if i.indicator_type == "domain"][0]
+        assert domain_ind.source_reference == "https://example.com/advisory"
+
+    def test_campaign_from_bundle(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        assert result.campaign_name == "APT-X"
+        assert result.campaign_description == "Advanced persistent threat"
+
+    def test_confidence_mapping(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        domain_ind = [i for i in result.indicators if i.indicator_type == "domain"][0]
+        assert domain_ind.severity == "critical"  # 85 >= 85
+
+        ip_ind = [i for i in result.indicators if i.indicator_type == "ip"][0]
+        assert ip_ind.severity == "medium"  # 60 >= 40, < 65
+
+    def test_invalid_json(self) -> None:
+        result = STIX21Parser().parse("not json", {})
+        assert len(result.indicators) == 0
+        assert any("Invalid JSON" in w for w in result.warnings)
+
+    def test_empty_bundle(self) -> None:
+        result = STIX21Parser().parse(json.dumps({"type": "bundle", "objects": []}), {})
+        assert len(result.indicators) == 0
+
+    def test_unsupported_stix_type_warning(self) -> None:
+        result = STIX21Parser().parse(_SAMPLE_STIX_BUNDLE, {})
+        assert any("Unknown STIX object type" in w for w in result.warnings)
+
+
+# ─── OpenSSF parser tests ────────────────────────────────────────────────────
+
+
+_SAMPLE_OPENSSF = json.dumps(
+    [
+        {
+            "package": {
+                "name": "evil-pkg",
+                "ecosystem": "npm",
+                "version": "1.0.0",
+                "maintainers": [
+                    {"email": "attacker@evil.com"},
+                ],
+            },
+            "analysis": {
+                "verdict": "malicious",
+                "behaviors": ["exfiltration", "code_execution"],
+            },
+            "url": "https://openssf.org/analysis/evil-pkg",
+        },
+        {
+            "package": {
+                "name": "safe-pkg",
+                "ecosystem": "pypi",
+                "version": "2.0.0",
+            },
+            "analysis": {"verdict": "benign"},
+        },
+    ]
+)
+
+
+class TestOpenSSFParser:
+    def test_malicious_package_extracted(self) -> None:
+        result = OpenSSFParser().parse(_SAMPLE_OPENSSF, {})
+        pkg_inds = [i for i in result.indicators if i.indicator_type == "package_name"]
+        assert len(pkg_inds) == 1
+        assert pkg_inds[0].value == "npm:evil-pkg"
+        assert pkg_inds[0].confidence == 0.90
+
+    def test_benign_skipped(self) -> None:
+        result = OpenSSFParser().parse(_SAMPLE_OPENSSF, {})
+        assert result.skipped_count >= 1
+
+    def test_maintainer_email_extracted(self) -> None:
+        result = OpenSSFParser().parse(_SAMPLE_OPENSSF, {})
+        email_inds = [i for i in result.indicators if i.indicator_type == "commit_author_email"]
+        assert len(email_inds) == 1
+        assert email_inds[0].value == "attacker@evil.com"
+
+    def test_ecosystem_in_metadata(self) -> None:
+        result = OpenSSFParser().parse(_SAMPLE_OPENSSF, {})
+        pkg_ind = [i for i in result.indicators if i.indicator_type == "package_name"][0]
+        assert pkg_ind.metadata.get("ecosystem") == "npm"
+        assert pkg_ind.metadata.get("version") == "1.0.0"
+
+    def test_action_filters_for_packages(self) -> None:
+        result = OpenSSFParser().parse(_SAMPLE_OPENSSF, {})
+        pkg_ind = [i for i in result.indicators if i.indicator_type == "package_name"][0]
+        assert "packages.package_created" in pkg_ind.suggested_action_filters
+
+    def test_external_id_includes_version(self) -> None:
+        result = OpenSSFParser().parse(_SAMPLE_OPENSSF, {})
+        pkg_ind = [i for i in result.indicators if i.indicator_type == "package_name"][0]
+        assert pkg_ind.external_id == "npm:evil-pkg@1.0.0"
+
+    def test_single_object_input(self) -> None:
+        single = json.dumps(
+            {
+                "package": {"name": "bad", "ecosystem": "pypi"},
+                "analysis": {"verdict": "malicious"},
+            }
+        )
+        result = OpenSSFParser().parse(single, {})
+        assert len(result.indicators) == 1
+        assert result.indicators[0].value == "pypi:bad"
+
+    def test_invalid_json(self) -> None:
+        result = OpenSSFParser().parse("not json", {})
+        assert any("Invalid JSON" in w for w in result.warnings)
+
+    def test_behavior_based_detection(self) -> None:
+        """Package without explicit verdict but with malicious behaviors."""
+        content = json.dumps(
+            {
+                "package": {"name": "sneaky", "ecosystem": "npm"},
+                "analysis": {"behaviors": ["exfiltration"]},
+            }
+        )
+        result = OpenSSFParser().parse(content, {})
+        assert len(result.indicators) == 1
+
+
+# ─── ParseResult structure tests ─────────────────────────────────────────────
+
+
+class TestParseResult:
+    def test_defaults(self) -> None:
+        result = ParseResult()
+        assert result.indicators == []
+        assert result.warnings == []
+        assert result.skipped_count == 0
+        assert result.campaign_name is None


### PR DESCRIPTION
## Summary

Implements the Feed Parser Registry (#335), the first major feature of the Adaptive Threat Intel epic (#333).

Replaces the single plaintext line parser with a pluggable registry supporting four feed formats:

### New Parsers

| Parser | Format | Use Case |
|--------|--------|----------|
| **Plaintext** | One IoC per line | Backwards-compatible, simple blocklists |
| **STIX 2.1** | JSON bundles | Industry-standard threat intel (MISP, TAXII) |
| **OpenSSF Package Analysis** | JSON reports | Malicious package detection with ecosystem awareness |
| **Custom JSON** | OctoWatch schema | Native format with campaign info, indicator groups, suggested rules |

### Key Changes

- `backend/app/services/feed_parsers/` — New module with Protocol-based parser interface
- `ParseResult` dataclass with warnings and skipped_count for graceful degradation
- Refactored `fetch_feed_indicators()` to use registry dispatch
- Enhanced indicator upsert (GREATEST confidence, COALESCE campaign/metadata)
- Campaign upsert helper with slug generation from name
- Wired `parser_type`, `parser_config`, `default_campaign_id` through create/update/get feed endpoints and worker
- 40 unit tests covering all parsers and registry

### Testing

- 40 new unit tests all passing
- 1858/1859 existing tests pass (1 pre-existing failure in `test_post_sync_pipeline`)
- Lint clean (ruff check + format)

Closes #335