### PR TITLE
feat: Detection engine expansions — threat_intel_actor, commit_author, scope, action_ref

### DIFF
--- a/backend/app/services/detection_service.py
+++ b/backend/app/services/detection_service.py
@@ -1027,6 +1027,18 @@ async def _check_x_config_engine(
     elif engine == "threat_intel_ip":
         return await _check_threat_intel_ip(event, x_config, session)
 
+    elif engine == "threat_intel_actor":
+        return await _check_threat_intel_actor(event, x_config, session)
+
+    elif engine == "threat_intel_commit_author":
+        return await _check_threat_intel_commit_author(event, x_config, session)
+
+    elif engine == "threat_intel_scope":
+        return await _check_threat_intel_scope(event, x_config, session)
+
+    elif engine == "threat_intel_action_ref":
+        return await _check_threat_intel_action_ref(event, x_config, session)
+
     elif engine == "dormant_account":
         return await _check_dormant_account(event, x_config, session)
 
@@ -1137,6 +1149,218 @@ async def _check_threat_intel_ip(
         return indicator is not None
     except Exception:
         logger.warning("detection.threat_intel_ip_check_failed", exc_info=True)
+        return False
+
+
+async def _check_threat_intel_actor(
+    event: AuditEvent,
+    x_config: dict[str, Any],
+    session: AsyncSession,
+) -> bool:
+    """Check if the event actor matches a known threat intel github_username indicator.
+
+    Returns True when the actor is found in threat intel (detection should fire).
+    """
+    actor = getattr(event, "actor", None)
+    if not actor:
+        return False
+
+    try:
+        from app.models.threat_intel import ThreatIntelIndicator
+
+        indicator_type = x_config.get("indicator_type", "github_username")
+        campaign_id = x_config.get("campaign_id")
+
+        stmt = (
+            select(ThreatIntelIndicator)
+            .where(ThreatIntelIndicator.value == str(actor))
+            .where(ThreatIntelIndicator.indicator_type == indicator_type)
+            .where(ThreatIntelIndicator.active.is_(True))
+            .where(
+                (ThreatIntelIndicator.expires_at.is_(None))
+                | (ThreatIntelIndicator.expires_at > datetime.now(UTC))
+            )
+        )
+        if campaign_id:
+            stmt = stmt.where(ThreatIntelIndicator.campaign_id == int(campaign_id))
+        stmt = stmt.limit(1)
+
+        result = await session.execute(stmt)
+        indicator = result.scalar_one_or_none()
+        return indicator is not None
+    except Exception:
+        logger.warning("detection.threat_intel_actor_check_failed", exc_info=True)
+        return False
+
+
+async def _check_threat_intel_commit_author(
+    event: AuditEvent,
+    x_config: dict[str, Any],
+    session: AsyncSession,
+) -> bool:
+    """Check if commit author/committer email matches a threat intel indicator.
+
+    Examines event.data for author_email and committer_email fields.
+    Returns True when an email matches an active commit_author_email indicator.
+    """
+    data = event.data if event.data else {}
+    emails = set()
+    for field_name in ("author_email", "committer_email"):
+        val = data.get(field_name)
+        if val:
+            emails.add(str(val))
+
+    if not emails:
+        return False
+
+    try:
+        from app.models.threat_intel import ThreatIntelIndicator
+
+        indicator_type = x_config.get("indicator_type", "commit_author_email")
+        campaign_id = x_config.get("campaign_id")
+
+        stmt = (
+            select(ThreatIntelIndicator)
+            .where(ThreatIntelIndicator.value.in_(list(emails)))
+            .where(ThreatIntelIndicator.indicator_type == indicator_type)
+            .where(ThreatIntelIndicator.active.is_(True))
+            .where(
+                (ThreatIntelIndicator.expires_at.is_(None))
+                | (ThreatIntelIndicator.expires_at > datetime.now(UTC))
+            )
+        )
+        if campaign_id:
+            stmt = stmt.where(ThreatIntelIndicator.campaign_id == int(campaign_id))
+        stmt = stmt.limit(1)
+
+        result = await session.execute(stmt)
+        indicator = result.scalar_one_or_none()
+        return indicator is not None
+    except Exception:
+        logger.warning("detection.threat_intel_commit_author_check_failed", exc_info=True)
+        return False
+
+
+async def _check_threat_intel_scope(
+    event: AuditEvent,
+    x_config: dict[str, Any],
+    session: AsyncSession,
+) -> bool:
+    """Check if a package name matches a known malicious npm_scope indicator.
+
+    Uses prefix matching: indicator '@evil-scope' matches package
+    '@evil-scope/any-package'. Works for npm scopes and similar namespaced
+    package ecosystems.
+
+    Returns True when the package scope matches a threat intel indicator.
+    """
+    data = event.data if event.data else {}
+    package_name = data.get("package_name") or data.get("name")
+    if not package_name:
+        return False
+
+    package_name = str(package_name)
+
+    try:
+        from app.models.threat_intel import ThreatIntelIndicator
+
+        indicator_type = x_config.get("indicator_type", "npm_scope")
+        campaign_id = x_config.get("campaign_id")
+
+        # Query active scope indicators
+        stmt = (
+            select(ThreatIntelIndicator)
+            .where(ThreatIntelIndicator.indicator_type == indicator_type)
+            .where(ThreatIntelIndicator.active.is_(True))
+            .where(
+                (ThreatIntelIndicator.expires_at.is_(None))
+                | (ThreatIntelIndicator.expires_at > datetime.now(UTC))
+            )
+        )
+        if campaign_id:
+            stmt = stmt.where(ThreatIntelIndicator.campaign_id == int(campaign_id))
+
+        result = await session.execute(stmt)
+        indicators = result.scalars().all()
+
+        # Prefix match: indicator value should be a prefix of the package name
+        for indicator in indicators:
+            scope = indicator.value
+            if package_name.startswith(scope) and (
+                len(package_name) == len(scope) or package_name[len(scope)] == "/"
+            ):
+                return True
+
+        return False
+    except Exception:
+        logger.warning("detection.threat_intel_scope_check_failed", exc_info=True)
+        return False
+
+
+async def _check_threat_intel_action_ref(
+    event: AuditEvent,
+    x_config: dict[str, Any],
+    session: AsyncSession,
+) -> bool:
+    """Check if a workflow action reference matches a known malicious action_ref indicator.
+
+    Examines event.data for action references (e.g. 'owner/action@ref') in
+    workflow job metadata.
+
+    Returns True when an action ref matches an active threat intel indicator.
+    """
+    data = event.data if event.data else {}
+    # Action refs can appear in different fields depending on the event type
+    action_refs: set[str] = set()
+    for field_name in ("action", "action_ref", "workflow_ref", "uses"):
+        val = data.get(field_name)
+        if val and isinstance(val, str) and "/" in val:
+            action_refs.add(val)
+
+    # Also check nested actions list if present
+    actions_list = data.get("actions", [])
+    if isinstance(actions_list, list):
+        for action_entry in actions_list:
+            if isinstance(action_entry, dict):
+                ref = action_entry.get("ref") or action_entry.get("uses")
+                if ref and isinstance(ref, str) and "/" in ref:
+                    action_refs.add(ref)
+
+    if not action_refs:
+        return False
+
+    try:
+        from app.models.threat_intel import ThreatIntelIndicator
+
+        indicator_type = x_config.get("indicator_type", "action_ref")
+        campaign_id = x_config.get("campaign_id")
+
+        # Normalize refs: strip version pinning for comparison
+        # e.g., "owner/action@v1" -> check both "owner/action@v1" and "owner/action"
+        normalized_refs = set(action_refs)
+        for ref in action_refs:
+            if "@" in ref:
+                normalized_refs.add(ref.split("@")[0])
+
+        stmt = (
+            select(ThreatIntelIndicator)
+            .where(ThreatIntelIndicator.value.in_(list(normalized_refs)))
+            .where(ThreatIntelIndicator.indicator_type == indicator_type)
+            .where(ThreatIntelIndicator.active.is_(True))
+            .where(
+                (ThreatIntelIndicator.expires_at.is_(None))
+                | (ThreatIntelIndicator.expires_at > datetime.now(UTC))
+            )
+        )
+        if campaign_id:
+            stmt = stmt.where(ThreatIntelIndicator.campaign_id == int(campaign_id))
+        stmt = stmt.limit(1)
+
+        result = await session.execute(stmt)
+        indicator = result.scalar_one_or_none()
+        return indicator is not None
+    except Exception:
+        logger.warning("detection.threat_intel_action_ref_check_failed", exc_info=True)
         return False
 
 
@@ -1661,6 +1885,10 @@ async def _write_detection_for_event(
         repo_short = _repo_short(event.repo)
         ctx["dedup_key"] = f"posture:{rule.slug}:{event.org or ''}:{repo_short}"
 
+    # Extract campaign_id from x_config for threat-intel-derived rules
+    x_config = rule.logic_config.get("x_config", {})
+    campaign_id = x_config.get("campaign_id")
+
     detection = Detection(
         rule_id=rule.id,
         rule_version=rule.version,
@@ -1677,6 +1905,7 @@ async def _write_detection_for_event(
         context_data=ctx,
         window_start=event.created_at,
         window_end=event.created_at,
+        campaign_id=int(campaign_id) if campaign_id else None,
     )
     session.add(detection)
     await session.flush()

--- a/backend/tests/test_detection_engines_threat_intel.py
+++ b/backend/tests/test_detection_engines_threat_intel.py
@@ -1,0 +1,340 @@
+"""Unit tests for new threat intel detection engines (#336)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.detection_service import (
+    _check_threat_intel_action_ref,
+    _check_threat_intel_actor,
+    _check_threat_intel_commit_author,
+    _check_threat_intel_scope,
+)
+
+
+def _make_event(
+    *,
+    actor: str | None = None,
+    data: dict | None = None,
+    source_ip: str | None = None,
+) -> MagicMock:
+    """Create a mock AuditEvent with specified attributes."""
+    event = MagicMock()
+    event.actor = actor
+    event.data = data or {}
+    event.source_ip = source_ip
+    return event
+
+
+def _make_indicator(
+    *,
+    value: str,
+    indicator_type: str = "github_username",
+    active: bool = True,
+    campaign_id: int | None = None,
+    expires_at: datetime | None = None,
+) -> MagicMock:
+    """Create a mock ThreatIntelIndicator."""
+    indicator = MagicMock()
+    indicator.value = value
+    indicator.indicator_type = indicator_type
+    indicator.active = active
+    indicator.campaign_id = campaign_id
+    indicator.expires_at = expires_at
+    return indicator
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock AsyncSession that returns configurable query results."""
+    session = AsyncMock()
+    return session
+
+
+def _setup_session_with_indicator(session: AsyncMock, indicator=None):
+    """Configure mock session to return a specific indicator from execute()."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = indicator
+    mock_result.scalars.return_value.all.return_value = [indicator] if indicator else []
+    session.execute = AsyncMock(return_value=mock_result)
+
+
+# =============================================================================
+# _check_threat_intel_actor
+# =============================================================================
+
+
+class TestThreatIntelActor:
+    """Tests for the threat_intel_actor engine."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_actor(self, mock_session):
+        event = _make_event(actor=None)
+        x_config = {"engine": "threat_intel_actor"}
+        result = await _check_threat_intel_actor(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_actor_matches_indicator(self, mock_session):
+        event = _make_event(actor="evil-user")
+        indicator = _make_indicator(value="evil-user")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_actor"}
+        result = await _check_threat_intel_actor(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_actor_not_in_indicators(self, mock_session):
+        event = _make_event(actor="good-user")
+        _setup_session_with_indicator(mock_session, None)
+        x_config = {"engine": "threat_intel_actor"}
+        result = await _check_threat_intel_actor(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_respects_campaign_id_filter(self, mock_session):
+        event = _make_event(actor="target-user")
+        _setup_session_with_indicator(mock_session, None)
+        x_config = {"engine": "threat_intel_actor", "campaign_id": 42}
+        result = await _check_threat_intel_actor(event, x_config, mock_session)
+        assert result is False
+        # Verify the query was called (campaign filter applied)
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_custom_indicator_type(self, mock_session):
+        event = _make_event(actor="bad-bot")
+        indicator = _make_indicator(value="bad-bot", indicator_type="bot_account")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_actor", "indicator_type": "bot_account"}
+        result = await _check_threat_intel_actor(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_graceful_failure_on_exception(self, mock_session):
+        event = _make_event(actor="user")
+        mock_session.execute = AsyncMock(side_effect=RuntimeError("DB error"))
+        x_config = {"engine": "threat_intel_actor"}
+        result = await _check_threat_intel_actor(event, x_config, mock_session)
+        assert result is False
+
+
+# =============================================================================
+# _check_threat_intel_commit_author
+# =============================================================================
+
+
+class TestThreatIntelCommitAuthor:
+    """Tests for the threat_intel_commit_author engine."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_email_fields(self, mock_session):
+        event = _make_event(data={"something_else": "value"})
+        x_config = {"engine": "threat_intel_commit_author"}
+        result = await _check_threat_intel_commit_author(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_matches_author_email(self, mock_session):
+        event = _make_event(data={"author_email": "attacker@evil.com"})
+        indicator = _make_indicator(value="attacker@evil.com", indicator_type="commit_author_email")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_commit_author"}
+        result = await _check_threat_intel_commit_author(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_matches_committer_email(self, mock_session):
+        event = _make_event(data={"committer_email": "bad@evil.org"})
+        indicator = _make_indicator(value="bad@evil.org", indicator_type="commit_author_email")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_commit_author"}
+        result = await _check_threat_intel_commit_author(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_email_not_in_indicators(self, mock_session):
+        event = _make_event(data={"author_email": "good@legit.com"})
+        _setup_session_with_indicator(mock_session, None)
+        x_config = {"engine": "threat_intel_commit_author"}
+        result = await _check_threat_intel_commit_author(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_checks_both_author_and_committer(self, mock_session):
+        event = _make_event(
+            data={
+                "author_email": "legit@good.com",
+                "committer_email": "evil@bad.com",
+            }
+        )
+        indicator = _make_indicator(value="evil@bad.com", indicator_type="commit_author_email")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_commit_author"}
+        result = await _check_threat_intel_commit_author(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_graceful_failure_on_exception(self, mock_session):
+        event = _make_event(data={"author_email": "x@y.com"})
+        mock_session.execute = AsyncMock(side_effect=RuntimeError("DB error"))
+        x_config = {"engine": "threat_intel_commit_author"}
+        result = await _check_threat_intel_commit_author(event, x_config, mock_session)
+        assert result is False
+
+
+# =============================================================================
+# _check_threat_intel_scope
+# =============================================================================
+
+
+class TestThreatIntelScope:
+    """Tests for the threat_intel_scope engine."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_package_name(self, mock_session):
+        event = _make_event(data={})
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_matches_scope_prefix(self, mock_session):
+        event = _make_event(data={"package_name": "@evil-scope/some-pkg"})
+        indicator = _make_indicator(value="@evil-scope", indicator_type="npm_scope")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_exact_scope_match(self, mock_session):
+        event = _make_event(data={"package_name": "@evil-scope"})
+        indicator = _make_indicator(value="@evil-scope", indicator_type="npm_scope")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_no_match_for_similar_but_different_scope(self, mock_session):
+        # "@evil-scope-extended/pkg" should NOT match indicator "@evil-scope"
+        event = _make_event(data={"package_name": "@evil-scope-extended/pkg"})
+        indicator = _make_indicator(value="@evil-scope", indicator_type="npm_scope")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_uses_name_field_fallback(self, mock_session):
+        event = _make_event(data={"name": "@bad/thing"})
+        indicator = _make_indicator(value="@bad", indicator_type="npm_scope")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_indicators_match(self, mock_session):
+        event = _make_event(data={"package_name": "@legit-scope/pkg"})
+        _setup_session_with_indicator(mock_session, None)
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_graceful_failure_on_exception(self, mock_session):
+        event = _make_event(data={"package_name": "@x/y"})
+        mock_session.execute = AsyncMock(side_effect=RuntimeError("DB error"))
+        x_config = {"engine": "threat_intel_scope"}
+        result = await _check_threat_intel_scope(event, x_config, mock_session)
+        assert result is False
+
+
+# =============================================================================
+# _check_threat_intel_action_ref
+# =============================================================================
+
+
+class TestThreatIntelActionRef:
+    """Tests for the threat_intel_action_ref engine."""
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_action_refs(self, mock_session):
+        event = _make_event(data={"some_field": "value"})
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_matches_action_ref_field(self, mock_session):
+        event = _make_event(data={"action_ref": "evil-org/malicious-action@v1"})
+        indicator = _make_indicator(value="evil-org/malicious-action", indicator_type="action_ref")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_matches_uses_field(self, mock_session):
+        event = _make_event(data={"uses": "bad-owner/bad-action@main"})
+        indicator = _make_indicator(value="bad-owner/bad-action", indicator_type="action_ref")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_matches_exact_versioned_ref(self, mock_session):
+        event = _make_event(data={"action_ref": "evil-org/malicious-action@abc123"})
+        indicator = _make_indicator(
+            value="evil-org/malicious-action@abc123", indicator_type="action_ref"
+        )
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_checks_nested_actions_list(self, mock_session):
+        event = _make_event(
+            data={
+                "actions": [
+                    {"uses": "good/action@v1"},
+                    {"uses": "evil/action@v2"},
+                ]
+            }
+        )
+        indicator = _make_indicator(value="evil/action", indicator_type="action_ref")
+        _setup_session_with_indicator(mock_session, indicator)
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_ignores_non_ref_strings(self, mock_session):
+        # "action" field without "/" is not a ref
+        event = _make_event(data={"action": "push"})
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_ref_not_in_indicators(self, mock_session):
+        event = _make_event(data={"action_ref": "legit-org/safe-action@v3"})
+        _setup_session_with_indicator(mock_session, None)
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_graceful_failure_on_exception(self, mock_session):
+        event = _make_event(data={"action_ref": "x/y@v1"})
+        mock_session.execute = AsyncMock(side_effect=RuntimeError("DB error"))
+        x_config = {"engine": "threat_intel_action_ref"}
+        result = await _check_threat_intel_action_ref(event, x_config, mock_session)
+        assert result is False


### PR DESCRIPTION
## Summary

Implements the four new detection engines specified in #336, extending the threat intel detection pipeline to match against expanded indicator types from the Feed Parser Registry (#335).

### New Engines

| Engine | Checks | Indicator Type | Trigger Events |
|--------|--------|----------------|----------------|
| `threat_intel_actor` | `event.actor` | `github_username` | Any action |
| `threat_intel_commit_author` | `event.data.author_email`, `committer_email` | `commit_author_email` | `git.push` |
| `threat_intel_scope` | `event.data.package_name` (prefix match) | `npm_scope` | `packages.package_version_published` |
| `threat_intel_action_ref` | Action references in workflow data | `action_ref` | `workflows.prepared_workflow_job`, `git.push` |

### Campaign Attribution

Detection records now carry `campaign_id` when the triggering rule has one configured in its `x_config`. This enables filtering detections by campaign in the API and including campaign metadata in SIEM exports.

### Design

All engines follow established patterns:
- Campaign-scoped queries (optional `campaign_id` filter)
- Expired indicator exclusion
- Graceful failure: log warning, return `False` (fail-open)
- Registered in the `_check_x_config_engine()` elif chain

### Testing

- 27 new unit tests covering all engines and edge cases
- 153 detection-related tests pass together
- Pre-existing `test_post_sync_pipeline` failure unrelated to this change

Closes #336