### PR TITLE
feat: Rule Synthesis Engine (#337)

### DIFF
--- a/backend/app/services/feed_parsers/base.py
+++ b/backend/app/services/feed_parsers/base.py
@@ -36,6 +36,7 @@ class ParseResult:
     campaign_severity: str | None = None
     campaign_references: list[str] = field(default_factory=list)
     campaign_mitre_attack: list[str] = field(default_factory=list)
+    suggested_rules: list[dict[str, Any]] | None = None
 
 
 class FeedParser(Protocol):

--- a/backend/app/services/feed_parsers/custom_json.py
+++ b/backend/app/services/feed_parsers/custom_json.py
@@ -124,6 +124,10 @@ class CustomJSONParser:
                     )
                 )
 
+        # Pass suggested_rules to ParseResult for rule synthesis
+        if feed.suggested_rules:
+            result.suggested_rules = [sr.model_dump() for sr in feed.suggested_rules]
+
         return result
 
 

--- a/backend/app/services/rule_synthesis_service.py
+++ b/backend/app/services/rule_synthesis_service.py
@@ -1,0 +1,253 @@
+"""Rule Synthesis Engine: auto-generate detection rules from feed indicators.
+
+Creates one rule per indicator_type per campaign. Rules reference x_config engines
+that query the indicators table at runtime, so adding new IOCs doesn't create
+additional rules — just enriches the existing query.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import structlog
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.detection import RuleDefinition
+
+logger = structlog.get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class RuleTemplate:
+    """Template mapping an indicator_type to detection rule configuration."""
+
+    display_name: str
+    action_filters: list[str]
+    engine: str
+    match_field: str
+    category: str = "supply_chain"
+    logic_type: str = "pattern"
+    default_severity: str = "critical"
+
+
+# Maps indicator_type → rule template
+RULE_TEMPLATES: dict[str, RuleTemplate] = {
+    "github_username": RuleTemplate(
+        display_name="Threat Actor Activity",
+        action_filters=["*"],
+        engine="threat_intel_actor",
+        match_field="actor",
+    ),
+    "commit_author_email": RuleTemplate(
+        display_name="Malicious Commit Author",
+        action_filters=["git.push"],
+        engine="threat_intel_commit_author",
+        match_field="data.author_email",
+    ),
+    "package_name": RuleTemplate(
+        display_name="Malicious Package",
+        action_filters=["packages.package_version_published"],
+        engine="threat_intel_field",
+        match_field="data.package_name",
+    ),
+    "npm_scope": RuleTemplate(
+        display_name="Malicious Package Scope",
+        action_filters=["packages.package_version_published"],
+        engine="threat_intel_scope",
+        match_field="data.package_name",
+    ),
+    "action_ref": RuleTemplate(
+        display_name="Malicious Action Reference",
+        action_filters=["workflows.prepared_workflow_job", "git.push"],
+        engine="threat_intel_action_ref",
+        match_field="data.workflow_action",
+    ),
+    "ip": RuleTemplate(
+        display_name="Threat Intel IP",
+        action_filters=["*"],
+        engine="threat_intel_ip",
+        match_field="source_ip",
+        default_severity="high",
+    ),
+    "domain": RuleTemplate(
+        display_name="Malicious Domain",
+        action_filters=["org.add_member", "org.update_webhook", "repo.create_webhook"],
+        engine="threat_intel_field",
+        match_field="data.config.url",
+        default_severity="high",
+    ),
+}
+
+
+async def synthesize_rules_for_campaign(
+    session: AsyncSession,
+    campaign_id: int,
+    campaign_name: str,
+    campaign_slug: str,
+    indicator_types: set[str],
+    *,
+    campaign_severity: str = "critical",
+    suggested_rules: list[dict[str, Any]] | None = None,
+    feed_id: int | None = None,
+) -> list[int]:
+    """Generate or update feed-derived rules for a campaign.
+
+    Creates one rule per indicator_type using the RULE_TEMPLATES mapping.
+    Returns list of rule IDs created/updated.
+    """
+    rule_ids: list[int] = []
+
+    # Build a lookup of suggested rule overrides by indicator_type
+    overrides: dict[str, dict[str, Any]] = {}
+    if suggested_rules:
+        for sr in suggested_rules:
+            itype = sr.get("indicator_type")
+            if itype:
+                overrides[itype] = sr
+
+    for indicator_type in indicator_types:
+        template = RULE_TEMPLATES.get(indicator_type)
+        if not template:
+            logger.debug(
+                "rule_synthesis.no_template",
+                indicator_type=indicator_type,
+                campaign=campaign_name,
+            )
+            continue
+
+        override = overrides.get(indicator_type, {})
+        slug = f"feed-{campaign_slug}-{indicator_type}"
+
+        # Build logic_config from template + overrides
+        action_filters = override.get("action_filters", template.action_filters)
+        severity = override.get("severity", campaign_severity or template.default_severity)
+
+        logic_config: dict[str, Any] = {
+            "action_filters": action_filters,
+            "confidence": override.get("confidence", 0.85),
+            "x_config": {
+                "engine": template.engine,
+                "check_field": template.match_field,
+                "indicator_type": indicator_type,
+                "campaign_id": campaign_id,
+            },
+        }
+
+        rule_id = await _upsert_feed_rule(
+            session,
+            slug=slug,
+            name=f"[{campaign_name}] {template.display_name}",
+            description=(
+                f"Auto-generated: detects {indicator_type} IOCs from campaign '{campaign_name}'"
+            ),
+            category=template.category,
+            logic_type=template.logic_type,
+            default_severity=severity,
+            logic_config=logic_config,
+            campaign_id=campaign_id,
+        )
+        rule_ids.append(rule_id)
+
+    return rule_ids
+
+
+async def disable_expired_feed_rules(session: AsyncSession) -> int:
+    """Disable feed-derived rules whose expires_at has passed.
+
+    Returns count of rules disabled.
+    """
+    result = await session.execute(
+        text("""
+            UPDATE rule_definitions
+            SET enabled = FALSE,
+                status = 'expired',
+                updated_at = NOW(),
+                updated_by = 'system:rule_synthesis'
+            WHERE source = 'feed'
+              AND enabled = TRUE
+              AND expires_at IS NOT NULL
+              AND expires_at < NOW()
+            RETURNING id
+        """)
+    )
+    disabled_ids = result.scalars().all()
+    if disabled_ids:
+        logger.info(
+            "rule_synthesis.expired_rules_disabled",
+            count=len(disabled_ids),
+            rule_ids=list(disabled_ids),
+        )
+    return len(disabled_ids)
+
+
+async def _upsert_feed_rule(
+    session: AsyncSession,
+    *,
+    slug: str,
+    name: str,
+    description: str,
+    category: str,
+    logic_type: str,
+    default_severity: str,
+    logic_config: dict[str, Any],
+    campaign_id: int,
+) -> int:
+    """Create or update a feed-derived rule definition.
+
+    On conflict (slug already exists), update the logic_config, severity,
+    and re-enable if previously expired. Returns the rule ID.
+    """
+    # Check if rule already exists
+    existing = await session.execute(select(RuleDefinition).where(RuleDefinition.slug == slug))
+    rule = existing.scalar_one_or_none()
+
+    if rule:
+        # Update existing rule
+        rule.logic_config = logic_config
+        rule.default_severity = default_severity
+        rule.description = description
+        rule.name = name
+        rule.campaign_id = campaign_id
+        rule.updated_by = "system:rule_synthesis"
+        # Re-enable if it was expired
+        if rule.status == "expired":
+            rule.enabled = True
+            rule.status = "active"
+            rule.expires_at = None
+        logger.debug(
+            "rule_synthesis.rule_updated",
+            slug=slug,
+            rule_id=rule.id,
+        )
+        await session.flush()
+        return rule.id
+    else:
+        # Create new rule
+        new_rule = RuleDefinition(
+            slug=slug,
+            name=name,
+            description=description,
+            category=category,
+            logic_type=logic_type,
+            default_severity=default_severity,
+            default_confidence="high",
+            logic_config=logic_config,
+            enabled=True,
+            status="active",
+            mode="active",
+            version=1,
+            source="feed",
+            campaign_id=campaign_id,
+            created_by="system:rule_synthesis",
+        )
+        session.add(new_rule)
+        await session.flush()
+        logger.info(
+            "rule_synthesis.rule_created",
+            slug=slug,
+            rule_id=new_rule.id,
+            campaign_id=campaign_id,
+        )
+        return new_rule.id

--- a/backend/app/services/threat_intel_service.py
+++ b/backend/app/services/threat_intel_service.py
@@ -463,6 +463,33 @@ async def fetch_feed_indicators(
         {"feed_id": feed_id, "count": count, "status": status},
     )
     await session.commit()
+
+    # Synthesize detection rules for campaigns with indicators
+    if count > 0 and campaign_id is not None:
+        from app.services.rule_synthesis_service import synthesize_rules_for_campaign
+
+        # Collect the distinct indicator types from this parse result
+        indicator_types = {ind.indicator_type for ind in parse_result.indicators}
+
+        # Get campaign slug from the campaign table
+        camp_row = await session.execute(
+            text("SELECT slug FROM threat_intel_campaigns WHERE id = :cid"),
+            {"cid": campaign_id},
+        )
+        camp = camp_row.fetchone()
+        if camp:
+            await synthesize_rules_for_campaign(
+                session,
+                campaign_id=campaign_id,
+                campaign_name=parse_result.campaign_name or f"campaign-{campaign_id}",
+                campaign_slug=camp[0],
+                indicator_types=indicator_types,
+                campaign_severity=parse_result.campaign_severity or "critical",
+                suggested_rules=parse_result.suggested_rules,
+                feed_id=feed_id,
+            )
+            await session.commit()
+
     return count
 
 

--- a/backend/tests/test_rule_synthesis_service.py
+++ b/backend/tests/test_rule_synthesis_service.py
@@ -1,0 +1,257 @@
+"""Tests for rule_synthesis_service."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.rule_synthesis_service import (
+    RULE_TEMPLATES,
+    RuleTemplate,
+    synthesize_rules_for_campaign,
+)
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock AsyncSession."""
+    session = AsyncMock(spec=AsyncSession)
+    return session
+
+
+class TestRuleTemplates:
+    """Test that rule templates are correctly defined."""
+
+    def test_all_indicator_types_have_templates(self):
+        """Verify expected indicator types are covered."""
+        expected = {
+            "github_username",
+            "commit_author_email",
+            "package_name",
+            "npm_scope",
+            "action_ref",
+            "ip",
+            "domain",
+        }
+        assert set(RULE_TEMPLATES.keys()) == expected
+
+    def test_template_structure(self):
+        """Each template must have required fields."""
+        for itype, tmpl in RULE_TEMPLATES.items():
+            assert isinstance(tmpl, RuleTemplate), f"{itype} not a RuleTemplate"
+            assert tmpl.display_name, f"{itype} missing display_name"
+            assert tmpl.action_filters, f"{itype} missing action_filters"
+            assert tmpl.engine, f"{itype} missing engine"
+            assert tmpl.match_field, f"{itype} missing match_field"
+
+    def test_github_username_template(self):
+        tmpl = RULE_TEMPLATES["github_username"]
+        assert tmpl.engine == "threat_intel_actor"
+        assert tmpl.action_filters == ["*"]
+        assert tmpl.default_severity == "critical"
+
+    def test_action_ref_template(self):
+        tmpl = RULE_TEMPLATES["action_ref"]
+        assert tmpl.engine == "threat_intel_action_ref"
+        assert "workflows.prepared_workflow_job" in tmpl.action_filters
+
+    def test_ip_template_severity(self):
+        """IP indicators default to high (not critical)."""
+        tmpl = RULE_TEMPLATES["ip"]
+        assert tmpl.default_severity == "high"
+
+
+class TestSynthesizeRulesForCampaign:
+    """Test rule synthesis logic."""
+
+    @pytest.mark.asyncio
+    async def test_creates_rules_for_known_types(self, mock_session):
+        """Should create a rule for each supported indicator type."""
+        # Mock: no existing rule
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        indicator_types = {"github_username", "action_ref"}
+
+        rule_ids = await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=42,
+            campaign_name="Evil Campaign",
+            campaign_slug="evil-campaign",
+            indicator_types=indicator_types,
+        )
+
+        # Should have created 2 rules (one per type)
+        assert len(rule_ids) == 2
+        # session.add should have been called twice
+        assert mock_session.add.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_skips_unknown_indicator_types(self, mock_session):
+        """Unknown indicator types should be skipped without error."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        rule_ids = await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=1,
+            campaign_name="Test",
+            campaign_slug="test",
+            indicator_types={"unknown_type", "also_unknown"},
+        )
+
+        assert rule_ids == []
+        assert mock_session.add.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_existing_rule(self, mock_session):
+        """If rule with same slug exists, update it rather than create."""
+        existing_rule = MagicMock()
+        existing_rule.id = 99
+        existing_rule.status = "active"
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_rule
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        rule_ids = await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=5,
+            campaign_name="Updated Campaign",
+            campaign_slug="updated-campaign",
+            indicator_types={"github_username"},
+        )
+
+        assert rule_ids == [99]
+        # Should NOT call session.add (update in place)
+        assert mock_session.add.call_count == 0
+        # Should have updated fields
+        assert existing_rule.campaign_id == 5
+        assert existing_rule.updated_by == "system:rule_synthesis"
+
+    @pytest.mark.asyncio
+    async def test_re_enables_expired_rule(self, mock_session):
+        """Expired rules should be re-enabled on update."""
+        existing_rule = MagicMock()
+        existing_rule.id = 77
+        existing_rule.status = "expired"
+        existing_rule.enabled = False
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = existing_rule
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=3,
+            campaign_name="Revived",
+            campaign_slug="revived",
+            indicator_types={"npm_scope"},
+        )
+
+        assert existing_rule.enabled is True
+        assert existing_rule.status == "active"
+        assert existing_rule.expires_at is None
+
+    @pytest.mark.asyncio
+    async def test_uses_suggested_rule_overrides(self, mock_session):
+        """Suggested rules from feed should override template defaults."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        suggested = [
+            {
+                "indicator_type": "github_username",
+                "action_filters": ["org.add_member"],
+                "severity": "medium",
+                "confidence": 0.7,
+            }
+        ]
+
+        await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=10,
+            campaign_name="Custom",
+            campaign_slug="custom",
+            indicator_types={"github_username"},
+            suggested_rules=suggested,
+        )
+
+        # Verify the rule was created with overridden values
+        added_rule = mock_session.add.call_args[0][0]
+        assert added_rule.default_severity == "medium"
+        assert added_rule.logic_config["action_filters"] == ["org.add_member"]
+        assert added_rule.logic_config["confidence"] == 0.7
+
+    @pytest.mark.asyncio
+    async def test_slug_format(self, mock_session):
+        """Rule slug should follow feed-{campaign_slug}-{indicator_type} pattern."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=1,
+            campaign_name="Evil Corp",
+            campaign_slug="evil-corp",
+            indicator_types={"ip"},
+        )
+
+        added_rule = mock_session.add.call_args[0][0]
+        assert added_rule.slug == "feed-evil-corp-ip"
+
+    @pytest.mark.asyncio
+    async def test_logic_config_structure(self, mock_session):
+        """Verify the logic_config has correct structure for engine matching."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=7,
+            campaign_name="Test",
+            campaign_slug="test",
+            indicator_types={"action_ref"},
+        )
+
+        added_rule = mock_session.add.call_args[0][0]
+        config = added_rule.logic_config
+        assert "x_config" in config
+        assert config["x_config"]["engine"] == "threat_intel_action_ref"
+        assert config["x_config"]["indicator_type"] == "action_ref"
+        assert config["x_config"]["campaign_id"] == 7
+        assert config["x_config"]["check_field"] == "data.workflow_action"
+
+    @pytest.mark.asyncio
+    async def test_campaign_severity_propagates(self, mock_session):
+        """Campaign severity should be used as rule severity."""
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session.flush = AsyncMock()
+
+        await synthesize_rules_for_campaign(
+            mock_session,
+            campaign_id=1,
+            campaign_name="High Sev",
+            campaign_slug="high-sev",
+            indicator_types={"package_name"},
+            campaign_severity="high",
+        )
+
+        added_rule = mock_session.add.call_args[0][0]
+        assert added_rule.default_severity == "high"


### PR DESCRIPTION
## Summary

Implements automatic detection rule generation from threat intel feed indicators, completing issue #337.

### Changes

- **New**: `backend/app/services/rule_synthesis_service.py` — Core synthesis engine
  - `RULE_TEMPLATES`: Maps 7 indicator types to detection rule configurations
  - `synthesize_rules_for_campaign()`: Creates/updates one rule per indicator_type per campaign
  - `disable_expired_feed_rules()`: Maintenance function for expired feed rules
  - Rules use x_config engines to query indicators at runtime (no rule-per-IOC explosion)

- **Modified**: `backend/app/services/threat_intel_service.py`
  - Hooks rule synthesis into `fetch_feed_indicators()` after indicator upsert
  - Automatically generates rules when a campaign has indicators

- **Modified**: `backend/app/services/feed_parsers/base.py`
  - Added `suggested_rules` field to `ParseResult` for feed-specific overrides

- **Modified**: `backend/app/services/feed_parsers/custom_json.py`
  - Populates `suggested_rules` on ParseResult from Custom JSON feed schema

- **New**: `backend/tests/test_rule_synthesis_service.py` — 13 unit tests

### Design

- One rule per `indicator_type` per campaign (slug: `feed-{campaign_slug}-{indicator_type}`)
- Rules reference x_config engines that query the indicators table at runtime
- Adding new IOCs enriches existing rules without creating additional rule records
- Expired rules are re-enabled if fresh indicators arrive
- Custom JSON feeds can override default templates via `suggested_rules`

Closes #337