### PR TITLE
feat: Retroactive Scanner (#338)

### DIFF
--- a/backend/app/celery_app.py
+++ b/backend/app/celery_app.py
@@ -51,6 +51,7 @@ app.config_from_object(
             "app.workers.package_sync_worker.*": {"queue": "github_sync"},
             "app.workers.user_classification_worker.*": {"queue": "baseline"},
             "app.workers.enrichment_worker.*": {"queue": "enrichment"},
+            "app.workers.retro_scan_worker.*": {"queue": "retro_scan"},
         },
         # ─── Soft / hard time limits ─────────────────────────────────────────
         "task_soft_time_limit": 1800,  # 30 minutes
@@ -173,6 +174,7 @@ app.conf.include = [
     "app.workers.package_sync_worker",
     "app.workers.user_classification_worker",
     "app.workers.enrichment_worker",
+    "app.workers.retro_scan_worker",
 ]
 
 # Conditionally add GitHub sync heartbeat to beat schedule

--- a/backend/app/services/threat_intel_service.py
+++ b/backend/app/services/threat_intel_service.py
@@ -490,6 +490,11 @@ async def fetch_feed_indicators(
             )
             await session.commit()
 
+            # Trigger retroactive scan for this campaign
+            from app.workers.retro_scan_worker import retro_scan_campaign_task
+
+            retro_scan_campaign_task.delay(campaign_id)
+
     return count
 
 

--- a/backend/app/workers/retro_scan_worker.py
+++ b/backend/app/workers/retro_scan_worker.py
@@ -1,0 +1,382 @@
+"""Retroactive scanner: scan recent events against newly-ingested campaign IOCs.
+
+When new threat intel indicators arrive, this worker scans recent audit log
+events for matches that occurred before the IOCs were known.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import structlog
+from celery import Task
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.celery_app import celery_app
+from app.database import AsyncSessionLocal
+
+logger = structlog.get_logger(__name__)
+
+# Processing constraints
+BATCH_SIZE = 1000
+DEFAULT_LOOKBACK_DAYS = 7
+
+
+@celery_app.task(
+    name="app.workers.retro_scan_worker.retro_scan_campaign",
+    bind=True,
+    max_retries=2,
+)
+def retro_scan_campaign_task(
+    self: Task,
+    campaign_id: int,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+) -> dict[str, object]:
+    """Celery task: scan recent events against a campaign's feed-derived rules."""
+    try:
+        result = asyncio.run(_retro_scan(campaign_id, lookback_days))
+        return {"status": "ok", **result}
+    except Exception as exc:
+        logger.error(
+            "retro_scan.task_failed",
+            campaign_id=campaign_id,
+            error=str(exc),
+        )
+        backoff = min(30 * (2**self.request.retries), 600)
+        jitter = secrets.randbelow(max(int(backoff * 0.1), 1))
+        raise self.retry(exc=exc, countdown=backoff + jitter) from exc
+
+
+async def _retro_scan(
+    campaign_id: int,
+    lookback_days: int,
+) -> dict[str, object]:
+    """Core retro scan logic.
+
+    1. Load feed-derived rules for this campaign
+    2. Query recent events matching rule action_filters in batches
+    3. Evaluate each event against each rule (action match + x_config engine)
+    4. Write detections with retroactive flag, skipping duplicates
+    """
+    from app.services.detection_service import (
+        _check_x_config_engine,
+        event_matches_rule,
+    )
+
+    scan_started_at = datetime.now(UTC).isoformat()
+    cutoff = datetime.now(UTC) - timedelta(days=lookback_days)
+
+    total_events_scanned = 0
+    detections_created = 0
+    duplicates_skipped = 0
+
+    async with AsyncSessionLocal() as session:
+        # Step 1: Load feed-derived rules for this campaign
+        rules = await _load_campaign_rules(session, campaign_id)
+        if not rules:
+            logger.info(
+                "retro_scan.no_rules",
+                campaign_id=campaign_id,
+            )
+            return {
+                "campaign_id": campaign_id,
+                "events_scanned": 0,
+                "detections_created": 0,
+            }
+
+        # Collect action filters across all rules for efficient event querying
+        action_filters = _collect_action_filters(rules)
+
+        logger.info(
+            "retro_scan.started",
+            campaign_id=campaign_id,
+            lookback_days=lookback_days,
+            rule_count=len(rules),
+            action_filters=action_filters,
+        )
+
+        # Step 2: Scan events in batches
+        last_id = 0
+        while True:
+            event_rows = await _fetch_event_batch(
+                session,
+                action_filters=action_filters,
+                cutoff=cutoff,
+                after_id=last_id,
+                batch_size=BATCH_SIZE,
+            )
+
+            if not event_rows:
+                break
+
+            total_events_scanned += len(event_rows)
+
+            # Step 3: Evaluate each event against each rule
+            for event in event_rows:
+                for rule in rules:
+                    if not event_matches_rule(event, rule):
+                        continue
+
+                    # Check x_config engine match
+                    if not await _check_x_config_engine(event, rule, session):
+                        continue
+
+                    # Step 4: Dedup — skip if detection already exists
+                    already_detected = await _detection_exists(session, rule.id, event.id)
+                    if already_detected:
+                        duplicates_skipped += 1
+                        continue
+
+                    # Write detection with retroactive flag
+                    det_id = await _write_retro_detection(
+                        session,
+                        rule=rule,
+                        event=event,
+                        scan_started_at=scan_started_at,
+                    )
+                    if det_id is not None:
+                        detections_created += 1
+
+            last_id = event_rows[-1].id
+            await session.commit()
+
+        # Final commit for any remaining work
+        await session.commit()
+
+        # Step 5: Send summary notification if matches found
+        if detections_created > 0:
+            await _send_retro_scan_notification(
+                session,
+                campaign_id=campaign_id,
+                detections_created=detections_created,
+                events_scanned=total_events_scanned,
+            )
+            await session.commit()
+
+    logger.info(
+        "retro_scan.completed",
+        campaign_id=campaign_id,
+        events_scanned=total_events_scanned,
+        detections_created=detections_created,
+        duplicates_skipped=duplicates_skipped,
+    )
+
+    return {
+        "campaign_id": campaign_id,
+        "events_scanned": total_events_scanned,
+        "detections_created": detections_created,
+        "duplicates_skipped": duplicates_skipped,
+    }
+
+
+async def _load_campaign_rules(
+    session: AsyncSession,
+    campaign_id: int,
+) -> list[Any]:
+    """Load active feed-derived rules for a campaign."""
+    from sqlalchemy import select
+
+    from app.models.detection import RuleDefinition
+
+    stmt = select(RuleDefinition).where(
+        RuleDefinition.campaign_id == campaign_id,
+        RuleDefinition.source == "feed",
+        RuleDefinition.enabled.is_(True),
+        RuleDefinition.status == "active",
+    )
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+def _collect_action_filters(rules: list[Any]) -> list[str]:
+    """Collect unique action filter patterns across all rules."""
+    filters: set[str] = set()
+    for rule in rules:
+        action_filters = rule.logic_config.get("action_filters", [])
+        filters.update(action_filters)
+    return sorted(filters)
+
+
+async def _fetch_event_batch(
+    session: AsyncSession,
+    *,
+    action_filters: list[str],
+    cutoff: datetime,
+    after_id: int,
+    batch_size: int,
+) -> list[Any]:
+    """Fetch a batch of events matching action filters since cutoff.
+
+    Uses cursor-based pagination (after_id) for efficient batching.
+    Wildcard '*' in action_filters means all events are eligible.
+    """
+    from sqlalchemy import select
+
+    from app.models.audit_event import AuditEvent
+
+    stmt = (
+        select(AuditEvent)
+        .where(
+            AuditEvent.created_at >= cutoff,
+            AuditEvent.id > after_id,
+        )
+        .order_by(AuditEvent.id.asc())
+        .limit(batch_size)
+    )
+
+    # If no wildcard, filter by specific actions
+    if "*" not in action_filters:
+        # Use LIKE patterns for fnmatch-style wildcards
+        from sqlalchemy import or_
+
+        action_conditions = []
+        for pattern in action_filters:
+            if "*" in pattern or "?" in pattern:
+                # Convert fnmatch to SQL LIKE
+                sql_pattern = pattern.replace("*", "%").replace("?", "_")
+                action_conditions.append(AuditEvent.action.like(sql_pattern))
+            else:
+                action_conditions.append(AuditEvent.action == pattern)
+
+        if action_conditions:
+            stmt = stmt.where(or_(*action_conditions))
+
+    result = await session.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def _detection_exists(
+    session: AsyncSession,
+    rule_id: int,
+    event_id: int,
+) -> bool:
+    """Check if a detection already exists for this rule + event combo."""
+    result = await session.execute(
+        text("""
+            SELECT 1 FROM detections
+            WHERE rule_id = :rule_id
+              AND :event_id = ANY(event_ids)
+            LIMIT 1
+        """),
+        {"rule_id": rule_id, "event_id": event_id},
+    )
+    return result.fetchone() is not None
+
+
+async def _write_retro_detection(
+    session: AsyncSession,
+    *,
+    rule: Any,
+    event: Any,
+    scan_started_at: str,
+) -> int | None:
+    """Write a detection with retroactive metadata flag.
+
+    Uses the same suppression/severity logic as the main pipeline but
+    adds retroactive markers to context_data.
+    """
+    from app.models.detection import Detection
+    from app.services.detection_service import (
+        check_suppression,
+        compute_confidence_score,
+        resolve_severity,
+    )
+
+    # Suppression check
+    suppression = await check_suppression(session, rule.id, event.actor, event.org, event.repo)
+    if suppression:
+        return None
+
+    severity = await resolve_severity(session, event.action, rule.default_severity)
+    base_conf = rule.logic_config.get("confidence", 0.5)
+    score, tier = compute_confidence_score(float(base_conf))
+
+    x_config = rule.logic_config.get("x_config", {})
+    campaign_id = x_config.get("campaign_id")
+
+    ctx: dict[str, Any] = {
+        "action": event.action,
+        "event_id": event.id,
+        "retroactive": True,
+        "scan_initiated_at": scan_started_at,
+    }
+
+    detection = Detection(
+        rule_id=rule.id,
+        rule_version=rule.version,
+        severity=severity,
+        confidence=tier,
+        confidence_score=score,
+        title=f"[Retro] {rule.name} — {event.actor or 'unknown'}",
+        description=rule.description or rule.name,
+        actor=event.actor,
+        org=event.org,
+        repo=event.repo,
+        source_ip=str(event.source_ip) if event.source_ip else None,
+        event_ids=[event.id],
+        context_data=ctx,
+        window_start=event.created_at,
+        window_end=event.created_at,
+        campaign_id=int(campaign_id) if campaign_id else None,
+    )
+    session.add(detection)
+    await session.flush()
+
+    logger.info(
+        "retro_scan.detection_written",
+        rule_id=rule.id,
+        detection_id=detection.id,
+        event_id=event.id,
+        severity=severity,
+    )
+
+    return detection.id
+
+
+async def _send_retro_scan_notification(
+    session: AsyncSession,
+    *,
+    campaign_id: int,
+    detections_created: int,
+    events_scanned: int,
+) -> None:
+    """Send a summary notification about retro scan results."""
+    # Get campaign name for notification
+    result = await session.execute(
+        text("SELECT name FROM threat_intel_campaigns WHERE id = :cid"),
+        {"cid": campaign_id},
+    )
+    row = result.fetchone()
+    campaign_name = row[0] if row else f"Campaign #{campaign_id}"
+
+    try:
+        from app.services.notification_service import send_notification
+
+        await send_notification(
+            session,
+            notification_type="retro_scan_complete",
+            title=f"Retroactive scan complete: {campaign_name}",
+            message=(
+                f"Retro scan for **{campaign_name}** found "
+                f"**{detections_created}** historical matches "
+                f"across {events_scanned:,} events."
+            ),
+            severity="high" if detections_created > 10 else "medium",
+            metadata={
+                "campaign_id": campaign_id,
+                "campaign_name": campaign_name,
+                "detections_created": detections_created,
+                "events_scanned": events_scanned,
+            },
+        )
+    except Exception as exc:
+        # Don't fail the scan if notification fails
+        logger.warning(
+            "retro_scan.notification_failed",
+            campaign_id=campaign_id,
+            error=str(exc),
+        )

--- a/backend/tests/test_retro_scan_worker.py
+++ b/backend/tests/test_retro_scan_worker.py
@@ -1,0 +1,290 @@
+"""Tests for retro_scan_worker."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.workers.retro_scan_worker import (
+    BATCH_SIZE,
+    DEFAULT_LOOKBACK_DAYS,
+    _collect_action_filters,
+    _detection_exists,
+    _retro_scan,
+    _write_retro_detection,
+)
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock AsyncSession."""
+    session = AsyncMock()
+    session.commit = AsyncMock()
+    session.flush = AsyncMock()
+    return session
+
+
+def _make_mock_rule(
+    rule_id: int = 1,
+    campaign_id: int = 42,
+    action_filters: list[str] | None = None,
+    engine: str = "threat_intel_actor",
+):
+    """Create a mock RuleDefinition."""
+    rule = MagicMock()
+    rule.id = rule_id
+    rule.version = 1
+    rule.name = "Test Rule"
+    rule.description = "Test rule description"
+    rule.default_severity = "critical"
+    rule.category = "supply_chain"
+    rule.slug = f"feed-test-rule-{rule_id}"
+    rule.logic_type = "pattern"
+    rule.logic_config = {
+        "action_filters": action_filters or ["*"],
+        "confidence": 0.85,
+        "x_config": {
+            "engine": engine,
+            "campaign_id": campaign_id,
+            "indicator_type": "github_username",
+            "check_field": "actor",
+        },
+    }
+    return rule
+
+
+def _make_mock_event(event_id: int = 100, action: str = "org.add_member"):
+    """Create a mock AuditEvent."""
+    event = MagicMock()
+    event.id = event_id
+    event.action = action
+    event.actor = "evil-user"
+    event.org = "target-org"
+    event.repo = "target-org/repo"
+    event.source_ip = "1.2.3.4"
+    event.created_at = datetime.now(UTC) - timedelta(days=2)
+    event.data = {}
+    return event
+
+
+class TestCollectActionFilters:
+    def test_collects_unique_filters(self):
+        r1 = _make_mock_rule(action_filters=["git.push", "org.add_member"])
+        r2 = _make_mock_rule(action_filters=["git.push", "packages.*"])
+        result = _collect_action_filters([r1, r2])
+        assert sorted(result) == ["git.push", "org.add_member", "packages.*"]
+
+    def test_wildcard_preserved(self):
+        r1 = _make_mock_rule(action_filters=["*"])
+        result = _collect_action_filters([r1])
+        assert result == ["*"]
+
+    def test_empty_rules(self):
+        assert _collect_action_filters([]) == []
+
+
+class TestDetectionExists:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_exists(self, mock_session):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = (1,)
+        mock_session.execute.return_value = mock_result
+
+        result = await _detection_exists(mock_session, rule_id=1, event_id=100)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_not_exists(self, mock_session):
+        mock_result = MagicMock()
+        mock_result.fetchone.return_value = None
+        mock_session.execute.return_value = mock_result
+
+        result = await _detection_exists(mock_session, rule_id=1, event_id=100)
+        assert result is False
+
+
+class TestWriteRetroDetection:
+    @pytest.mark.asyncio
+    async def test_writes_detection_with_retroactive_flag(self, mock_session):
+        """Detection should have retroactive=True in context_data."""
+        rule = _make_mock_rule()
+        event = _make_mock_event()
+
+        # Make session.add set a fake ID on the detection
+        def _set_id(det):
+            det.id = 501
+
+        mock_session.add = MagicMock(side_effect=_set_id)
+        mock_session.flush = AsyncMock()
+
+        with (
+            patch(
+                "app.services.detection_service.check_suppression",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "app.services.detection_service.resolve_severity",
+                new_callable=AsyncMock,
+                return_value="critical",
+            ),
+            patch(
+                "app.services.detection_service.compute_confidence_score",
+                return_value=(0.85, "high"),
+            ),
+        ):
+            det_id = await _write_retro_detection(
+                mock_session,
+                rule=rule,
+                event=event,
+                scan_started_at="2026-07-09T12:00:00Z",
+            )
+
+        assert det_id == 501
+        # Verify the detection was added to session
+        added = mock_session.add.call_args[0][0]
+        assert added.context_data["retroactive"] is True
+        assert added.context_data["scan_initiated_at"] == "2026-07-09T12:00:00Z"
+        assert "[Retro]" in added.title
+
+    @pytest.mark.asyncio
+    async def test_skips_when_suppressed(self, mock_session):
+        """Suppressed events should return None."""
+        rule = _make_mock_rule()
+        event = _make_mock_event()
+        suppression = MagicMock()
+
+        with patch(
+            "app.services.detection_service.check_suppression",
+            new_callable=AsyncMock,
+            return_value=suppression,
+        ):
+            det_id = await _write_retro_detection(
+                mock_session,
+                rule=rule,
+                event=event,
+                scan_started_at="2026-07-09T12:00:00Z",
+            )
+
+        assert det_id is None
+        assert mock_session.add.call_count == 0
+
+
+class TestRetroScan:
+    @pytest.mark.asyncio
+    async def test_no_rules_returns_early(self):
+        """If no rules exist for campaign, return immediately."""
+        with patch("app.workers.retro_scan_worker.AsyncSessionLocal") as mock_session_cls:
+            mock_session = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with patch(
+                "app.workers.retro_scan_worker._load_campaign_rules",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                result = await _retro_scan(campaign_id=99, lookback_days=7)
+
+        assert result["events_scanned"] == 0
+        assert result["detections_created"] == 0
+
+    @pytest.mark.asyncio
+    async def test_processes_events_in_batches(self):
+        """Should process events and skip duplicates."""
+        rule = _make_mock_rule()
+        event1 = _make_mock_event(event_id=1)
+        event2 = _make_mock_event(event_id=2)
+
+        with patch("app.workers.retro_scan_worker.AsyncSessionLocal") as mock_session_cls:
+            mock_session = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            with (
+                patch(
+                    "app.workers.retro_scan_worker._load_campaign_rules",
+                    new_callable=AsyncMock,
+                    return_value=[rule],
+                ),
+                patch(
+                    "app.workers.retro_scan_worker._fetch_event_batch",
+                    new_callable=AsyncMock,
+                    side_effect=[[event1, event2], []],
+                ),
+                patch(
+                    "app.services.detection_service.event_matches_rule",
+                    return_value=True,
+                ),
+                patch(
+                    "app.services.detection_service._check_x_config_engine",
+                    new_callable=AsyncMock,
+                    return_value=True,
+                ),
+                patch(
+                    "app.workers.retro_scan_worker._detection_exists",
+                    new_callable=AsyncMock,
+                    side_effect=[False, True],  # event1 new, event2 duplicate
+                ),
+                patch(
+                    "app.workers.retro_scan_worker._write_retro_detection",
+                    new_callable=AsyncMock,
+                    return_value=501,
+                ),
+                patch(
+                    "app.workers.retro_scan_worker._send_retro_scan_notification",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                result = await _retro_scan(campaign_id=42, lookback_days=7)
+
+        assert result["events_scanned"] == 2
+        assert result["detections_created"] == 1
+        assert result["duplicates_skipped"] == 1
+
+    @pytest.mark.asyncio
+    async def test_no_notification_when_no_matches(self):
+        """Should not send notification if no detections created."""
+        rule = _make_mock_rule()
+        event = _make_mock_event()
+
+        with patch("app.workers.retro_scan_worker.AsyncSessionLocal") as mock_session_cls:
+            mock_session = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            mock_notify = AsyncMock()
+            with (
+                patch(
+                    "app.workers.retro_scan_worker._load_campaign_rules",
+                    new_callable=AsyncMock,
+                    return_value=[rule],
+                ),
+                patch(
+                    "app.workers.retro_scan_worker._fetch_event_batch",
+                    new_callable=AsyncMock,
+                    side_effect=[[event], []],
+                ),
+                patch(
+                    "app.services.detection_service.event_matches_rule",
+                    return_value=False,
+                ),
+                patch(
+                    "app.workers.retro_scan_worker._send_retro_scan_notification",
+                    mock_notify,
+                ),
+            ):
+                result = await _retro_scan(campaign_id=42, lookback_days=7)
+
+        assert result["detections_created"] == 0
+        mock_notify.assert_not_awaited()
+
+
+class TestRetroScanConstants:
+    def test_default_lookback(self):
+        assert DEFAULT_LOOKBACK_DAYS == 7
+
+    def test_batch_size(self):
+        assert BATCH_SIZE == 1000


### PR DESCRIPTION
## Summary

Implements background scanning of recent audit log events against newly-ingested campaign IOCs, completing issue #338.

### Changes

- **New**: `backend/app/workers/retro_scan_worker.py` — Core retro scan worker
  - `retro_scan_campaign_task`: Celery task on dedicated `retro_scan` queue
  - Batch processing (1000 events/batch) with cursor-based pagination
  - Dedup via `_detection_exists()` — checks if rule+event combo already detected
  - Retroactive detections carry `{"retroactive": true, "scan_initiated_at": "..."}` in `context_data`
  - Title prefixed with `[Retro]` for UI distinction
  - Summary notification via existing notification pipeline on completion

- **Modified**: `backend/app/celery_app.py`
  - Added `retro_scan` queue routing
  - Registered worker module in `conf.include`

- **Modified**: `backend/app/services/threat_intel_service.py`
  - Triggers `retro_scan_campaign_task.delay(campaign_id)` after rule synthesis

- **New**: `backend/tests/test_retro_scan_worker.py` — 12 unit tests

### Design

- Triggered automatically when feed indicators are ingested and rules synthesized
- Scans events within configurable lookback window (default 7 days)
- Uses existing detection pipeline functions (`event_matches_rule`, `_check_x_config_engine`)
- Lower priority queue (`retro_scan`) to avoid blocking real-time detection
- Idempotent — won't create duplicates for already-detected events

Closes #338